### PR TITLE
Feature/remove search from navigation

### DIFF
--- a/components/site/Nav/Nav.tsx
+++ b/components/site/Nav/Nav.tsx
@@ -33,6 +33,21 @@ const hamburgerBarClasses = classnames(
   'transition'
 );
 
+/*
+ * @TODO: Adding search back
+ *
+ * To re-enable search (at least the UI in navigation)
+ * You only need to change a few classes and uncomment the search include below.
+ *
+ * All @TODO: statements have the same text, so you can simply search for
+ *    @TODO: Adding search back
+ * to find what you need to change.
+ *
+ * Files affected:
+ *   - Nav.tsx
+ *   - NavMenu.tsx
+ */
+
 const Nav = (): JSX.Element => {
   const navRef = useRef<HTMLElement>(null);
   const [isOpen, setOpen] = useState(false);
@@ -46,6 +61,17 @@ const Nav = (): JSX.Element => {
       body.classList.toggle('lg-mw:overflow-hidden');
     }
     setOpen(!isOpen);
+  };
+
+  /**
+   *  Hook for handling closing the mobile nav.
+   */
+  const closeNav = () => {
+    const body = document.querySelector<HTMLBodyElement>('body');
+    if (body !== null) {
+      body.classList.remove('lg-mw:overflow-hidden');
+    }
+    setOpen(false);
   };
 
   /**
@@ -88,7 +114,15 @@ const Nav = (): JSX.Element => {
   }, [scrolled]);
 
   return (
-    <header className={classnames('h-32')}>
+    // @TODO: Adding search back
+    // Change height utility to `h-32` to the header.
+    //
+    // Necesarry to retain the space for the fixed header.
+    <header className={classnames('h-16')}>
+      {/*
+        // @TODO: Adding search back
+        // Change height utility to `h-32` to the containing div.
+      */}
       <div
         className={classnames(
           'bg-theme-bg',
@@ -99,7 +133,7 @@ const Nav = (): JSX.Element => {
           'fixed',
           'inset-x-0',
           'top-0',
-          'h-32',
+          'h-16',
           'transition-all',
           {
             '-top-16': scrolled, // Note: absolute is being used here to avoid "transform" resetting the coordinate system for the children that are relying on the document's coordinates.
@@ -141,7 +175,10 @@ const Nav = (): JSX.Element => {
           )}
         >
           <Link href="/">
-            <a className={classnames('flex', 'items-center', 'mr-auto', 'flex-shrink-0')}>
+            <a
+              className={classnames('flex', 'items-center', 'mr-auto', 'flex-shrink-0')}
+              onClick={closeNav}
+            >
               <span className={classnames('block', 'relative', 'w-36', 'lg:w-48')}>
                 <Logo />
               </span>
@@ -160,13 +197,17 @@ const Nav = (): JSX.Element => {
               </span>
             </a>
           </Link>
+          {/*
+            // @TODO: Adding search back
+            // Change the top value to `top-32`.
+          */}
           <nav
             ref={navRef}
             id="scdp-nav"
             className={classnames(
               'fixed',
               'bg-theme-bg',
-              'top-32',
+              'top-16',
               'bottom-0',
               'inset-0',
               'items-center',
@@ -278,11 +319,15 @@ const Nav = (): JSX.Element => {
             />
           </div>
         </div>
-        <div>
+        {/*
+          // @TODO: Adding search back
+          // Uncomment the div containing search here.
+        */}
+        {/* <div>
           <div className={classnames('px-gutter-all', 'py-2.5', 'max-w-screen-xl', 'm-auto')}>
             <SearchBox />
           </div>
-        </div>
+        </div> */}
       </div>
     </header>
   );

--- a/components/site/Nav/NavMenu.tsx
+++ b/components/site/Nav/NavMenu.tsx
@@ -17,8 +17,20 @@ type NavMenuProps = NavigationData & {
 };
 
 /*
- * The menus themselves.
+ * @TODO: Adding search back
+ *
+ * To re-enable search (at least the UI in navigation)
+ * You only need to change a few classes and uncomment the search include below.
+ *
+ * All @TODO: statements have the same text, so you can simply search for
+ *    @TODO: Adding search back
+ * to find what you need to change.
+ *
+ * Files affected:
+ *   - Nav.tsx
+ *   - NavMenu.tsx
  */
+
 const NavMenu = ({ title, url, children, buttonIcon, callback }: NavMenuProps): JSX.Element => {
   const navItemRef = useRef<HTMLDivElement>(null);
   const [isOpen, setOpen] = useState(false);
@@ -157,13 +169,17 @@ const NavMenu = ({ title, url, children, buttonIcon, callback }: NavMenuProps): 
       {/* 
         Nav Item Overlay
       */}
+      {/*
+        // @TODO: Adding Search Back
+        // Change the top value to `top-32`.
+      */}
       {children && (
         <React.Fragment>
           <div
             ref={navItemRef}
             className={classnames(
               'fixed',
-              'top-32',
+              'top-16',
               'bottom-0',
               'inset-x-0',
               'bg-theme-bg',

--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -50,20 +50,20 @@ export const SitecoreQuickLinks: NavigationData = {
 
 const NavigationData: NavigationData[] = [
   {
-    title: 'Docs',
-    url: '/docs',
-  },
-  {
-    title: 'Discover',
-    url: '/discover',
-  },
-  {
     title: 'Learn',
     url: '/learn',
   },
   {
+    title: 'Docs',
+    url: '/docs',
+  },
+  {
     title: 'Community',
     url: '/community',
+  },
+  {
+    title: 'Discover',
+    url: '/discover',
   },
   {
     title: 'Solution',

--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
   // Needed to expose in clientside.
   env: {
     GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID,
+    COOKIE_CONSENT_URL: process.env.COOKIE_CONSENT_URL,
   },
   images: {
     domains: ['sitecorecdn.azureedge.net', 'i.ytimg.com', 'mss-p-006-delivery.sitecorecontenthub.cloud'],

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -53,6 +53,20 @@ function SCDPApp({ Component, pageProps }: AppProps) {
           `,
         }}
       />
+
+      <Script
+        strategy="afterInteractive"
+        src={process.env.COOKIE_CONSENT_URL}
+      />
+      <Script
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            function OptanonWrapper() { }
+            `,
+        }}
+      />
+      
       <div className="theme-light text-theme-text bg-theme-bg dark:theme-dark">
         <Nav />
         <Component {...pageProps} />
@@ -63,3 +77,5 @@ function SCDPApp({ Component, pageProps }: AppProps) {
 }
 
 export default SCDPApp;
+
+


### PR DESCRIPTION
This branch "disables" search in the navigation. Only two files are affected, `Nav.tsx` and `NavMenu.tsx`. Each file has the same instructions commented at the top, and each change location is marked with the `@TODO: Adding search back`. 

Pretty simply all around, but it will take all of 30 seconds to "enable" search (from a UI perspective :P).

Also closes #97.