### PR TITLE
Removing the extra 's' on the containers page

### DIFF
--- a/data/markdown/partials/solution/devops/containers.md
+++ b/data/markdown/partials/solution/devops/containers.md
@@ -6,7 +6,7 @@ product: ['experience-manager', 'experience-platform', 'experience-commerce', 'c
 ## Introduction
 Containers are executable units of software that code is packaged in, along with libraries and dependencies, so that it can be run anywhere, whether on a developer's workstation, an on-prem server, or in the cloud, and deployed easily and consistently, regardless of the target environment.
 
-There are a number of reasons why the use of containers is attractive for Sitecore development, and it becomes even more attractive as Sitecores moves towards a microservices-based architecture. Containers lend themselves very well to this architecture (and in fact encourage it). Read more about container in Sitecore Development [here](https://doc.sitecore.com/en/developers/100/developer-tools/containers-in-sitecore-development.html)
+There are a number of reasons why the use of containers is attractive for Sitecore development, and it becomes even more attractive as Sitecore moves towards a microservices-based architecture. Containers lend themselves very well to this architecture (and in fact encourage it). Read more about container in Sitecore Development [here](https://doc.sitecore.com/en/developers/100/developer-tools/containers-in-sitecore-development.html)
 
 
 ## Documentation


### PR DESCRIPTION
Should be 'Sitecore' not 'Sitecores'

Fixes #165 