### PR TITLE
Added free Learning essentials course to Learn and product pages

### DIFF
--- a/data/markdown/partials/learn/getting-started/composable-dxp.md
+++ b/data/markdown/partials/learn/getting-started/composable-dxp.md
@@ -6,3 +6,7 @@
 - [Getting Started with Moosend](https://help.moosend.com/hc/en-us/articles/208076445-How-do-I-get-started-with-my-Moosend-account-)
 - [Getting started with Experience Edge for ContentHub](https://docs.stylelabs.com/content/4.0.x/user-documentation/experience-edge/content-delivery/quickstart-guide.html)
 - [Getting started with Experience Edge for XM](https://doc.sitecore.com/en/developers/hd/190/sitecore-headless-development/sitecore-experience-edge-for-xm.html)
+- [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials)
+	- Introduction to Sitecore Content Hub
+	- Introduction to Sitecore OrderCloud
+	- Introduction to Sitecore CDP and Personalize

--- a/data/markdown/partials/learn/getting-started/platform-dxp-development-frameworks.md
+++ b/data/markdown/partials/learn/getting-started/platform-dxp-development-frameworks.md
@@ -5,3 +5,7 @@
 - [Getting Started with Sitecore Headless .NET Core SDK](https://doc.sitecore.com/en/developers/hd/190/sitecore-headless-development/walkthrough--using-the-getting-started-template.html)
 - [Getting Started with SXA](https://www.youtube.com/watch?v=nMTUitaBMek&list=PL1jJVFm_lGnwKmalgi6sukqDhoYA73JDn&index=1)
 - [Getting Started with Containers](https://doc.sitecore.com/en/developers/101/developer-tools/containers-in-sitecore-development.html)
+- [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials)
+	- Introduction to Sitecore Experience Accelerator
+	- Sitecore JSS Fundamentals
+

--- a/data/markdown/partials/learn/getting-started/platform-dxp.md
+++ b/data/markdown/partials/learn/getting-started/platform-dxp.md
@@ -2,3 +2,11 @@
 
 - [Getting Started with Sitecore Experience Manager/Platform (XM/XP)](https://doc.sitecore.com/en/developers/hd/190/sitecore-headless-development/walkthrough--using-the-getting-started-template.html)
 - [Getting Started with Sitecore Experience Commerce (XC)](https://doc.sitecore.com/en/developers/101/sitecore-experience-commerce/getting-started-with-development.html)
+- [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials): 
+	- Getting Started with Managed Cloud
+	- Introduction to Developing with Sitecore
+	- Sitecore 10 Development Features Overview
+	- Marketing Essentials (Experience Editor, Web Experience Management, Marketing Features)
+	- Introduction to Sitecore Experience Commerce 9
+	- Introduction to Sitecore Experience Commerce 10
+

--- a/data/markdown/partials/learn/getting-started/product-features.md
+++ b/data/markdown/partials/learn/getting-started/product-features.md
@@ -6,3 +6,9 @@
 - [Getting started with EXM for developers](https://doc.sitecore.com/en/developers/exm/101/email-experience-manager/getting-started-with-exm-for-developers.html)
 - [Getting started with custom condition and segmentation](https://doc.sitecore.com/en/developers/101/sitecore-experience-platform/create-a-custom-condition-and-segmentation-query.html)
 - [Getting started with federated experience manager](https://doc.sitecore.com/en/developers/101/sitecore-experience-platform/using-fxm.html)
+- [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials)
+	- Design and Edit in the Sitecore Experience Editor
+	- Prepare for Web Experience Management
+	- Utilize Sitecore Marketing Features
+
+

--- a/data/markdown/partials/solution/commerce/ordercloud.md
+++ b/data/markdown/partials/solution/commerce/ordercloud.md
@@ -16,6 +16,7 @@ With Sitecore OrderCloud®, design your own commerce solution with an API-first,
 ## Getting Started
 
 - [Getting Started with OrderCloud](https://ordercloud.io/learn/getting-started/welcome-to-ordercloud)
+- [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Sitecore OrderCloud
 
 ## Discover more
 

--- a/data/markdown/partials/solution/commerce/sitecore-commerce.md
+++ b/data/markdown/partials/solution/commerce/sitecore-commerce.md
@@ -22,9 +22,9 @@ Sitecore Experience Commerce (XC) empowers marketers and merchandisers to fully 
 
 - [Installation Guides](https://dev.sitecore.net/Downloads/Sitecore_Commerce/101/Sitecore_Experience_Commerce_101.aspx)
 - [Getting Started](https://doc.sitecore.com/en/developers/101/sitecore-experience-commerce/getting-started-with-development.html)
+- [Sitecore Essentials (FREE)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Sitecore Experience Commerce 9 and 10
 
 ## Learn more
-
 - [Sitecore Experience Commerce - learning.sitecore.com](https://learning.sitecore.com/pathway/sitecore-experience-commerce)
 - [YouTube: Sitecore Experience Commerce Deep Dive](https://www.youtube.com/watch?v=T0cn3yBbRro&list=PL1jJVFm_lGny-vqNPTv3VdBA_o31-Tq94)
 - [How to series on YouTube](https://www.youtube.com/watch?v=aWeC7SXNifw&list=PL1jJVFm_lGnwa9R0XqeGrhmNj1AHbAnE9)

--- a/data/markdown/partials/solution/content-management/jss.md
+++ b/data/markdown/partials/solution/content-management/jss.md
@@ -16,6 +16,7 @@ Sitecore JSS offers front-end developer of whole new way of working and interact
 ## Learn
 
 - [Getting Started](https://doc.sitecore.com/en/developers/hd/190/sitecore-headless-development/getting-started-with-jss-for-next-js-development.html)
+- [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Sitecore JSS Fundamentals
 - [Sitecore Headless Services for JSS Workshop](https://learning.sitecore.com/instructor-led-training/sitecore-jss-workshop)
 - [JSS with Blazer YouTube playlist](https://www.youtube.com/watch?v=EkJJmqQGkVI&list=PL1jJVFm_lGnzMlj7g-hJEFNEPDs5yhzf0)
 - [Integrating a Client Framework with JSS YouTube playlist](https://www.youtube.com/watch?v=vQxLQH0iYps&list=PL1jJVFm_lGnxDrexrlt0Wy_va_vQvQvjN)

--- a/data/markdown/partials/solution/content-management/sxa.md
+++ b/data/markdown/partials/solution/content-management/sxa.md
@@ -24,6 +24,7 @@ In order to get started with SXA you will need a clean installation of Sitecore 
 
 - [SXA Tutorial YouTube series](https://www.youtube.com/watch?v=nMTUitaBMek&list=PL1jJVFm_lGnwKmalgi6sukqDhoYA73JDn&index=1)
 - [Unofficial SXA tutorials](https://www.youtube.com/c/SXA-Tutorials)
+- [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Sitecore Experience Accelerator
 - [Official Sitecore course](https://learning.sitecore.com/course/sitecore-experience-accelerator-sxa-collection)
 
 ## Resources

--- a/data/markdown/partials/solution/content-management/web-cms.md
+++ b/data/markdown/partials/solution/content-management/web-cms.md
@@ -25,6 +25,12 @@ With Experience Manager, you can create, manage, and publish content to your web
 - [Sitecore Docker Examples](https://github.com/Sitecore/docker-examples)
 
 ### Official Sitecore Training
+- [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials)
+	- Introduction to Developing with Sitecore
+	- Sitecore 10 Development Features Overview
+	- Sitecore JSS Fundamentals
+	- Introduction to Sitecore Experience Accelerator
+	- Marketing Essentials
 - [Web Experience Management Collection](https://learning.sitecore.com/course/updated-web-experience-management-collection)
 - [Sitecore Experience Accelerator (SXA) Collection](https://learning.sitecore.com/course/sitecore-experience-accelerator-sxa-collection)
 - [Developer's Fundamentals 10 Collection](https://learning.sitecore.com/course/developers-fundamentals-10-collection)

--- a/data/markdown/partials/solution/customer-data-management/cdp.md
+++ b/data/markdown/partials/solution/customer-data-management/cdp.md
@@ -20,6 +20,7 @@ Sitecore CDP brings together real-time behavioral insights and all your customer
 
 ## Learn
 
+- [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Sitecore CDP and Personalize
 - [Boxever Training path](https://learning.sitecore.com/pathway/boxever-training)
 
 ## Integrations

--- a/data/markdown/partials/solution/dam-and-content-operations/content-hub.md
+++ b/data/markdown/partials/solution/dam-and-content-operations/content-hub.md
@@ -26,6 +26,7 @@ Sitecore Content Hub&trade; offers multiple modules. Here is a brief overview of
 - [Navigate Content Hub](https://docs.stylelabs.com/content/4.0.x/user-documentation/get-started/content-hub/log-in.html)
 - [The different modules](https://docs.stylelabs.com/content/4.0.x/user-documentation/get-started/content-hub/modules.html)
 - [Terminology](https://docs.stylelabs.com/content/4.0.x/user-documentation/get-started/content-hub/glossary.html)
+- [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Content Hub
 
 ## User Documentation
 

--- a/data/markdown/partials/solution/personalization-testing/personalize.md
+++ b/data/markdown/partials/solution/personalization-testing/personalize.md
@@ -20,4 +20,5 @@ Sitecore Personalize brings together real-time behavioral insights and all your 
 
 ## Learn
 
+- [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Sitecore CDP and Personalize
 - [Boxever Training path](https://learning.sitecore.com/pathway/boxever-training)


### PR DESCRIPTION
## Description
For the `/learn` page and a group of product pages, I have added links to the new Sitecore Essentials course that is free and now available on learning.sitecore.com. There is only one 'pathway' that covers a lot of products, so I've tried to provide sub-bullets or descriptions where necessary to list the relevant topic/module that makes sense for that page.

For example, on the `/learn` page the Sitecore Essentials course shows up in all 4 "Getting Started" boxes, but I only list the modules that are appropriate for that box. Similarly, on the SXA page, I only mention the Introduction to SXA module. This pattern repeats across the product pages that are required.

## Motivation
This fixes #180, and is meant as an interim solution to get the free courses listed. We may need a new issue to further refine the `/learn` page to highlight appropriate learning options.

## How Has This Been Tested?
All markdown changes were tested locally in-browser to validate the display of the new text. Also validated on Vercel preview site and validated that all links work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM