### PR TITLE
Virtual Developer Day promo

### DIFF
--- a/data/promos/newpromo.ts
+++ b/data/promos/newpromo.ts
@@ -1,15 +1,15 @@
 import type { PromoCardProps } from '@/components/cards/PromoCard';
 
 const data: PromoCardProps = {
-  title: 'Sitecore Developer Experience Survey 2021 !',
+  title: 'Call for speakers open for Sitecore’s Virtual Developer Day',
   description:
-    'We want to hear from you! Take the Developer Experience Survey if you’ve worked professionally with the Sitecore platform or contributed to a project in the past 12 months. Your answers will help shape our future! Just provide your name and email at the end of the survey to be part of the raffle.',
+    'The 5th VDD will be held in February 2022. For those that do not know, VDD is a complimentary 24-hour virtual event showcasing pre-recorded presentations designed to drive and foster engagement with existing and potential Sitecore developers around the world. Please keep in mind that the deadline to submit your topic is December 15th, 2021.',
   img: {
-    src: 'https://mss-p-006-delivery.sitecorecontenthub.cloud/api/public/content/be4a712f6d7149339b599ac33721bbeb?v=cbd8fad3',
+    src: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/da050901b5ee4a3788c024a26a97a6f7?v=dbe4f6f9',
   },
   link: {
-    href: 'https://www.research.net/r/SitecoreDeveloperExperience',
-    text: 'Take the survey now...',
+    href: 'https://bit.ly/3cRsyYq',
+    text: 'Apply here',
   },
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -18,7 +18,7 @@ const nextConfig = {
     GTM_ENVIRONMENT: process.env.GTM_ENVIRONMENT
   },
   images: {
-    domains: ['sitecorecdn.azureedge.net', 'i.ytimg.com', 'mss-p-006-delivery.sitecorecontenthub.cloud'],
+    domains: ['sitecorecdn.azureedge.net', 'i.ytimg.com', 'mss-p-006-delivery.sitecorecontenthub.cloud', 'mss-p-006-delivery.stylelabs.cloud'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920],
   },
 };


### PR DESCRIPTION
## Description
Replacing the DevEx survey promo with VDD
Added stylelabs CDN url to next.config.js since DAM provided a public link with the stylelabs url.

## Motivation
DevEx survey has been featured for two weeks and has been closed.

## How Has This Been Tested?
Local and [Vercel staging environment](https://developer-portal-614588r7w-sitecoretechnicalmarketing.vercel.app/)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM