### PR TITLE
added onetrust client-side integration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
   // Needed to expose in clientside.
   env: {
     GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID,
+    COOKIE_CONSENT_URL: process.env.COOKIE_CONSENT_URL,
   },
   images: {
     domains: ['sitecorecdn.azureedge.net', 'i.ytimg.com', 'mss-p-006-delivery.sitecorecontenthub.cloud'],

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -53,6 +53,20 @@ function SCDPApp({ Component, pageProps }: AppProps) {
           `,
         }}
       />
+
+      <Script
+        strategy="afterInteractive"
+        src={process.env.COOKIE_CONSENT_URL}
+      />
+      <Script
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            function OptanonWrapper() { }
+            `,
+        }}
+      />
+      
       <div className="theme-light text-theme-text bg-theme-bg dark:theme-dark">
         <Nav />
         <Component {...pageProps} />
@@ -63,3 +77,5 @@ function SCDPApp({ Component, pageProps }: AppProps) {
 }
 
 export default SCDPApp;
+
+


### PR DESCRIPTION
Adding initial version of OneTrust Cookie Compliance integration. Since this runs client-side I used the same approach as the Google Analytics integration. Environment variables are stored in Vercel.

@andershopkins could you do a quick sanity check to confirm it will work properly? 

