### PR TITLE
Updated Content Hub docs links to 4.2

### DIFF
--- a/data/markdown/partials/docs/cms/sitecore-content-hub.md
+++ b/data/markdown/partials/docs/cms/sitecore-content-hub.md
@@ -1,9 +1,9 @@
 ### Sitecore Content Hub
 
-- [Cloud Development](https://docs.stylelabs.com/contenthub/4.1.x/content/integrations/index.html)
-- [API Reference](https://docs.stylelabs.com/contenthub/4.1.x/content/api-reference/index.html)
-- [Digital Asset Management (DAM)](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/content-user-manual/dam.html)
-- [Product Content Management (PCM)](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/pcm/pcm.html)
-- [Content Marketing Platform (CMP)](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/cmp/cmp.html)
-- [Marketing Resource Management (MRM)](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/marketing-resource-management/introduction.html)
-- [Web-to-print](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/web-to-print/chili-publisher.html)
+- [Cloud Development](https://docs.stylelabs.com/contenthub/4.2.x/content/integrations/index.html)
+- [API Reference](https://docs.stylelabs.com/contenthub/4.2.x/content/api-reference/index.html)
+- [Digital Asset Management (DAM)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/manage-digital-assets/manage-digital-assets.html)
+- [Product Content Management (PCM)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/pcm/pcm.html)
+- [Content Marketing Platform (CMP)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/manage-content/manage-content.html)
+- [Marketing Resource Management (MRM)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/marketing-resource-management/introduction.html)
+- [Content Publisher (a.k.a Web-to-print)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/sitecore-content-publisher/sitecore-content-publisher.html)

--- a/data/markdown/partials/solution/dam-and-content-operations/content-hub.md
+++ b/data/markdown/partials/solution/dam-and-content-operations/content-hub.md
@@ -30,11 +30,11 @@ Sitecore Content Hub&trade; offers multiple modules. Here is a brief overview of
 
 ## User Documentation
 
-- [Digital Asset Management (DAM)](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/content-user-manual/dam.html)
-- [Product Content Management (PCM)](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/pcm/pcm.html)
-- [Content Marketing Platform (CMP)](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/cmp/cmp.html)
-- [Marketing Resource Management (MRM)](https://docs.stylelabs.com/contenthub/4.1.x/content/user-documentation/marketing-resource-management/introduction.html)
-- [Web-to-print](https://docs.stylelabs.com/content/4.0.x/user-documentation/web-to-print/chili-publisher.html)
+- [Digital Asset Management (DAM)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/manage-digital-assets/manage-digital-assets.html)
+- [Product Content Management (PCM)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/pcm/pcm.html)
+- [Content Marketing Platform (CMP)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/manage-content/manage-content.html)
+- [Marketing Resource Management (MRM)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/marketing-resource-management/introduction.html)
+- [Content Publisher (a.k.a Web-to-print)](https://docs.stylelabs.com/contenthub/4.2.x/content/user-documentation/sitecore-content-publisher/sitecore-content-publisher.html)
 
 ## Developer Documentation
 


### PR DESCRIPTION
## Description / Motivation
Several links were reported as broken, and others that work go to the earlier version (4.1). These changes update all links to working 4.2 versions of the docs.

Not all doc links were updated across all pages. I fixed the reported ones on the Docs page, and then the matching ones on the Content Hub page. There may be others that also need to be fixed, or are out of date.

## How Has This Been Tested?
Content changes only. No local testing done. Tested on Vercel environment:
* [Docs page](https://developer-portal-a52f1mv73-sitecoretechnicalmarketing.vercel.app/docs)
* [CH page](https://developer-portal-a52f1mv73-sitecoretechnicalmarketing.vercel.app/dam-and-content-operations/content-hub#heading-user-documentation)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM