### PR TITLE
Fixed issue with missing integration link, added 301 from previous URL

### DIFF
--- a/data/markdown/partials/learn/integrations/xm.md
+++ b/data/markdown/partials/learn/integrations/xm.md
@@ -1,4 +1,4 @@
 ### Integrating with Sitecore XM
 
-- [Integrating Sitecore XM with Sitecore CDP](/learn/integrations/xm-cdp)
+- [Integrating Sitecore XM with Sitecore SmartHub CDP](/learn/integrations/xm-smarthub-cdp)
 - [Integrating Sitecore XM with Sitecore Send](/learn/integrations/send-xm)

--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,13 @@ const securityHeaders = [
     value: "1; mode=block"
   }
 ];
+const redirects = [
+  {
+    source: '/learn/integrations/xm-cdp',
+    destination: '/learn/integrations/xm-smarthub-cdp',
+    permanent: true
+  }
+]
 
 const nextConfig = {
   // Set locales so we have appropriate lang attributes without a custom _document
@@ -54,6 +61,9 @@ const nextConfig = {
         headers: securityHeaders
       }
     ]
+  },
+  async redirects() {
+    return redirects
   }
 };
 


### PR DESCRIPTION
- Added XM <-> CDP SmartHub link missed in previous commit. @dylanyoung-dev this should cover the missing items.
- Added 301 redirect from previous URL @markvanaalst, I think this is the first time we've had to change a URL and introduce a 301. Are you happy with the implementation in here?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM