### PR TITLE
Added markdown layout components.

### DIFF
--- a/components/helper/MarkdownContent.tsx
+++ b/components/helper/MarkdownContent.tsx
@@ -1,0 +1,24 @@
+// Global
+import { classnames } from '@/tailwindcss-classnames';
+import ReactMarkdown from 'react-markdown';
+
+type MarkdownContentProps = {
+  partials: string[];
+};
+
+const MarkdownContent = ({ partials }: MarkdownContentProps): JSX.Element => (
+  <div>
+    {partials.map((item, i) => (
+      <div
+        className={classnames('prose', {
+          'mb-16': i !== partials.length,
+        })}
+        key={i}
+      >
+        <ReactMarkdown>{item}</ReactMarkdown>
+      </div>
+    ))}
+  </div>
+);
+
+export default MarkdownContent;

--- a/components/helper/MarkdownGrid.tsx
+++ b/components/helper/MarkdownGrid.tsx
@@ -1,0 +1,19 @@
+// Global
+import { classnames } from '@/tailwindcss-classnames';
+import ReactMarkdown from 'react-markdown';
+
+type MarkdownGridProps = {
+  partials: string[];
+};
+
+const MarkdownGrid = ({ partials }: MarkdownGridProps): JSX.Element => (
+  <div className={classnames('grid', 'gap-6', 'md:grid-cols-3')}>
+    {partials.map((item, i) => (
+      <div className={classnames('prose', 'border', 'p-4')} key={i}>
+        <ReactMarkdown>{item}</ReactMarkdown>
+      </div>
+    ))}
+  </div>
+);
+
+export default MarkdownGrid;

--- a/pages/[solution]/[product].tsx
+++ b/pages/[solution]/[product].tsx
@@ -1,8 +1,6 @@
 // Global
-import { classnames } from '@/tailwindcss-classnames';
 import { useRouter } from 'next/dist/client/router';
 import Link from 'next/link';
-import ReactMarkdown from 'react-markdown';
 // Scripts
 import { getPageInfo, getPartialsAsArray } from '@/scripts/page-info';
 import { getProductPaths } from '@/scripts/static-paths';
@@ -10,6 +8,7 @@ import { getProductPaths } from '@/scripts/static-paths';
 import type { PageInfo } from '@/interfaces/page-info';
 // Components
 import Layout from '@/components/layout/Layout';
+import MarkdownContent from '@/components/helper/MarkdownContent';
 import StackExchangeFeed from '@/components/integrations/stackexchange/StackExchangeFeed';
 import TwitterFeed from '@/components/integrations/twitter/TwitterFeed';
 import YouTubeFeed from '@/components/integrations/youtube/YouTubeFeed';
@@ -56,13 +55,7 @@ export default function productPage({
       <Link href={`/${parent}`}>
         <a>back up to {parent}...</a>
       </Link>
-      <div className={classnames('grid', 'md:grid-cols-3', 'gap-6')}>
-        {partials.map((partial, i) => (
-          <div key={i}>
-            <ReactMarkdown>{partial}</ReactMarkdown>
-          </div>
-        ))}
-      </div>
+      <MarkdownContent partials={partials} />
       <StackExchangeFeed content={pageInfo.stackexchange} />
       <YouTubeFeed content={pageInfo.youtube} />
       <TwitterFeed content={pageInfo.twitter} />

--- a/pages/[solution]/index.tsx
+++ b/pages/[solution]/index.tsx
@@ -1,6 +1,6 @@
 // Global
 import { useRouter } from 'next/dist/client/router';
-import Link from 'next/link';
+import { classnames } from '@/tailwindcss-classnames';
 // Scripts
 import { getPageInfo, getChildPageInfo } from '@/scripts/page-info';
 import { getSolutionPaths } from '@/scripts/static-paths';
@@ -8,6 +8,7 @@ import { getSolutionPaths } from '@/scripts/static-paths';
 import { PageInfo, ChildPageInfo } from '@/interfaces/page-info';
 // Components
 import Layout from '@/components/layout/Layout';
+import ProductCategoryCard from '@/components/cards/ProductCategoryCard';
 import StackExchangeFeed from '@/components/integrations/stackexchange/StackExchangeFeed';
 import TwitterFeed from '@/components/integrations/twitter/TwitterFeed';
 import YouTubeFeed from '@/components/integrations/youtube/YouTubeFeed';
@@ -49,15 +50,18 @@ export default function solutionPage({
 
   return (
     <Layout pageInfo={pageInfo}>
-      {products.map((child) => (
-        <div key={child.id} className={styles.productCategoryCardCompact}>
-          <h2>{child.title}</h2>
-          <p>{child.description}</p>
-          <Link href={child.link}>
-            <a>Learn more...</a>
-          </Link>
-        </div>
-      ))}
+      <ul className={classnames('grid', 'gap-6', 'md:grid-cols-3')}>
+        {products.map((child) => (
+          <ProductCategoryCard
+            key={child.id}
+            containerTag="li"
+            headingLevel="h2"
+            description={child.description as string}
+            title={child.title}
+            href={child.link}
+          />
+        ))}
+      </ul>
 
       <StackExchangeFeed content={pageInfo.stackexchange} />
 

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -1,14 +1,12 @@
-// Global
-import ReactMarkdown from 'react-markdown';
 // Scripts
 import { getPageInfo, getPartials } from '@/scripts/page-info';
 // Interfaces
 import { PageInfo, PagePartials } from '@/interfaces/page-info';
 // Components
 import Layout from '@/components/layout/Layout';
+import MarkdownGrid from '@/components/helper/MarkdownGrid';
 import StackExchangeFeed from '@/components/integrations/stackexchange/StackExchangeFeed';
 import TwitterFeed from '@/components/integrations/twitter/TwitterFeed';
-import styles from '@/styles/Home.module.css';
 
 export async function getStaticProps() {
   const pageInfo = await getPageInfo('community');
@@ -36,22 +34,11 @@ export default function Community({
 }) {
   return (
     <Layout pageInfo={pageInfo}>
-      <div className={styles.grid}>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.slack}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.stackExchange}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.forums}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.mvpSite}</ReactMarkdown>
-        </div>
-        <TwitterFeed content={pageInfo.twitter} />
-        <StackExchangeFeed content={pageInfo.stackexchange} />
-      </div>
+      <MarkdownGrid
+        partials={[partials.slack, partials.stackExchange, partials.forums, partials.mvpSite]}
+      />
+      <TwitterFeed content={pageInfo.twitter} />
+      <StackExchangeFeed content={pageInfo.stackexchange} />
     </Layout>
   );
 }

--- a/pages/discover.tsx
+++ b/pages/discover.tsx
@@ -1,14 +1,12 @@
-// Global
-import ReactMarkdown from 'react-markdown';
 // Scripts
 import { getPageInfo, getPartials } from '@/scripts/page-info';
 // Interfaces
 import { PageInfo, PagePartials } from '@/interfaces/page-info';
 // Components
 import Layout from '@/components/layout/Layout';
+import MarkdownGrid from '@/components/helper/MarkdownGrid';
 import TwitterFeed from '@/components/integrations/twitter/TwitterFeed';
 import YouTubeFeed from '@/components/integrations/youtube/YouTubeFeed';
-import styles from '@/styles/Home.module.css';
 
 export async function getStaticProps() {
   const pageInfo = await getPageInfo('discover');
@@ -38,28 +36,18 @@ export default function Discover({
 }) {
   return (
     <Layout pageInfo={pageInfo}>
-      <div className={styles.grid}>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.supportKB}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.cdpKB}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.orderCloud}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.contentHub}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.moosend}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.sitecoreKC}</ReactMarkdown>
-        </div>
-        <YouTubeFeed content={pageInfo.youtube} />
-        <TwitterFeed content={pageInfo.twitter} />
-      </div>
+      <MarkdownGrid
+        partials={[
+          partials.supportKB,
+          partials.cdpKB,
+          partials.orderCloud,
+          partials.contentHub,
+          partials.moosend,
+          partials.sitecoreKC,
+        ]}
+      />
+      <YouTubeFeed content={pageInfo.youtube} />
+      <TwitterFeed content={pageInfo.twitter} />
     </Layout>
   );
 }

--- a/pages/docs.tsx
+++ b/pages/docs.tsx
@@ -1,17 +1,14 @@
-// Global
-import ReactMarkdown from 'react-markdown';
 // Scipts
 import { getPageInfo, getPartials } from '@/scripts/page-info';
 // Interfaces
 import { PageInfo, PagePartials } from '@/interfaces/page-info';
 // Components
 import Layout from '@/components/layout/Layout';
+import MarkdownContent from '@/components/helper/MarkdownContent';
 import TwitterFeed from '@/components/integrations/twitter/TwitterFeed';
 import YouTubeFeed from '@/components/integrations/youtube/YouTubeFeed';
-import styles from '@/styles/Home.module.css';
 
 export async function getStaticProps() {
-  const docsMarkDownFolder = 'docs';
   const pageInfo = await getPageInfo('docs');
   const partials = await getPartials({
     cms: 'docs/cms',
@@ -39,28 +36,18 @@ export default function Docs({
 }) {
   return (
     <Layout pageInfo={pageInfo}>
-      <div className={styles.grid}>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.cms}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.dam}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.cdm}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.personalization}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.ma}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.commerce}</ReactMarkdown>
-        </div>
-        <YouTubeFeed content={pageInfo.youtube} />
-        <TwitterFeed content={pageInfo.twitter} />
-      </div>
+      <MarkdownContent
+        partials={[
+          partials.cms,
+          partials.dam,
+          partials.cdm,
+          partials.personalization,
+          partials.ma,
+          partials.commerce,
+        ]}
+      />
+      <YouTubeFeed content={pageInfo.youtube} />
+      <TwitterFeed content={pageInfo.twitter} />
     </Layout>
   );
 }

--- a/pages/help.tsx
+++ b/pages/help.tsx
@@ -1,12 +1,14 @@
 // Global
 import ReactMarkdown from 'react-markdown';
 import { useRouter } from 'next/dist/client/router';
+import { classnames } from '@/tailwindcss-classnames';
 // Scipts
 import { getPageInfo, getPartials } from '@/scripts/page-info';
 // Interfaces
 import { PageInfo, PagePartials } from '@/interfaces/page-info';
 // Component
 import Layout from '@/components/layout/Layout';
+import MarkdownGrid from '@/components/helper/MarkdownGrid';
 import StackExchangeFeed from '@/components/integrations/stackexchange/StackExchangeFeed';
 import styles from '@/styles/Home.module.css';
 
@@ -43,22 +45,12 @@ export default function Help({
   return (
     <Layout pageInfo={pageInfo}>
       <div className={styles.grid}>
-        <div className={styles.socialsCard}>
+        <div className={classnames('prose')}>
           <ReactMarkdown>{partials.support}</ReactMarkdown>
         </div>
         <div className={styles.youtubeCard}>
           <h2>Ask the community</h2>
-          <div className={styles.threeColumn}>
-            <div className={styles.oneThirdCard}>
-              <ReactMarkdown>{partials.slack}</ReactMarkdown>
-            </div>
-            <div className={styles.oneThirdCard}>
-              <ReactMarkdown>{partials.stackExchange}</ReactMarkdown>
-            </div>
-            <div className={styles.oneThirdCard}>
-              <ReactMarkdown>{partials.forums}</ReactMarkdown>
-            </div>
-          </div>
+          <MarkdownGrid partials={[partials.slack, partials.stackExchange, partials.forums]} />
         </div>
         <div className={styles.youtubeCard}>
           <h2>Contact Us info here (or redirect to sitecore.com contact)</h2>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import Layout from '@/components/layout/Layout';
 import ProductCategoryCard, {
   ProductCategoryCardProps,
 } from '@/components/cards/ProductCategoryCard';
+import MarkdownGrid from '@/components/helper/MarkdownGrid';
 import StackExchangeFeed from '@/components/integrations/stackexchange/StackExchangeFeed';
 import YouTubeFeed from '@/components/integrations/youtube/YouTubeFeed';
 import styles from '@/styles/Home.module.css';
@@ -79,34 +80,22 @@ export default function Home({
 }) {
   return (
     <Layout pageInfo={pageInfo}>
-      <div className={styles.grid}>
-        <YouTubeFeed content={pageInfo.youtube} />
-        <div className={styles.youtubeCard}>
-          <h2>Join these cool Sitecore Communities 🤖</h2>
-          <div className={styles.threeColumn}>
-            <div className={styles.oneThirdCard}>
-              <ReactMarkdown>{partials.slack}</ReactMarkdown>
-            </div>
-            <div className={styles.oneThirdCard}>
-              <ReactMarkdown>{partials.stackExchange}</ReactMarkdown>
-            </div>
-            <div className={styles.oneThirdCard}>
-              <ReactMarkdown>{partials.forums}</ReactMarkdown>
-            </div>
-          </div>
-        </div>
-
-        {/* PRODUCT SOLUTIONS */}
-        <ul className={classnames('grid', 'gap-6', 'md:grid-cols-2')}>
-          {productSolutions.map((solution, i) => (
-            <ProductCategoryCard {...solution} key={i} />
-          ))}
-        </ul>
-        <div className={styles.youtubeCard}>
-          <ReactMarkdown>{partials.getHelp}</ReactMarkdown>
-        </div>
-        <StackExchangeFeed content={pageInfo.stackexchange} />
+      <YouTubeFeed content={pageInfo.youtube} />
+      <div className={styles.youtubeCard}>
+        <h2>Join these cool Sitecore Communities 🤖</h2>
+        <MarkdownGrid partials={[partials.slack, partials.stackExchange, partials.forums]} />
       </div>
+
+      {/* PRODUCT SOLUTIONS */}
+      <ul className={classnames('grid', 'gap-6', 'md:grid-cols-2')}>
+        {productSolutions.map((solution, i) => (
+          <ProductCategoryCard {...solution} key={i} />
+        ))}
+      </ul>
+      <div className={classnames('prose')}>
+        <ReactMarkdown>{partials.getHelp}</ReactMarkdown>
+      </div>
+      <StackExchangeFeed content={pageInfo.stackexchange} />
     </Layout>
   );
 }

--- a/pages/integrations/xm-cdp/index.tsx
+++ b/pages/integrations/xm-cdp/index.tsx
@@ -1,11 +1,10 @@
-// Global
-import ReactMarkdown from 'react-markdown';
 // Scripts
 import { getPageInfo, getPartialsAsArray } from '@/scripts/page-info';
 // Interfaces
 import type { PageInfo } from '@/interfaces/page-info';
 // Components
 import Layout from '@/components/layout/Layout';
+import MarkdownContent from '@/components/helper/MarkdownContent';
 
 export async function getStaticProps() {
   const pageInfo = await getPageInfo('integrations/xm-cdp');
@@ -22,13 +21,7 @@ export async function getStaticProps() {
 export default function XM_CDP({ pageInfo, partials }: { pageInfo: PageInfo; partials: string[] }) {
   return (
     <Layout pageInfo={pageInfo}>
-      <div>
-        {partials.map((partial, i) => (
-          <div key={i}>
-            <ReactMarkdown>{partial}</ReactMarkdown>
-          </div>
-        ))}
-      </div>
+      <MarkdownContent partials={partials} />
     </Layout>
   );
 }

--- a/pages/learn.tsx
+++ b/pages/learn.tsx
@@ -7,6 +7,7 @@ import { getPageInfo, getPartials } from '@/scripts/page-info';
 import { PageInfo, PagePartials } from '@/interfaces/page-info';
 // Components
 import Layout from '@/components/layout/Layout';
+import MarkdownGrid from '@/components/helper/MarkdownGrid';
 import TwitterFeed from '@/components/integrations/twitter/TwitterFeed';
 import YouTubeFeed from '@/components/integrations/youtube/YouTubeFeed';
 import styles from '@/styles/Home.module.css';
@@ -42,24 +43,16 @@ export default function Learn({
 
   return (
     <Layout pageInfo={pageInfo}>
-      <div className={styles.grid}>
-        <div className={styles.productCategoryCard}>
-          <ReactMarkdown>{partials.starterKits}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCardLarge}>
-          <ReactMarkdown>{partials.gettingStarted}</ReactMarkdown>
-        </div>
-        <div className={styles.productCategoryCardLarge}>
-          <ReactMarkdown>{partials.learningSitecore}</ReactMarkdown>
-        </div>
-        <YouTubeFeed content={pageInfo.youtube} />
-        <TwitterFeed content={pageInfo.twitter} />
-        <div className={styles.socialsCard}>
-          <h2>News &amp; Announcements</h2>
-          <a href="" className={styles.link}>
-            <li>Cool new things</li>
-          </a>
-        </div>
+      <MarkdownGrid
+        partials={[partials.starterKits, partials.gettingStarted, partials.learningSitecore]}
+      />
+      <YouTubeFeed content={pageInfo.youtube} />
+      <TwitterFeed content={pageInfo.twitter} />
+      <div className={styles.socialsCard}>
+        <h2>News &amp; Announcements</h2>
+        <a href="" className={styles.link}>
+          <li>Cool new things</li>
+        </a>
       </div>
     </Layout>
   );


### PR DESCRIPTION
Opening against parent branch for now, will change to main once parent has been merged in.

Added 2 markdown layout components that take an array of partials as args and display them appropriately.

`MarkdownContent` is intended for the body content of child pages
`MarkdownGrid` is intended for those card list ones that we see on parent pages