### PR TITLE
Updated home page promo to direct users to YouTube video

### DIFF
--- a/data/promos/newpromo.ts
+++ b/data/promos/newpromo.ts
@@ -3,13 +3,13 @@ import type { PromoCardProps } from '@/components/cards/PromoCard';
 const data: PromoCardProps = {
   title: 'Virtual Developer Day',
   description:
-    "This April 13th 2022 sharpen your Sitecore dev skills by registering for 24 hours of developer-led sessions and camaraderie with Sitecore’s global developer community and MVPs. Don't miss out on technical tips, tips based on the latest technology, and much more! Register today for free!",
+    "Did you miss the Virtual Developer Day? You can watch it now on YouTube! Sharpen your Sitecore dev skills with over 8 hours of developer-led sessions from Sitecore’s global developer community and MVPs. Don't miss out on technical tips, tips based on the latest technology, and much more!",
   img: {
-    src: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/2e10a5a7d825482f9e23c096c79f7635?v=dd90b9b6',
+    src: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/c612f3d1efbe4e0cb946ab96d0b4aea1?v=0cca3868',
   },
   link: {
-    href: 'https://www.sitecore.com/company/news-events/events/2022/03/virtual-developer-day',
-    text: 'Join for free!',
+    href: 'https://www.youtube.com/watch?v=fkXZEYxKnGY',
+    text: 'Watch now!',
   },
 };
 


### PR DESCRIPTION
## Description
For the newpromo.ts file, I updated the description, image, and link to refer to VDD being in the past and redirect to the YouTube video.

## Motivation
Fixes #262. Now that Virtual Developer Day is open, driving users to registration doesn't make much sense.

## How Has This Been Tested?
Tested this locally for the home page, and also on the Vercel preview environment. Checked that the correct image and text displayed and that the link goes to the correct video.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM