### PR TITLE
Updating promo from VDD to SSE news

### DIFF
--- a/data/promos/newpromo.ts
+++ b/data/promos/newpromo.ts
@@ -1,15 +1,15 @@
 import type { PromoCardProps } from '@/components/cards/PromoCard';
 
 const data: PromoCardProps = {
-  title: 'Call for speakers open for Sitecore’s Virtual Developer Day',
+  title: 'Sitecore Stack Exchange Beta stage is over!',
   description:
-    'The 5th VDD will be held in February 2022. For those that do not know, VDD is a complimentary 24-hour virtual event showcasing pre-recorded presentations designed to drive and foster engagement with existing and potential Sitecore developers around the world. Please keep in mind that the deadline to submit your topic is December 15th, 2021.',
+    'Today is an exciting day for the community as the Sitecore Stack Exchange site has graduated from the Stack Exchange Beta program and become a fully public member of the Stack Exchange family!',
   img: {
-    src: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/da050901b5ee4a3788c024a26a97a6f7?v=dbe4f6f9',
+    src: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/a3c5df7b1d06426ca0b7cac57e4804e7?v=dbd864c9',
   },
   link: {
-    href: 'https://bit.ly/3cRsyYq',
-    text: 'Apply here',
+    href: 'https://community.sitecore.com/community?id=community_blog&sys_id=fffb00b31b580110b8954371b24bcbfb',
+    text: 'Read more about the news!',
   },
 };
 

--- a/data/promos/newpromo.ts
+++ b/data/promos/newpromo.ts
@@ -8,7 +8,7 @@ const data: PromoCardProps = {
     src: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/a3c5df7b1d06426ca0b7cac57e4804e7?v=dbd864c9',
   },
   link: {
-    href: 'https://community.sitecore.com/community?id=community_blog&sys_id=fffb00b31b580110b8954371b24bcbfb',
+    href: 'https://community.sitecore.com/community?id=community_blog&sys_id=002249581ba40110722d4042b24bcb4c',
     text: 'Read more about the news!',
   },
 };


### PR DESCRIPTION
For pushing to production after the blog goes live on December 16th. This promotes the new blog on the community portal about the SSE announcement.

## Description
The promo card data has been updated from the Virtual Developer Day information to the SSE blog information. 

## Motivation
There is no open issue for this, this is related to marketing around an event. This supports highlighting developer content to developers.

## How Has This Been Tested?
Tested locally and on the [Vercel preview environment](https://developer-portal-g10tnbob2-sitecoretechnicalmarketing.vercel.app/)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM