### PR TITLE
Fixes #216 - Remove capital S from sitecore url path

### DIFF
--- a/data/markdown/partials/trials/jss-connected-demo/exploring-code/graphql.md
+++ b/data/markdown/partials/trials/jss-connected-demo/exploring-code/graphql.md
@@ -26,7 +26,7 @@ Click on _Canada > Alberta > Banff > Banff 3 on 3 Basketball Challenge_. You can
 Now that you know where the data lives, it's time to create a query.
 
 The Graph Browser
-In your browser, navigate to `<Sitecore hostname>/Sitecore/api/graph/items/master/ui` to bring up the Sitecore Experience Graph Browser.
+In your browser, navigate to `<Sitecore hostname>/sitecore/api/graph/items/master/ui` to bring up the Sitecore Experience Graph Browser.
 
 ![The Graph Browser](https://mss-p-006-delivery.sitecorecontenthub.cloud/api/public/content/21e76cb6f23f4e5ba81b0210f7940971?v=ca097335)
 


### PR DESCRIPTION
## Description
Closes #216 as reported by the demo team. 

## Motivation
Path with capital S results in error

## How Has This Been Tested?
Local testing and [Vercel preview environment](https://developer-portal-nlw91hi0y-sitecoretechnicalmarketing.vercel.app/trials/jss-connected-demo/exploring-code/graphql)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM