### PR TITLE
Adding CDP data retention policy to CDP product page

### DIFF
--- a/data/markdown/partials/solution/customer-data-management/cdp.md
+++ b/data/markdown/partials/solution/customer-data-management/cdp.md
@@ -12,6 +12,7 @@ Sitecore CDP brings together real-time behavioral insights and all your customer
 - [Developer Docs - Data Model 2.1](https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-1/index-en.html)
 - [Developer Docs - Data Model 2.0](https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-0/index-en.html)
 - [Introduction to Sitecore CDP - Managing Users](https://doc.sitecore.com/cdp/en/users/sitecore-customer-data-platform/introduction-to-sitecore-cdp.html)
+- [Sitecore CDP Data retention policy](https://doc.sitecore.com/cdp/en/users/sitecore-cdp/introduction-to-sitecore-cdp-data-retention-policy.html)
 - [Knowledge Hub](https://sitecore.cdpknowledgehub.com/docs)
 
 ## Discover


### PR DESCRIPTION
## Description
I added a link to the CDP product page that goes to the documentation on the data retention policy. 

## Motivation
This request keeps coming up with team members at Sitecore, so it's wise to get it out and more visible so it is easier for all to find it.

## How Has This Been Tested?
No tests done, this was a text only change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM