### PR TITLE
Removed VS Code color settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,23 +1,6 @@
 {
-    "workbench.colorCustomizations": {
-      "activityBar.activeBackground": "#ab307e",
-      "activityBar.activeBorder": "#25320e",
-      "activityBar.background": "#ab307e",
-      "activityBar.foreground": "#e7e7e7",
-      "activityBar.inactiveForeground": "#e7e7e799",
-      "activityBarBadge.background": "#25320e",
-      "activityBarBadge.foreground": "#e7e7e7",
-      "statusBar.background": "#832561",
-      "statusBar.foreground": "#e7e7e7",
-      "statusBarItem.hoverBackground": "#ab307e",
-      "titleBar.activeBackground": "#832561",
-      "titleBar.activeForeground": "#e7e7e7",
-      "titleBar.inactiveBackground": "#83256199",
-      "titleBar.inactiveForeground": "#e7e7e799"
-    },
     "editor.tabSize": 2,
     "[typescript]": {
       "editor.formatOnSave": true
     },
-    "peacock.color": "#832561"
 }


### PR DESCRIPTION
## Description
Removing color setting for VS Code

## Motivation
Unnecessary setting

## How Has This Been Tested?
Local VS Code environment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM