### PR TITLE
Added GTM/GA snippets to the app and appropriate env variable support…

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,10 @@
  */
 
 const nextConfig = {
+  // Needed to expose in clientside.
+  env: {
+    GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID,
+  },
   images: {
     domains: ['sitecorecdn.azureedge.net', 'i.ytimg.com'],
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,18 +1,56 @@
 // Global
+import { useEffect } from 'react';
+import Script from 'next/script';
+import router, { useRouter } from 'next/router';
+import Head from 'next/head';
 import { AppProps } from 'next/dist/shared/lib/router/router';
 import { resetId } from 'react-id-generator';
 // Local
+import * as gtag from '../scripts/gtag';
 import '@/styles/global.css';
 // Components
 import Nav from '@/components/site/Nav/Nav';
 import Footer from '@/components/site/Footer/Footer';
 
-function MyApp({ Component, pageProps }: AppProps) {
+function SCDPApp({ Component, pageProps }: AppProps) {
   // Reset id counter during SSR
   resetId();
 
+  // useEffect for basic page views tracking via router/gtag.
+  useEffect(() => {
+    const handleRouteChange = (url: URL) => {
+      gtag.pageview(url);
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <>
+      <Head>
+        <link rel="dns-prefetch" href="https://www.googletagmanager.com/" />
+      </Head>
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`}
+      />
+      <Script
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${gtag.GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+        }}
+      />
       <Nav />
       <Component {...pageProps} />
       <Footer />
@@ -20,4 +58,4 @@ function MyApp({ Component, pageProps }: AppProps) {
   );
 }
 
-export default MyApp;
+export default SCDPApp;

--- a/scripts/gtag.ts
+++ b/scripts/gtag.ts
@@ -1,0 +1,30 @@
+export const GA_TRACKING_ID = process.env.GOOGLE_ANALYTICS_ID;
+
+declare global {
+  interface Window {
+    gtag: any;
+  }
+}
+
+type GTagEvent = {
+  action: string;
+  category: string;
+  label: string;
+  value: number;
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url: URL) => {
+  window.gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }: GTagEvent) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};


### PR DESCRIPTION
I used the [Next.js example](https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics) as a starting point (with basic page views and events supported), but made some additional changes including:

- Added basic types for GA
- Had to expose the GA environment variable via `next.config.js` for the clientside
- Added a `dns-prefetch` to GTM

**Notes:**
- To test this locally:
  Add `GOOGLE_ANALYTICS_ID=G-6RYVGRMJ0K` to your `.env.local` file.
- To test this on `preview` builds, we need to add the above environment variable to Vercel.

@jst-cyr  - Do we want to role with the `development` analytics ID on `production` for now, until we confirm things are happening on the GA side? We can then switch the environment variable for `production` at any time to the appropriate analytics ID.
