### PR TITLE
Disable deploy on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.repository_owner == 'Sitecore'
+    if: github.repository_owner == 'Sitecore' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions: 
       deployments: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == push))
+    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     runs-on: ubuntu-latest
     permissions: 
       deployments: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.repository_owner == 'Sitecore' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == push))
     runs-on: ubuntu-latest
     permissions: 
       deployments: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.repository_owner == 'Sitecore'
     runs-on: ubuntu-latest
     permissions: 
       deployments: write

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ If you want to make changes to the code, follow these steps:
 6. Make your changes
 7. Commit, push to your remote fork of the Developer Portal repo, then open a pull request (PR) to the `main` branch of the Developer Portal repo.
 
-Your changes will be reviewed and merged if appropriate.
+Your changes will be reviewed and merged if appropriate..

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ If you want to make changes to the code, follow these steps:
 6. Make your changes
 7. Commit, push to your remote fork of the Developer Portal repo, then open a pull request (PR) to the `main` branch of the Developer Portal repo.
 
-Your changes will be reviewed and merged if appropriate..
+Your changes will be reviewed and merged if appropriate.


### PR DESCRIPTION
Added logic to disable the Github Action `deploy` step in certain scenarios. 

Breakdown of the logic is.....

`github.repository_owner == 'Sitecore'` This step will only fire for repo's within the Sitecore Org, meaning that Forks where actions have been enabled won't execute this step. Secrets aren't passed to Forks so this isn't an issue from our side but will stop Forks from having a heap of failed actions executing on them.

`((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))` The PR repo and target must be the same (i.e. disable this step for external PR's), or it must be a push (i.e. we still want this step to fire for pushes on our branches to be able to test before opening PR).