### PR TITLE
Fixed errors in static and dynamic call to questions API.

### DIFF
--- a/components/integrations/sitecore-community/questions/SitecoreCommunityQuestions.tsx
+++ b/components/integrations/sitecore-community/questions/SitecoreCommunityQuestions.tsx
@@ -2,7 +2,7 @@
 import type { SitecoreCommunityContent } from '@/interfaces/integrations';
 // Global
 import axios from 'axios';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { classnames } from 'tailwindcss-classnames';
 // Components
 import TextLink from '@/components/helper/TextLink';
@@ -31,9 +31,8 @@ const SitecoreCommunityQuestions = ({
   const [sort, setSort] = useState<string | undefined>(undefined);
   const [forum, setForum] = useState<string | undefined>(undefined);
 
-  const fetchNewResults = (type: 'sort' | 'forum', val: string) => {
+  useEffect(() => {
     setIsLoading(true);
-    type === 'sort' ? setSort(val) : setForum(val);
     const query = ['contentType=questions'];
     if (sort) {
       query.push(`sort=${sort}`);
@@ -48,9 +47,11 @@ const SitecoreCommunityQuestions = ({
         setIsLoading(false);
       })
       .catch((err) => console.log(err));
-  };
+  }, [sort, forum]);
 
   const items = fetchedResults || content;
+
+  const hasForumKeys = forumKeys && Array.isArray(forumKeys) && forumKeys.length > 1;
 
   return (
     <>
@@ -67,11 +68,13 @@ const SitecoreCommunityQuestions = ({
       <div className={classnames('flex', 'justify-end', 'mb-6')}>
         {sortKeys && Array.isArray(sortKeys) && sortKeys.length > 1 && (
           <label
-            className={classnames('text-xs', 'mr-10', 'font-semibold', 'flex', 'items-center')}
+            className={classnames('text-xs', 'font-semibold', 'flex', 'items-center', {
+              'mr-10': hasForumKeys,
+            })}
           >
             Order by:
             <select
-              onChange={(changeEvent) => fetchNewResults('sort', changeEvent.target.value)}
+              onChange={(changeEvent) => setSort(changeEvent.target.value)}
               className={classnames(
                 'bg-theme-bg',
                 'border-2',
@@ -91,7 +94,7 @@ const SitecoreCommunityQuestions = ({
           <label className={classnames('text-xs', 'font-semibold', 'flex', 'items-center')}>
             Filter by:
             <select
-              onChange={(changeEvent) => fetchNewResults('forum', changeEvent.target.value)}
+              onChange={(changeEvent) => setForum(changeEvent.target.value)}
               className={classnames(
                 'bg-theme-bg',
                 'border-2',

--- a/scripts/page-info.ts
+++ b/scripts/page-info.ts
@@ -112,10 +112,10 @@ export const getPageInfo = async (
       typeof meta.sitecoreCommunityQuestions === 'number'
         ? meta.sitecoreCommunityQuestions
         : SITECORE_COMMUNITY_MAX_COUNT;
-    const sort = !!meta.sitecoreCommunityBlogSort
-      ? Array.isArray(meta.sitecoreCommunityBlogSort)
-        ? meta.sitecoreCommunityBlogSort[0]
-        : meta.sitecoreCommunityBlogSort
+    const sort = !!meta.sitecoreCommunityQuestionsSort
+      ? Array.isArray(meta.sitecoreCommunityQuestionsSort)
+        ? meta.sitecoreCommunityQuestionsSort[0]
+        : meta.sitecoreCommunityQuestionsSort
       : 'publish';
     const forum = !!meta.sitecoreCommunityQuestionsCategory
       ? Array.isArray(meta.sitecoreCommunityQuestionsCategory)


### PR DESCRIPTION
Fixes to query calls

## Description
- Fix copy-pasta error in static call to use correct key for sort
- Moved Axios call into useEffect to fire after set state action is complete
- Minor styling fix for when sort is present but not filter

## Motivation
https://github.com/Sitecore/developer-portal/issues/231

## How Has This Been Tested?
- Tested static locally by confirming the URL matches appropriate sort variable
- Tested dynamic locally using network tab and confirming correct query

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM