### PR TITLE
Hiding Twitter component if there is no content to display

### DIFF
--- a/components/integrations/twitter/TwitterFeed.tsx
+++ b/components/integrations/twitter/TwitterFeed.tsx
@@ -15,7 +15,7 @@ type TwitterFeedProps = {
 };
 
 const TwitterFeed = ({ content, handle, headingLevel = 'h2' }: TwitterFeedProps): JSX.Element => {
-  if (!content || !handle) {
+  if (!content || content.length==0 || !handle) {
     return <></>;
   }
 


### PR DESCRIPTION
Added a conditional check to hide the Twitter component if there is no content passed to the component (not just a null check, checks for an array length of zero as well)

Fixes #187 