### PR TITLE
Ensure dependabot has access to settings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: deploy website
-on: [push, pull_request]
+on: [push, pull_request, pull_request_target]
 jobs:
 
   build:
@@ -16,7 +16,12 @@ jobs:
 
   deploy:
     needs: build
-    if: github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]". Otherwise, check whether it's an internal push
+    if: |
+            github.repository_owner == 'Sitecore' && ((github.event.pull_request.head.repo.full_name == github.repository) || 
+            (github.event_name == 'push')) || 
+            (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
+            (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     permissions: 
       deployments: write
@@ -29,7 +34,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ fromJSON('["Production", "Preview"]')[github.ref != 'refs/heads/main'] }} 
 
-      - uses: actions/checkout@v2
+      - name: Checkout
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: actions/checkout@v2
+
+      - name: Checkout PR
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: amondnet/vercel-action@v20
         with:


### PR DESCRIPTION
## Description
Change in deploy workflow to run on pull_request_target event which is triggered by dependabot

## Motivation
PRs created by dependabot do not run in the context of the merge commit therefore has no access to the secrets stored in Github

## How Has This Been Tested?
Local testing using ACT, 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM