### PR TITLE
Highlighting the downloads links in the nav

### DIFF
--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -235,7 +235,7 @@ const NavigationData: NavigationData[] = [
             url: '/content-management/sxa',
           },
           {
-            title: 'Downloads',
+            title: 'Downloads 💾',
             url: 'https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform.aspx'
           },
         ],
@@ -256,7 +256,7 @@ const NavigationData: NavigationData[] = [
             url: '/personalization-testing/experience-platform',
           },
           {
-            title: 'Downloads',
+            title: 'Downloads 💾',
             url: 'https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform.aspx'
           },
         ],
@@ -270,7 +270,7 @@ const NavigationData: NavigationData[] = [
             url: '/marketing-automation/send',
           },
           {
-            title: 'Get Sitecore Send for free',
+            title: 'Get Sitecore Send for free 📧',
             url: 'https://identity.moosend.com/register/'
           }
         ]
@@ -284,7 +284,7 @@ const NavigationData: NavigationData[] = [
             url: '/commerce/ordercloud',
           },
           {
-            title: 'Access OrderCloud Portal for free',
+            title: 'Access OrderCloud Portal for free 💸',
             url: 'https://portal.ordercloud.io/',
           }
         ]
@@ -298,7 +298,7 @@ const NavigationData: NavigationData[] = [
             url: '/commerce/experience-commerce',
           },
           {
-            title: 'Downloads',
+            title: 'Downloads 💾',
             url: 'https://dev.sitecore.net/Downloads/Sitecore_Commerce.aspx'
           }
         ]


### PR DESCRIPTION
I'm using this branch for us to try different ways of highlighting the downloads links in the nav, now that the content is in the nav. This first attempt is using simple emoji. It makes them stand out, but doesn't necessarily fit with the rest of the brand style?

Thoughts and suggestions to talk this one through are welcome. I figure this is one of those where we need to see some iterations to see what we want to go with. Not a priority for launch, but starting the discussion while it's in our heads.