### PR TITLE
Added simple delay to stackexchange requests to prevent rate limiting.

### DIFF
--- a/components/integrations/stackexchange/StackExchange.api.ts
+++ b/components/integrations/stackexchange/StackExchange.api.ts
@@ -8,7 +8,7 @@ type StackExchangeResponse = {
 };
 
 const avoidRateLimit = async () => {
-  // Rate limit ourselves to 20 per second
+  // Rate limit ourselves to ...about... 20 per second
   return new Promise((res) => setTimeout(res, 50));
 };
 

--- a/components/integrations/stackexchange/StackExchange.api.ts
+++ b/components/integrations/stackexchange/StackExchange.api.ts
@@ -7,10 +7,17 @@ type StackExchangeResponse = {
   items: StackExchangeQuestion[];
 };
 
+const avoidRateLimit = async () => {
+  // Rate limit ourselves to 20 per second
+  return new Promise((res) => setTimeout(res, 50));
+};
+
 const get = async (args?: string | string[]): Promise<StackExchangeQuestion[]> => {
   if (!args) {
     return [];
   }
+
+  await avoidRateLimit();
 
   const tags: string[] = [];
 


### PR DESCRIPTION
A bit ugly. But this should prevent us from breaking the 30 per second limit.

My local tests have this returning an average of 45ms between requests. Anything above 33.33 should be safe.