### PR TITLE
Added #cdp tag to the SSE configs for CDP/Personalize pages

### DIFF
--- a/data/markdown/pages/solution/customer-data-management/index.md
+++ b/data/markdown/pages/solution/customer-data-management/index.md
@@ -5,6 +5,7 @@ title: 'Customer Data Management'
 description: 'Maintain a persistent, unified view of your customers that is available to be leveraged in all your channels'
 stackexchange:
   [
+    '#cdp',
     '#xconnect',
     '#xdb',
     '#experience-analytics',

--- a/data/markdown/pages/solution/customer-data-management/product/cdp/index.md
+++ b/data/markdown/pages/solution/customer-data-management/product/cdp/index.md
@@ -5,5 +5,6 @@ page: 'cdp'
 title: 'Sitecore CDP'
 description: 'Ingest, connect, and activate customer data across your tech stack and composable DXP'
 partials: ['solution/customer-data-management/cdp']
+stackexchange: ['#cdp']
 youtube: PL1jJVFm_lGnx-VFtQBFiOscKJhddMpp2s
 ---

--- a/data/markdown/pages/solution/personalization-testing/index.md
+++ b/data/markdown/pages/solution/personalization-testing/index.md
@@ -3,5 +3,5 @@ solution: ['personalization-testing']
 product: ['personalization-testing']
 title: 'Personalization and Testing'
 description: 'Deliver personalized content and test which content is working.'
-stackexchange: ['#personalization', '#content-testing', '#fxm', '#universal-tracker']
+stackexchange: ['#personalization', '#cdp', '#content-testing', '#fxm', '#universal-tracker']
 ---

--- a/data/markdown/pages/solution/personalization-testing/product/personalize/index.md
+++ b/data/markdown/pages/solution/personalization-testing/product/personalize/index.md
@@ -5,6 +5,7 @@ page: 'cdp'
 title: 'Sitecore Personalize'
 description: 'Use advanced decisioning models and machine learning for personalization in your composable DXP.'
 partials: ['solution/personalization-testing/personalize']
+stackexchange: ['#cdp']
 youtube: PL1jJVFm_lGnx-VFtQBFiOscKJhddMpp2s
 youtubeTitle: 'Latest Sitecore Personalize videos'
 ---


### PR DESCRIPTION
This has been done for the CDP product page, Personalize product page, and the parent landing pages for Customer Data Management and Personalization/Testing.

NOTE: I put #cdp first for the customer data management page, and put it second on Personalize as that product will actually be called "Sitecore Personalize", and #personalization is a more relevant tag. Currently, there is an issue where only the first tag seems to be displayed on the page (logged as issue #210)

## Description
In the configuration markdwon files for the pages, the tag #cdp was added to the stackexchange metadata property where present. A new stackexchange metadata property was added to the pages where there was not already a list configured, and #cdp was put as the value for that property.

This causes the StackExchange feed to include questions tagged with #cdp on StackExchange to show on the page (except where issue #210 causes interference)

## Motivation
This configuration change will drive interest and awareness in the new CDP tag on Sitecore StackExchange.

## How Has This Been Tested?
This has been tested to work on a local environment, and also in the Vercel preview environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM