### PR TITLE
Updated integrations page to be dynamically generated

### DIFF
--- a/pages/integrations/[integration].tsx
+++ b/pages/integrations/[integration].tsx
@@ -1,25 +1,34 @@
 // Scripts
 import { getPageInfo, getPartialsAsArray } from '@/scripts/page-info';
+import { getIntegrationPaths } from '@/scripts/static-paths';
 // Interfaces
 import type { PageInfo, PartialData } from '@/interfaces/page-info';
 // Components
 import GenericContentPage from '@/components/layout/GenericContentPage';
 
-export async function getStaticProps() {
-  const pageInfo = await getPageInfo('integrations/xm-cdp');
+export async function getStaticPaths() {
+  const productPaths = await getIntegrationPaths();
+  return {
+    paths: productPaths,
+    fallback: false
+  }
+}
+
+export async function getStaticProps(context : any) {
+  const pageInfo = await getPageInfo(`integrations/${context?.params?.integration}`);
   const partials = pageInfo?.partials ? await getPartialsAsArray(pageInfo.partials) : [];
 
   return {
     props: {
-      pageInfo,
-      partials,
+     pageInfo,
+     partials
     },
   };
 }
 
 type XMCDPPageProps = {
-  pageInfo: PageInfo;
-  partials: PartialData;
+ pageInfo: PageInfo;
+ partials: PartialData;
 };
 
 const XMCDPPage = ({ pageInfo, partials }: XMCDPPageProps): JSX.Element => (

--- a/scripts/static-paths.ts
+++ b/scripts/static-paths.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 const solutionsDirectory = path.join(process.cwd(), 'data/markdown/pages/solution/');
+const integrationDirectory = path.join(process.cwd(), 'data/markdown/pages/integrations/');
 
 type SolutionPaths = {
   params: {
@@ -13,6 +14,12 @@ type ProductPaths = {
   params: {
     product: string;
     solution: string;
+  };
+};
+
+type IntegrationPaths = {
+  params: {
+    integration: string;
   };
 };
 
@@ -35,3 +42,8 @@ export const getProductPaths = async (): Promise<ProductPaths[]> => {
   });
   return paths;
 };
+
+export const getIntegrationPaths = async (): Promise<IntegrationPaths[]> => {
+  const files = fs.readdirSync(integrationDirectory);
+  return files.map((file) => ({ params: { integration: file } }));
+}


### PR DESCRIPTION
Changed the integrations page to now be dynamically generated.

@bhgeorge, I followed the same pattern you created for Solution & Product dynamic pages, so it would be good to get your eyes across this to ensure it makes sense 😁