### PR TITLE
Use metadata for dedicated OG image

### DIFF
--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -98,7 +98,9 @@ const Layout = ({ pageInfo, children }: LayoutProps): JSX.Element => {
         <meta
           property="og:image"
           content={`${publicUrl}${
-            pageInfo.heroImage ? pageInfo.heroImage : '/images/social/social-card-default.jpeg'
+            pageInfo.openGraphImage
+              ? pageInfo.openGraphImage
+              : '/images/social/social-card-default.jpeg'
           }`}
         />
         <meta name="twitter:card" content="summary_large_image" />

--- a/data/markdown/pages/learn/getting-started/xm-cloud-introduction/index.md
+++ b/data/markdown/pages/learn/getting-started/xm-cloud-introduction/index.md
@@ -1,7 +1,8 @@
 ---
 title: 'XM Cloud Introduction'
 description: 'XM Cloud is around the corner. But what is XM Cloud? What does it include? And how can you prepare for it?'
-heroImage: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/1915549492604a64864578fe51d2a597?v=244f9e64'
+promoAfter: ['learning-essentials']
+openGraphImage: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/1915549492604a64864578fe51d2a597?v=244f9e64'
 ---
 
 ## What is XM Cloud?

--- a/interfaces/page-info.ts
+++ b/interfaces/page-info.ts
@@ -14,6 +14,7 @@ type PageInfoCore = {
   description?: string;
   hasInPageNav?: boolean;
   heroImage?: string;
+  openGraphImage?: string;
   id?: string;
   partials?: string[];
   title: string;


### PR DESCRIPTION
## Description & motivation
Including an separate metadata field to define OG image. Fallback to default social media share image

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-187b326bi-sitecoretechnicalmarketing.vercel.app/learn/getting-started/xm-cloud-introduction) 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change is a documentation change and it requires an update to the navigation.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM