### PR TITLE
Adding created as default sort option

### DIFF
--- a/components/integrations/sitecore-community/SitecoreCommunity.api.ts
+++ b/components/integrations/sitecore-community/SitecoreCommunity.api.ts
@@ -43,7 +43,7 @@ export type ForumOption =
   | 'personalizationAndTesting'
   | 'searchAndMerchandizing'
   | 'storefrontsAndMarketplaces';
-export type SortOption = 'publish' | 'view';
+export type SortOption = 'publish' | 'view' | 'created';
 
 type SitecoreCommunityOptions = {
   contentType?: ContentType;
@@ -144,7 +144,7 @@ const get = async ({
   contentType = undefined,
   forum = undefined,
   maxResults = 3,
-  sort = 'publish' as SortOption,
+  sort = 'created' as SortOption,
 }: SitecoreCommunityOptions): Promise<SitecoreCommunityEvent[] | SitecoreCommunityContent[]> => {
   // Prevent showing more than 5, its just too many
   const count = maxResults > 5 ? 5 : maxResults;

--- a/components/integrations/sitecore-community/blog/SitecoreCommunityBlog.tsx
+++ b/components/integrations/sitecore-community/blog/SitecoreCommunityBlog.tsx
@@ -61,8 +61,9 @@ const SitecoreCommunityBlog = ({ content, sortKeys }: SitecoreCommunityBlogProps
                 'text-theme-text'
               )}
             >
-              <option value="publish">Recent Questions</option>
+              <option value="created">Recent Questions</option>
               <option value="view">Most Popular</option>
+              <option value="created">Created</option>
             </select>
           </label>
         )}

--- a/components/integrations/sitecore-community/questions/SitecoreCommunityQuestions.tsx
+++ b/components/integrations/sitecore-community/questions/SitecoreCommunityQuestions.tsx
@@ -86,6 +86,7 @@ const SitecoreCommunityQuestions = ({
             >
               <option value="publish">Recent Questions</option>
               <option value="view">Most Popular</option>
+              <option value="created">Created</option>
             </select>
           </label>
         )}

--- a/scripts/page-info.ts
+++ b/scripts/page-info.ts
@@ -101,7 +101,7 @@ export const getPageInfo = async (
       ? Array.isArray(meta.sitecoreCommunityBlogSort)
         ? meta.sitecoreCommunityBlogSort[0]
         : meta.sitecoreCommunityBlogSort
-      : 'publish';
+      : 'created';
     const sCBlog = await SitecoreCommunityApi.get({
       forum: 'blog',
       contentType: 'blog',


### PR DESCRIPTION
## Description
Fixes #247 - Adding created as the default sort option for announcements and blogposts.

## Motivation
Latest blogpost component on the homepage listed updated (but old) posts.

## How Has This Been Tested?
Local and [Vercel environment](https://developer-portal-qxurk1zd8-sitecoretechnicalmarketing.vercel.app/)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM