### PR TITLE
Configured community questions for solution pages

### DIFF
--- a/data/markdown/pages/solution/commerce/index.md
+++ b/data/markdown/pages/solution/commerce/index.md
@@ -12,4 +12,7 @@ stackexchange:
     '#commerce-connect',
   ]
 twitter: ['#OrderCloud', '#SitecoreCommerce']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['searchAndMerchandizing', 'storefrontsAndMarketplaces']
+
 ---

--- a/data/markdown/pages/solution/commerce/product/discover/index.md
+++ b/data/markdown/pages/solution/commerce/product/discover/index.md
@@ -4,4 +4,6 @@ product: ['discover']
 title: 'Sitecore Discover'
 description: "From search to sale, Discover helps you create relevant experiences that drive conversions."
 partials: ['solution/commerce/discover']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['searchAndMerchandizing']
 ---

--- a/data/markdown/pages/solution/commerce/product/experience-commerce/index.md
+++ b/data/markdown/pages/solution/commerce/product/experience-commerce/index.md
@@ -13,4 +13,7 @@ stackexchange:
   ]
 youtube: 'PL1jJVFm_lGnwa9R0XqeGrhmNj1AHbAnE9'
 partials: ['solution/commerce/sitecore-commerce']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['searchAndMerchandizing', 'storefrontsAndMarketplaces', 'orderManagement']
+
 ---

--- a/data/markdown/pages/solution/commerce/product/ordercloud/index.md
+++ b/data/markdown/pages/solution/commerce/product/ordercloud/index.md
@@ -5,4 +5,6 @@ title: 'Sitecore OrderCloud®'
 description: 'Cloud-native, headless, and API-first commerce solution'
 youtube: 'PL1jJVFm_lGnxDN-HHtT_WQRpI3zvMdYU-'
 partials: ['solution/commerce/ordercloud']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['searchAndMerchandizing', 'storefrontsAndMarketplaces', 'orderManagement']
 ---

--- a/data/markdown/pages/solution/content-management/index.md
+++ b/data/markdown/pages/solution/content-management/index.md
@@ -27,4 +27,6 @@ stackexchange:
     '#headless',
   ]
 twitter: ['#SitecoreJSS', '#SitecoreForms']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['contentManagement']
 ---

--- a/data/markdown/pages/solution/content-management/product/experience-manager/index.md
+++ b/data/markdown/pages/solution/content-management/product/experience-manager/index.md
@@ -30,4 +30,6 @@ partials:
   [
     'solution/content-management/web-cms',
   ]
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['contentManagement']
 ---

--- a/data/markdown/pages/solution/customer-data-management/index.md
+++ b/data/markdown/pages/solution/customer-data-management/index.md
@@ -18,4 +18,6 @@ stackexchange:
     '#tracking'
   ]
 twitter: ['#sitecorexp', '#sitecorecdp', '#boxever']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['customerDataManagement', 'experiencePlatform']
 ---

--- a/data/markdown/pages/solution/customer-data-management/product/cdp/index.md
+++ b/data/markdown/pages/solution/customer-data-management/product/cdp/index.md
@@ -7,4 +7,6 @@ description: 'Ingest, connect, and activate customer data across your tech stack
 partials: ['solution/customer-data-management/cdp']
 stackexchange: ['#cdp']
 youtube: PL1jJVFm_lGnx-VFtQBFiOscKJhddMpp2s
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['customerDataManagement']
 ---

--- a/data/markdown/pages/solution/customer-data-management/product/experience-platform/index.md
+++ b/data/markdown/pages/solution/customer-data-management/product/experience-platform/index.md
@@ -13,4 +13,6 @@ partials:
     'solution/personalization-testing/universal-tracker',
     'solution/customer-data-management/reference-data-service',
   ]
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['experiencePlatform']
 ---

--- a/data/markdown/pages/solution/dam-and-content-operations/index.md
+++ b/data/markdown/pages/solution/dam-and-content-operations/index.md
@@ -4,4 +4,6 @@ product: ['dam-and-content-operations']
 title: 'Digital Asset Management and Content Operations'
 description: 'Scale management, workflow, and delivery of content, media, and static assets '
 stackexchange: ['#dam', '#content-hub', '#content-hub-scripting']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['contentOperations','digitalAssetManagement']
 ---

--- a/data/markdown/pages/solution/dam-and-content-operations/product/content-hub/index.md
+++ b/data/markdown/pages/solution/dam-and-content-operations/product/content-hub/index.md
@@ -7,4 +7,6 @@ stackexchange: ['#dam', '#content-hub', '#content-hub-scripting']
 partials: ['solution/dam-and-content-operations/content-hub']
 youtube: PL1jJVFm_lGnydV6XCOptUYPmyLBg-0NLA
 youtubeTitle: Learn more about Sitecore Content Hub
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['contentOperations']
 ---

--- a/data/markdown/pages/solution/dam-and-content-operations/product/dam/index.md
+++ b/data/markdown/pages/solution/dam-and-content-operations/product/dam/index.md
@@ -8,4 +8,6 @@ partials: ['solution/dam-and-content-operations/dam']
 hasInPageNav: true
 youtube: PL1jJVFm_lGnydV6XCOptUYPmyLBg-0NLA
 youtubeTitle: Learn more on DAM & Sitecore Content Hub
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['digitalAssetManagement']
 ---

--- a/data/markdown/pages/solution/marketing-automation/index.md
+++ b/data/markdown/pages/solution/marketing-automation/index.md
@@ -5,4 +5,6 @@ title: 'Marketing Automation'
 description: 'Connect with customers using marketing automation'
 stackexchange: ['#marketing-automation', '#exm']
 twitter: ['@Moosend', '#Moosend']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['marketingAutomation']
 ---

--- a/data/markdown/pages/solution/marketing-automation/product/experience-platform/index.md
+++ b/data/markdown/pages/solution/marketing-automation/product/experience-platform/index.md
@@ -6,4 +6,6 @@ description: 'Connecting with customers using Sitecore Experience Platform marke
 stackexchange: ['#marketing-automation', '#exm']
 youtube: 'PL1jJVFm_lGnyicywCcwcWa8RtsoiJEbC9'
 partials: ['solution/marketing-automation/sitecore-xp-marketing-automation']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['experiencePlatform']
 ---

--- a/data/markdown/pages/solution/marketing-automation/product/send/index.md
+++ b/data/markdown/pages/solution/marketing-automation/product/send/index.md
@@ -7,4 +7,6 @@ twitter: ['@Moosend', '#Moosend']
 youtube: 'PLAKrWBcgVt6M4Ia_bECQVOyxUe1eDFpG6'
 youtubeTitle: 'Latest Marketing Automation videos'
 partials: ['solution/marketing-automation/send']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['marketingAutomation']
 ---

--- a/data/markdown/pages/solution/personalization-testing/index.md
+++ b/data/markdown/pages/solution/personalization-testing/index.md
@@ -4,4 +4,7 @@ product: ['personalization-testing']
 title: 'Personalization and Testing'
 description: 'Deliver personalized content and test which content is working.'
 stackexchange: ['#personalization', '#cdp', '#content-testing', '#fxm', '#universal-tracker']
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['personalizationAndTesting', 'customerDataManagement', 'experiencePlatform']
+
 ---

--- a/data/markdown/pages/solution/personalization-testing/product/experience-platform/index.md
+++ b/data/markdown/pages/solution/personalization-testing/product/experience-platform/index.md
@@ -11,4 +11,6 @@ partials:
     'solution/personalization-testing/federated-experience-manager',
     'solution/personalization-testing/universal-tracker',
   ]
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['experiencePlatform']
 ---

--- a/data/markdown/pages/solution/personalization-testing/product/personalize/index.md
+++ b/data/markdown/pages/solution/personalization-testing/product/personalize/index.md
@@ -8,4 +8,6 @@ partials: ['solution/personalization-testing/personalize']
 stackexchange: ['#cdp']
 youtube: PL1jJVFm_lGnx-VFtQBFiOscKJhddMpp2s
 youtubeTitle: 'Latest Sitecore Personalize videos'
+sitecoreCommunityQuestions: true
+sitecoreCommunityQuestionsCategory: ['customerDataManagement']
 ---

--- a/data/markdown/pages/solution/personalization-testing/product/personalize/index.md
+++ b/data/markdown/pages/solution/personalization-testing/product/personalize/index.md
@@ -9,5 +9,5 @@ stackexchange: ['#cdp']
 youtube: PL1jJVFm_lGnx-VFtQBFiOscKJhddMpp2s
 youtubeTitle: 'Latest Sitecore Personalize videos'
 sitecoreCommunityQuestions: true
-sitecoreCommunityQuestionsCategory: ['customerDataManagement']
+sitecoreCommunityQuestionsCategory: ['personalizationAndTesting']
 ---


### PR DESCRIPTION
## Description
Configured the solution pages to show the latest questions (if available) from their respective sub forums on Sitecore Community 

## Motivation
Community integration was only used on homepage and community page. Solution pages where still a todo.

## How Has This Been Tested?
Local testing and Vercel preview environment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM