### PR TITLE
Added new Content Hub playlist to CH pages

### DIFF
--- a/data/markdown/pages/solution/dam-and-content-operations/product/content-hub/index.md
+++ b/data/markdown/pages/solution/dam-and-content-operations/product/content-hub/index.md
@@ -5,7 +5,7 @@ title: 'Sitecore Content Hub'
 description: 'Content Hub content management and content operations'
 stackexchange: ['#dam', '#content-hub', '#content-hub-scripting']
 partials: ['solution/dam-and-content-operations/content-hub']
-youtube: PL1jJVFm_lGnydV6XCOptUYPmyLBg-0NLA
+youtube: PL1jJVFm_lGnwi3LhIuz-Zbeekh9kehTSZ
 youtubeTitle: Learn more about Sitecore Content Hub
 sitecoreCommunityQuestions: true
 sitecoreCommunityQuestionsCategory: ['contentOperations']

--- a/data/markdown/pages/solution/dam-and-content-operations/product/dam/index.md
+++ b/data/markdown/pages/solution/dam-and-content-operations/product/dam/index.md
@@ -6,7 +6,7 @@ description: 'Scale management and delivery of media and static assets'
 stackexchange: ['#dam']
 partials: ['solution/dam-and-content-operations/dam']
 hasInPageNav: true
-youtube: PL1jJVFm_lGnydV6XCOptUYPmyLBg-0NLA
+youtube: PL1jJVFm_lGnwi3LhIuz-Zbeekh9kehTSZ
 youtubeTitle: Learn more on DAM & Sitecore Content Hub
 sitecoreCommunityQuestions: true
 sitecoreCommunityQuestionsCategory: ['digitalAssetManagement']


### PR DESCRIPTION
## Description
The playlist ID value for the `youtube` metadata was updated to point to the newly created Content Hub playlist on Discover Sitecore.

## Motivation
Fixes issue #260 to update the playlist used for the Content Hub pages. All videos related to Content Hub are on this new playlist.

## How Has This Been Tested?
Tested locally and on Vercel preview environment to ensure that the new playlist displays on both the Content Operations and DAM pages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM