### PR TITLE
Sym rebranding products solutions

### DIFF
--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -195,7 +195,7 @@ const NavigationData: NavigationData[] = [
         title: 'Sitecore Content Hub',
         children: [
           {
-            title: 'Content Management',
+            title: 'Content Operations',
             url: '/content-management/content-hub',
           },
           {
@@ -209,7 +209,7 @@ const NavigationData: NavigationData[] = [
         ],
       },
       {
-        title: 'Sitecore CDP',
+        title: 'Sitecore CDP and Personalize',
         children: [
           {
             title: 'Customer Data Management',

--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -114,7 +114,7 @@ const NavigationData: NavigationData[] = [
         children: [
           {
             title: 'Sitecore Personalize',
-            url: '/personalization-testing/cdp',
+            url: '/personalization-testing/personalize',
           },
           {
             title: 'Sitecore Experience Platform',
@@ -217,7 +217,7 @@ const NavigationData: NavigationData[] = [
           },
           {
             title: 'Personalization and Testing',
-            url: '/personalization-testing/cdp',
+            url: '/personalization-testing/personalize',
           },
         ],
       },

--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -73,20 +73,16 @@ const NavigationData: NavigationData[] = [
         url: '/content-management',
         children: [
           {
-            title: 'Sitecore Content Hub',
-            url: '/content-management/content-hub',
-          },
-          {
-            title: 'Experience Edge for Content Hub',
-            url: '/content-management/edge-content-hub',
-          },
-          {
             title: 'Sitecore Experience Manager',
             url: '/content-management/experience-manager',
           },
           {
             title: 'Experience Edge for XM',
             url: '/content-management/edge-xm',
+          },
+          {
+            title: 'Experience Edge for Content Hub',
+            url: '/content-management/edge-content-hub',
           },
           {
             title: 'Sitecore Experience Accelerator (SXA)',
@@ -117,7 +113,7 @@ const NavigationData: NavigationData[] = [
         url: '/personalization-testing',
         children: [
           {
-            title: 'Sitecore CDP',
+            title: 'Sitecore Personalize',
             url: '/personalization-testing/cdp',
           },
           {
@@ -155,8 +151,18 @@ const NavigationData: NavigationData[] = [
         ],
       },
       {
-        title: 'Digital Asset Management',
-        url: '/digital-asset-management/dam',
+        title: 'DAM and Content Operations',
+        url: '/digital-asset-management',
+        children: [
+          {
+            title: 'Sitecore Content Hub',
+            url: '/content-management/content-hub',
+          },
+          {
+            title: 'Sitecore DAM',
+            url: '/content-management/dam',
+          },
+        ]
       },
       {
         title: 'DevOps',

--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -152,15 +152,15 @@ const NavigationData: NavigationData[] = [
       },
       {
         title: 'DAM and Content Operations',
-        url: '/digital-asset-management',
+        url: '/dam-and-content-operations',
         children: [
           {
             title: 'Sitecore Content Hub',
-            url: '/content-management/content-hub',
+            url: '/dam-and-content-operations/content-hub',
           },
           {
             title: 'Sitecore DAM',
-            url: '/content-management/dam',
+            url: '/dam-and-content-operations/dam',
           },
         ]
       },
@@ -196,11 +196,11 @@ const NavigationData: NavigationData[] = [
         children: [
           {
             title: 'Content Operations',
-            url: '/content-management/content-hub',
+            url: '/dam-and-content-operations/content-hub',
           },
           {
             title: 'Digital Asset Management',
-            url: '/digital-asset-management/dam',
+            url: '/dam-and-content-operations/dam',
           },
           {
             title: 'Experience Edge for Content Hub',

--- a/data/markdown/pages/solution/content-management/index.md
+++ b/data/markdown/pages/solution/content-management/index.md
@@ -2,7 +2,7 @@
 solution: ['content-management']
 product: ['content-management']
 title: 'Content Management and Delivery'
-description: 'Manage content and presentation for the web channel.'
+description: 'Manage content and presentation for your channels and then scale out your delivery'
 stackexchange:
   [
     '#dam',

--- a/data/markdown/pages/solution/dam-and-content-operations/index.md
+++ b/data/markdown/pages/solution/dam-and-content-operations/index.md
@@ -1,0 +1,7 @@
+---
+solution: ['dam-and-content-operations']
+product: ['dam-and-content-operations']
+title: 'Digital Asset Management and Content Operations'
+description: 'Scale management, workflow, and delivery of content, media, and static assets '
+stackexchange: ['#dam', '#content-hub', '#content-hub-scripting']
+---

--- a/data/markdown/pages/solution/dam-and-content-operations/product/content-hub/index.md
+++ b/data/markdown/pages/solution/dam-and-content-operations/product/content-hub/index.md
@@ -1,10 +1,10 @@
 ---
-solution: ['content-management']
+solution: ['dam-and-content-operations']
 product: ['content-hub']
 title: 'Sitecore Content Hub'
 description: 'Content Hub content management and content operations'
 stackexchange: ['#dam', '#content-hub', '#content-hub-scripting']
-partials: ['solution/content-management/content-hub']
+partials: ['solution/dam-and-content-operations/content-hub']
 youtube: PL1jJVFm_lGnydV6XCOptUYPmyLBg-0NLA
 youtubeTitle: Learn more about Sitecore Content Hub
 ---

--- a/data/markdown/pages/solution/dam-and-content-operations/product/dam/index.md
+++ b/data/markdown/pages/solution/dam-and-content-operations/product/dam/index.md
@@ -1,10 +1,10 @@
 ---
-solution: ['digital-asset-management']
+solution: ['dam-and-content-operations']
 product: ['dam']
-title: 'Digital Asset Management - Sitecore DAM'
+title: 'Sitecore DAM'
 description: 'Scale management and delivery of media and static assets'
 stackexchange: ['#dam']
-partials: ['solution/digital-asset-management/dam']
+partials: ['solution/dam-and-content-operations/dam']
 hasInPageNav: true
 youtube: PL1jJVFm_lGnydV6XCOptUYPmyLBg-0NLA
 youtubeTitle: Learn more on DAM & Sitecore Content Hub

--- a/data/markdown/pages/solution/digital-asset-management/index.md
+++ b/data/markdown/pages/solution/digital-asset-management/index.md
@@ -1,7 +1,0 @@
----
-solution: ['digital-asset-management']
-product: ['digital-asset-management']
-title: 'Digital Asset Management'
-description: 'Scale management and delivery of media and static assets'
-stackexchange: ['#dam']
----

--- a/data/markdown/pages/solution/personalization-testing/product/personalize/index.md
+++ b/data/markdown/pages/solution/personalization-testing/product/personalize/index.md
@@ -2,8 +2,9 @@
 solution: ['personalization-testing']
 product: ['cdp']
 page: 'cdp'
-title: 'Sitecore CDP'
+title: 'Sitecore Personalize'
 description: 'Use advanced decisioning models and machine learning for personalization in your composable DXP.'
-partials: ['solution/personalization-testing/cdp']
+partials: ['solution/personalization-testing/personalize']
 youtube: PL1jJVFm_lGnx-VFtQBFiOscKJhddMpp2s
+youtubeTitle: 'Latest Sitecore Personalize videos'
 ---

--- a/data/markdown/partials/docs/personalization/sitecore-personalize.md
+++ b/data/markdown/partials/docs/personalization/sitecore-personalize.md
@@ -1,4 +1,4 @@
-### Sitecore CDP
+### Sitecore Personalize
 
 - [Developer Docs - Data Model 2.1](https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-1/index-en.html)
 - [Developer Docs - Data Model 2.0](https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-0/index-en.html)

--- a/data/markdown/partials/solution/dam-and-content-operations/content-hub.md
+++ b/data/markdown/partials/solution/dam-and-content-operations/content-hub.md
@@ -1,5 +1,5 @@
 ---
-solution: ['content-management']
+solution: ['dam-and-content-operations']
 product: ['content-hub']
 prettyName: 'Content Hub'
 description: 'Centralize content strategy and operations for all delivery channels'

--- a/data/markdown/partials/solution/dam-and-content-operations/dam.md
+++ b/data/markdown/partials/solution/dam-and-content-operations/dam.md
@@ -1,5 +1,5 @@
 ---
-solution: ['digital-asset-management']
+solution: ['dam-and-content-operations']
 product: ['dam']
 ---
 

--- a/data/markdown/partials/solution/personalization-testing/personalize.md
+++ b/data/markdown/partials/solution/personalization-testing/personalize.md
@@ -1,11 +1,11 @@
 ---
 solution: 'personalization-testing'
 product: ['cdp']
-title: 'Personalization & Testing - Sitecore CDP'
+title: 'Personalization & Testing - Sitecore Personalize'
 ---
 
 ## Introduction
-Sitecore CDP brings together real-time behavioral insights and all your customer data so you can understand and engage every customer (and anonymous visitors) instantly.
+Sitecore Personalize brings together real-time behavioral insights and all your customer data so you can understand and engage every customer (and anonymous visitors) instantly.
 
 ## Documentation
 

--- a/pages/docs.tsx
+++ b/pages/docs.tsx
@@ -18,7 +18,7 @@ export async function getStaticProps() {
     'docs/customer-data-management/sitecore-experience-platform',
   ]);
   const personalization = await getPartialsAsArray([
-    'docs/personalization/sitecore-cdp',
+    'docs/personalization/sitecore-personalize',
     'docs/personalization/sitecore-experience-platform',
   ]);
   const marketingAutomation = await getPartialsAsArray([

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,9 +35,9 @@ const productSolutions: CategoryTileProps[] = [
     href: '/content-management/',
   },
   {
-    title: 'Digital Asset Management (DAM)',
-    description: 'Scale management and delivery of media and static assets',
-    href: '/digital-asset-management/dam',
+    title: 'Digital Asset Management (DAM) and Content Operations',
+    description: 'Scale management, workflow and delivery of content, media and static assets',
+    href: '/dam-and-content-operations',
   },
   {
     title: 'Customer Data Management',


### PR DESCRIPTION
The Digital Asset Management solution is now the DAM and Content Operations solution. Titles, menu items, files, and routes are all updated for this new grouping. Content Hub has also been moved into this solution category and out of Content Management and Delivery. 

**NOTE:** Experience Edge for Content Hub is still in Content Management and Delivery. 

This branch also renames Sitecore CDP to Sitecore Personalize when speaking about personalization and testing, but I have not updated the content itself (such as the Sitecore CDP Knowledgebase, or references to the Sitecore CDP docs).

Fixes #172 