### PR TITLE
Reverting Sitecore Send to Moosend

### DIFF
--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -128,7 +128,7 @@ const NavigationData: NavigationData[] = [
         url: '/marketing-automation',
         children: [
           {
-            title: 'Sitecore Send',
+            title: 'Moosend',
             url: '/marketing-automation/send',
           },
           {
@@ -275,7 +275,7 @@ const NavigationData: NavigationData[] = [
         ],
       },
       {
-        title: 'Sitecore Send',
+        title: 'Moosend',
         url: '/marketing-automation/send',
         children: [
           {
@@ -283,7 +283,7 @@ const NavigationData: NavigationData[] = [
             url: '/marketing-automation/send',
           },
           {
-            title: 'Get your free Sitecore Send account',
+            title: 'Get your free Moosend account',
             url: 'https://identity.moosend.com/register/',
             external: true,
           },

--- a/data/markdown/pages/solution/marketing-automation/product/send/index.md
+++ b/data/markdown/pages/solution/marketing-automation/product/send/index.md
@@ -1,8 +1,8 @@
 ---
 solution: ['marketing-automation']
 product: ['send']
-title: 'Sitecore Send'
-description: 'Connecting with customers with Sitecore Send marketing automation'
+title: 'Moosend'
+description: 'Connecting with customers with Moosend marketing automation'
 twitter: ['@Moosend', '#Moosend']
 youtube: 'PLAKrWBcgVt6M4Ia_bECQVOyxUe1eDFpG6'
 youtubeTitle: 'Latest Marketing Automation videos'

--- a/data/markdown/partials/discover/send.md
+++ b/data/markdown/partials/discover/send.md
@@ -1,6 +1,6 @@
-## Sitecore Send
+## Moosend
 
-Sitecore Send's Knowledge Base covers a lot of topics to help you get started:
+Moosend's Knowledge Base covers a lot of topics to help you get started:
 
 - Getting Started
 - Integrations
@@ -8,4 +8,4 @@ Sitecore Send's Knowledge Base covers a lot of topics to help you get started:
 - Email Automation
 - etc.
 
-[Get help with Sitecore Send](https://moosend.com/help/)
+[Get help with Moosend](https://moosend.com/help/)

--- a/data/markdown/partials/docs/marketing-automation/send.md
+++ b/data/markdown/partials/docs/marketing-automation/send.md
@@ -1,3 +1,3 @@
-### Sitecore Send
+### Moosend
 
 - [Documentation](https://moosend.com/help/)

--- a/data/markdown/partials/learn/getting-started/composable-dxp.md
+++ b/data/markdown/partials/learn/getting-started/composable-dxp.md
@@ -3,6 +3,6 @@
 - [Getting Started with Sitecore CDP](https://doc.sitecore.com/cdp/en/users/sitecore-customer-data-platform/introduction-to-sitecore-cdp.html)
 - [Getting Started with OrderCloud](https://ordercloud.io/learn/getting-started/welcome-to-ordercloud)
 - [Getting Started with Content Hub](https://docs.stylelabs.com/contenthub/4.0.x/content/user-documentation/get-started/get-started.html)
-- [Getting Started with Sitecore Send](https://help.moosend.com/hc/en-us/articles/208076445-How-do-I-get-started-with-my-Moosend-account-)
+- [Getting Started with Moosend](https://help.moosend.com/hc/en-us/articles/208076445-How-do-I-get-started-with-my-Moosend-account-)
 - [Getting started with Experience Edge for ContentHub](https://docs.stylelabs.com/content/4.0.x/user-documentation/experience-edge/content-delivery/quickstart-guide.html)
 - [Getting started with Experience Edge for XM](https://doc.sitecore.com/en/developers/101/developer-tools/sitecore-experience-edge-for-xm.html)

--- a/data/markdown/partials/solution/marketing-automation/send.md
+++ b/data/markdown/partials/solution/marketing-automation/send.md
@@ -1,12 +1,12 @@
 ---
 solution: ['marketing-automation']
 product: ['send']
-title: 'Sitecore Send'
-description: 'Connecting with customers with Sitecore Send marketing automation'
+title: 'Moosend'
+description: 'Connecting with customers with Moosend marketing automation'
 ---
 
 ## Introduction
-With Sitecore Send you can dive into the world of email marketing and create the most responsive newsletters to amaze your subscribers. However, sending email campaigns is not the only thing you can do. By leveraging state-of-the-art marketing automation features you can save valuable time by scheduling your campaigns and tracking their performance based on your recipients’ behaviour through advanced Reporting Capabilities.
+With Moosend you can dive into the world of email marketing and create the most responsive newsletters to amaze your subscribers. However, sending email campaigns is not the only thing you can do. By leveraging state-of-the-art marketing automation features you can save valuable time by scheduling your campaigns and tracking their performance based on your recipients’ behavior through advanced Reporting Capabilities.
 
 
 ## Documentation
@@ -15,8 +15,8 @@ With Sitecore Send you can dive into the world of email marketing and create the
 - [API Documentation](https://moosendapp.docs.apiary.io/)
 
 ## Learn
-- [Sitecore Send Academy](https://academy.moosend.com/)
-- [How do I get started with my Sitecore Send account?](https://help.moosend.com/hc/en-us/articles/208076445-How-do-I-get-started-with-my-Moosend-account-)
+- [Moosend Academy](https://academy.moosend.com/)
+- [How do I get started with my Moosend account?](https://help.moosend.com/hc/en-us/articles/208076445-How-do-I-get-started-with-my-Moosend-account-)
 - [Extra tools](https://moosend.com/resources/fancy-toolshed/)
 - [Moosend blog](https://moosend.com/blog/)
 


### PR DESCRIPTION
Per request from internal technical writing, we are reverting current text for links to Moosend documents to use the name "Moosend" as this product will continue to exist after Sitecore Send is released, and these links will continue to refer to 'Moosend' and not Sitecore Send. We will need to add new Sitecore Send links in the future.

For now, this PR does changes to navigation links and text on multiple pages to revert the name Sitecore Send to Moosend. The routes have not been changed, they still use "/send" as the page route.

I have not updated anything referring to the integration guides. Those are not Moosend URLs and we can update the instructions in them to match with Sitecore Send details after Sitecore Send is released.

Fixes #185 