### PR TITLE
Removed emjois from page header meta where it still existed

### DIFF
--- a/data/markdown/pages/solution/commerce/index.md
+++ b/data/markdown/pages/solution/commerce/index.md
@@ -1,7 +1,7 @@
 ---
 solution: ['commerce']
 product: ['commerce']
-title: 'Commerce 💸'
+title: 'Commerce'
 description: 'Build out order management, merchandising, marketplaces, and storefronts'
 stackexchange:
   [

--- a/data/markdown/pages/solution/devops/index.md
+++ b/data/markdown/pages/solution/devops/index.md
@@ -1,7 +1,7 @@
 ---
 solution: ['devops']
 product: ['devops']
-title: 'DevOps 🎁'
+title: 'DevOps'
 description: 'Scale management and delivery of media and static assets'
 stackexchange: ['#docker', '#arm-template', '#sitecore-install-framework']
 ---

--- a/data/markdown/pages/solution/digital-asset-management/index.md
+++ b/data/markdown/pages/solution/digital-asset-management/index.md
@@ -1,7 +1,7 @@
 ---
 solution: ['digital-asset-management']
 product: ['digital-asset-management']
-title: 'Digital Asset Management 🕵️‍♀️'
+title: 'Digital Asset Management'
 description: 'Scale management and delivery of media and static assets'
 stackexchange: ['#dam']
 ---

--- a/data/markdown/pages/solution/marketing-automation/index.md
+++ b/data/markdown/pages/solution/marketing-automation/index.md
@@ -1,7 +1,7 @@
 ---
 solution: ['marketing-automation']
 product: ['marketing-automation']
-title: 'Marketing Automation 🚗'
+title: 'Marketing Automation'
 description: 'Connect with customers using marketing automation'
 stackexchange: ['#marketing-automation', '#exm']
 twitter: ['@Moosend', '#Moosend']

--- a/data/markdown/pages/solution/personalization-testing/index.md
+++ b/data/markdown/pages/solution/personalization-testing/index.md
@@ -1,7 +1,7 @@
 ---
 solution: ['personalization-testing']
 product: ['personalization-testing']
-title: 'Personalization and Testing 🕵️‍♀️'
+title: 'Personalization and Testing'
 description: 'Deliver personalized content and test which content is working.'
 stackexchange: ['#personalization', '#content-testing', '#fxm', '#universal-tracker']
 ---


### PR DESCRIPTION
Some of the top level Solution pages still had emoji's in the title, whereas some had been tidied to remove them.

This PR removes the remaining ones to bring them all inline.