### PR TITLE
Added highlight in main nav to currently active section.

### DIFF
--- a/components/layout/InPageNav/InPageNav.tsx
+++ b/components/layout/InPageNav/InPageNav.tsx
@@ -55,8 +55,8 @@ const InPageNav = ({ titles }: InPageNavProps): JSX.Element => {
     >
       <p className={classnames('font-bold', 'text-sm', 'mb-4', 'md:hidden')}>Table of contents</p>
       <ul className={classnames('in-page-nav', 'relative', 'pl-1.5')}>
-        {titles.map((title) => (
-          <li className={classnames('in-page-nav-item', 'pb-4', 'relative', 'pl-4')} key={title}>
+        {titles.map((title, i) => (
+          <li className={classnames('in-page-nav-item', 'pb-4', 'relative', 'pl-4')} key={i}>
             <Link href={`#${getSectionId(title)}`}>
               <a
                 className={classnames(

--- a/components/site/Nav/Nav.tsx
+++ b/components/site/Nav/Nav.tsx
@@ -241,6 +241,7 @@ const Nav = (): JSX.Element => {
                       title={item.title}
                       children={item.children}
                       url={item.url}
+                      pathname={item.pathname}
                       callback={toggleNav}
                     />
                   </li>

--- a/components/site/Nav/NavLink.tsx
+++ b/components/site/Nav/NavLink.tsx
@@ -19,13 +19,13 @@ const Level2Classes = classnames('text-xs');
 /*
  * A simple wrapper for nav link items within the menus.
  */
-const NavLink = ({ text, url, level, external, onClick }: NavLinkProps): JSX.Element => {
+const NavLink = ({ text, url, level, external, onClick, ...props }: NavLinkProps): JSX.Element => {
   return (
     <ConditionalWrapper
       condition={!!url}
       wrapper={(children) => (
         <Link href={url as string}>
-          <a className={classnames('inline-block', 'hover:underline')} onClick={onClick}>
+          <a className={classnames('inline-block', 'hover:underline')} onClick={onClick} {...props}>
             {children}
           </a>
         </Link>
@@ -40,13 +40,23 @@ const NavLink = ({ text, url, level, external, onClick }: NavLinkProps): JSX.Ele
         {text}
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          className={external ? classnames('h-4', 'w-4', 'ml-1', 'mb-1', 'inline-flex') : classnames('hidden')} 
+          className={
+            external
+              ? classnames('h-4', 'w-4', 'ml-1', 'mb-1', 'inline-flex')
+              : classnames('hidden')
+          }
           fill="none"
-          viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+          />
         </svg>
       </span>
-      
     </ConditionalWrapper>
   );
 };

--- a/components/site/Nav/NavMenu.tsx
+++ b/components/site/Nav/NavMenu.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { classnames } from 'tailwindcss-classnames';
+import { useRouter } from 'next/router';
 // Data
 import { NavigationData } from '@/data/data-navigation';
 // Components
@@ -32,7 +33,14 @@ type NavMenuProps = NavigationData & {
  *   - InPageNav.tsx
  */
 
-const NavMenu = ({ title, url, children, buttonIcon, callback }: NavMenuProps): JSX.Element => {
+const NavMenu = ({
+  title,
+  url,
+  children,
+  pathname,
+  buttonIcon,
+  callback,
+}: NavMenuProps): JSX.Element => {
   const navItemRef = useRef<HTMLDivElement>(null);
   const [isOpen, setOpen] = useState(false);
   const toggleNavItem = (event: React.MouseEvent) => {
@@ -84,6 +92,10 @@ const NavMenu = ({ title, url, children, buttonIcon, callback }: NavMenuProps): 
   );
   const navItemOverlayActiveClasses = classnames('translate-x-0');
 
+  const router = useRouter();
+  const currentRoute = router.pathname;
+  const isCurrentPage = (!!url && currentRoute.startsWith(url)) || currentRoute === pathname;
+
   return (
     <div>
       {/* 
@@ -100,7 +112,7 @@ const NavMenu = ({ title, url, children, buttonIcon, callback }: NavMenuProps): 
         <DynamicTag
           tag={children ? 'button' : 'a'}
           className={classnames(mainNavItemStyles, {
-            [buttonActiveClasses]: children && isOpen,
+            [buttonActiveClasses]: (children && isOpen) || isCurrentPage,
             ['lg:pr-5']: !!children,
           })}
           onClick={toggleNavItem}
@@ -279,7 +291,12 @@ const NavMenu = ({ title, url, children, buttonIcon, callback }: NavMenuProps): 
                         <ul>
                           {child.children?.map((child, index) => (
                             <li key={`child-${index}`} className={classnames('mb-4', 'lg:mb-2')}>
-                              <NavLink text={child.title} url={child.url} external={child.external} onClick={toggleNavItem} />
+                              <NavLink
+                                text={child.title}
+                                url={child.url}
+                                external={child.external}
+                                onClick={toggleNavItem}
+                              />
                             </li>
                           ))}
                         </ul>

--- a/components/site/Nav/NavMenu.tsx
+++ b/components/site/Nav/NavMenu.tsx
@@ -93,8 +93,10 @@ const NavMenu = ({
   const navItemOverlayActiveClasses = classnames('translate-x-0');
 
   const router = useRouter();
+  const currentPage = router.asPath;
+  const isCurrentPage = currentPage === url;
   const currentRoute = router.pathname;
-  const isCurrentPage = (!!url && currentRoute.startsWith(url)) || currentRoute === pathname;
+  const isCurrentPath = (!!url && currentRoute.startsWith(url)) || currentRoute === pathname;
 
   return (
     <div>
@@ -111,8 +113,9 @@ const NavMenu = ({
       >
         <DynamicTag
           tag={children ? 'button' : 'a'}
+          aria-current={!children ? isCurrentPage : undefined}
           className={classnames(mainNavItemStyles, {
-            [buttonActiveClasses]: (children && isOpen) || isCurrentPage,
+            [buttonActiveClasses]: (children && isOpen) || isCurrentPath,
             ['lg:pr-5']: !!children,
           })}
           onClick={toggleNavItem}
@@ -292,6 +295,7 @@ const NavMenu = ({
                           {child.children?.map((child, index) => (
                             <li key={`child-${index}`} className={classnames('mb-4', 'lg:mb-2')}>
                               <NavLink
+                                aria-current={currentPage === child.url}
                                 text={child.title}
                                 url={child.url}
                                 external={child.external}

--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -9,6 +9,7 @@ export type NavigationData = {
   title: string;
   url?: string;
   children?: NavigationChildData[];
+  pathname?: string;
 };
 
 export const SitecoreQuickLinks: NavigationData = {
@@ -68,6 +69,7 @@ const NavigationData: NavigationData[] = [
   },
   {
     title: 'Solution',
+    pathname: '/[solution]',
     children: [
       {
         title: 'Content Management and Delivery',
@@ -163,7 +165,7 @@ const NavigationData: NavigationData[] = [
             title: 'Sitecore DAM',
             url: '/dam-and-content-operations/dam',
           },
-        ]
+        ],
       },
       {
         title: 'DevOps',
@@ -191,6 +193,7 @@ const NavigationData: NavigationData[] = [
   },
   {
     title: 'Product',
+    pathname: '/[solution]/[product]',
     children: [
       {
         title: 'Sitecore Content Hub',
@@ -316,8 +319,8 @@ const NavigationData: NavigationData[] = [
             title: 'Downloads',
             url: 'https://dev.sitecore.net/Downloads/Sitecore_Commerce.aspx',
             external: true,
-          }
-        ]
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Description
When the user is on a page under one of the main nav sections, that section will now have the highlighted state.

## Motivation
Extra context to the user to understand what they're reading

## How Has This Been Tested?
Manual confirmation in local environment
- No pages highlighted on home
- Pages highlighted for a simple URL `/community`
- Solution category highlighted only when on the Solutions parent page
- Product category highlighted only when on a Product child page
- Learn highlighted when on an integrations child page


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM