### PR TITLE
Updating YouTube links to SXA tutorial series to specify playlist

### DIFF
--- a/data/markdown/partials/learn/getting-started/platform-dxp-development-frameworks.md
+++ b/data/markdown/partials/learn/getting-started/platform-dxp-development-frameworks.md
@@ -3,5 +3,5 @@
 - [Getting Started with JSS](https://jss.sitecore.com/docs/nextjs/getting-started-nextjs/workflow-options)
 - [Getting Started with JSS with Next.js](https://jss.sitecore.com/docs/nextjs/getting-started-nextjs/walkthrough-dotnetnew)
 - [Getting Started with Sitecore Headless .NET Core SDK](https://doc.sitecore.com/en/developers/101/developer-tools/walkthrough--using-the-getting-started-template.html)
-- [Getting Started with SXA](https://www.youtube.com/watch?v=nMTUitaBMek)
+- [Getting Started with SXA](https://www.youtube.com/watch?v=nMTUitaBMek&list=PL1jJVFm_lGnwKmalgi6sukqDhoYA73JDn&index=1)
 - [Getting Started with Containers](https://doc.sitecore.com/en/developers/101/developer-tools/containers-in-sitecore-development.html)

--- a/data/markdown/partials/solution/content-management/sxa.md
+++ b/data/markdown/partials/solution/content-management/sxa.md
@@ -22,7 +22,7 @@ In order to get started with SXA you will need a clean installation of Sitecore 
 
 ## Learn
 
-- [SXA Tutorial YouTube series](https://www.youtube.com/watch?v=nMTUitaBMek)
+- [SXA Tutorial YouTube series](https://www.youtube.com/watch?v=nMTUitaBMek&list=PL1jJVFm_lGnwKmalgi6sukqDhoYA73JDn&index=1)
 - [Unofficial SXA tutorials](https://www.youtube.com/c/SXA-Tutorials)
 - [Official Sitecore course](https://learning.sitecore.com/course/sitecore-experience-accelerator-sxa-collection)
 


### PR DESCRIPTION
The new playlist setting will make sure users can navigate to the next episode in the tutorial series.

Fixes #170 