### PR TITLE
Adding SF Commerce connector to integrations list

### DIFF
--- a/data/markdown/partials/learn/integrations/content-hub.md
+++ b/data/markdown/partials/learn/integrations/content-hub.md
@@ -1,3 +1,4 @@
 ### Integrating with Sitecore Content Hub
 
 - [Integrating Sitecore Content Hub with Sitecore Send](/learn/integrations/send-ch)
+- [Integrating Sitecore Content Hub with Salesforce Commerce Cloud](https://docs.stylelabs.com/contenthub/4.1.x/content/integrations/salesforce-commerce-connector/salesforce-commerce-connector.html)

--- a/data/markdown/partials/solution/dam-and-content-operations/dam.md
+++ b/data/markdown/partials/solution/dam-and-content-operations/dam.md
@@ -31,3 +31,4 @@ The various connectors allow the integration of Sitecore Content Hub with differ
 ## Integrations
 
 - [Integrating Sitecore Content Hub with Sitecore Send](/learn/integrations/send-ch)
+- [Integrating Sitecore Content Hub with Salesforce Commerce Cloud](https://docs.stylelabs.com/contenthub/4.1.x/content/integrations/salesforce-commerce-connector/salesforce-commerce-connector.html)


### PR DESCRIPTION
## Description
There is a new Salesforce Commerce Cloud integration guide for the new Content Hub connector that is published in the documentation: https://docs.stylelabs.com/contenthub/4.1.x/content/integrations/salesforce-commerce-connector/salesforce-commerce-connector.html

This PR adds this to the list of 'integrations' for Content Hub on both the `/learn` page and the integrations list on the `/dam-and-content-operations/dam` page.

## Motivation
This raises awareness of the Content Hub integration capabilities. We should look at whether other connectors in that documentation should also be listed.

## How Has This Been Tested?
This is a markdown change only. Validated that the new items appear on local and Vercel, and validated that the links work going to the destination page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM