### PR TITLE
Typo in the SmartHub CDP description

### DIFF
--- a/data/markdown/partials/integrations/blueprint-xm-smarthub-cdp.md
+++ b/data/markdown/partials/integrations/blueprint-xm-smarthub-cdp.md
@@ -9,7 +9,7 @@ The purpose of this document is to analyze the integration blueprint for joining
 
 This will detail how to provide the customers with a standard way to integrate their Sitecore XM instance with Sitecore SmartHub CDP, allowing them to quickly integrate these products in a future proof way and getting them to start on the process of migrating to the Composable DXP.
 
-The integration will allow you to push interaction data from a website built using Sitecore XM into Sitecore SmartHub CDP. After this process, you can use Sitecore SmartHub CDP to then build personalized & optimized experiences to be delivered on your web channel. Note that Sitecore SmartHub CDP is a combination of two products, Sitecore Personalize and Sitecore SmartHub CDP. This document will cover how to integrate Sitecore XM with both of those products.
+The integration will allow you to push interaction data from a website built using Sitecore XM into Sitecore SmartHub CDP. After this process, you can use Sitecore SmartHub CDP to then build personalized & optimized experiences to be delivered on your web channel. Note that Sitecore SmartHub CDP is a combination of two products, Sitecore Personalize and Sitecore CDP. This document will cover how to integrate Sitecore XM with both of those products.
 
 You can see the products involved in said integration highlighted below:
 


### PR DESCRIPTION
SmartHub CDP is a combination of Sitecore Personalize and Sitecore CDP.

## Description
Fix a typo in the description of SmartHub CDP.

## Motivation
Remove the SmartHub in one line, as it is not clear what SmartHub CDP is.

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM