### PR TITLE
Allow SVG in Nextjs image component

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -51,6 +51,7 @@ const nextConfig = {
     GTM_ENVIRONMENT: process.env.GTM_ENVIRONMENT
   },
   images: {
+    dangerouslyAllowSVG: true,
     domains: ['sitecorecdn.azureedge.net', 'i.ytimg.com', 'mss-p-006-delivery.sitecorecontenthub.cloud', 'mss-p-006-delivery.stylelabs.cloud'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920],
   },
@@ -64,7 +65,7 @@ const nextConfig = {
   },
   async redirects() {
     return redirects
-  }
+  },
 };
 
 module.exports = withTM(nextConfig);


### PR DESCRIPTION
## Description
Adding config setting to allow SVG images used in the Nextjs image component

## Motivation
SVG images are not working currently

## How Has This Been Tested?
Local and [Vercel environment](https://developer-portal-3op4w701w-sitecoretechnicalmarketing.vercel.app/)

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM