### PR TITLE
Fix edit link

### DIFF
--- a/src/common/page-info.ts
+++ b/src/common/page-info.ts
@@ -63,8 +63,10 @@ const getFileData = (directory: string, file: string): Matter => {
   const fileMarkdown = fs.readFileSync(filePath, 'utf-8');
   // @TODO: Handle failures
   const results = matter(fileMarkdown);
-  results.data['fileName'] = filePath;
 
+  // Quick fix for wrong edit urls
+  const fileName = `${repoUrl}/data/${filePath.split('\\data')[1].replace('\\', '/')}`;
+  results.data['fileName'] = fileName;
   return results;
 };
 
@@ -75,7 +77,7 @@ export const getPageInfo = async (
   const fileData = getFileData(pagesDirectory, `${file}`);
   const meta = fileData.data as MarkdownMeta;
   const content = await ParseContent(fileData.content);
-  const fileName = meta.fileName;
+  const fileName = `${repoUrl}/data/markdown/pages/${file}/index.md`;
   const pageInfo = {
     // Default hasInPageNav to true, overwrite with false in md
     hasInPageNav: true,
@@ -184,6 +186,7 @@ export const getPartialsAsArray = async (partials: string[]): Promise<PartialDat
   await Promise.all(
     partials.map(async function (partial) {
       const data = getFileData(partialsDirectory, partial) as Matter;
+
       const fileName = `${repoUrl}/data/markdown/partials/${partial}.md`;
       const parsedContent = await ParseContent(data.content);
 

--- a/src/common/page-info.ts
+++ b/src/common/page-info.ts
@@ -63,13 +63,10 @@ const getFileData = (directory: string, file: string): Matter => {
   const fileMarkdown = fs.readFileSync(filePath, 'utf-8');
   // @TODO: Handle failures
   const results = matter(fileMarkdown);
-  results.data['fileName'] = filePath;
 
-  // Quick fix for wrong edit urls
-  if (filePath.split('\\data') && filePath.split('\\data').length > 0) {
-    const fileName = `${repoUrl}/data/${filePath.split('\\data')[1].replace('\\', '/')}`;
-    results.data['fileName'] = fileName;
-  }
+  const relativePath = path.relative(process.cwd(), filePath).replace(/\\/g, '/');
+  const fileName = `${repoUrl}/${relativePath}`;
+  results.data['fileName'] = fileName;
 
   return results;
 };

--- a/src/common/page-info.ts
+++ b/src/common/page-info.ts
@@ -63,10 +63,14 @@ const getFileData = (directory: string, file: string): Matter => {
   const fileMarkdown = fs.readFileSync(filePath, 'utf-8');
   // @TODO: Handle failures
   const results = matter(fileMarkdown);
+  results.data['fileName'] = filePath;
 
   // Quick fix for wrong edit urls
-  const fileName = `${repoUrl}/data/${filePath.split('\\data')[1].replace('\\', '/')}`;
-  results.data['fileName'] = fileName;
+  if (filePath.split('\\data') && filePath.split('\\data').length > 0) {
+    const fileName = `${repoUrl}/data/${filePath.split('\\data')[1].replace('\\', '/')}`;
+    results.data['fileName'] = fileName;
+  }
+
   return results;
 };
 


### PR DESCRIPTION
## Description / Motivation
Fix the GitHub edit link for pages where no partials are being used (learning articles)

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-47winyoct-sitecoretechnicalmarketing.vercel.app/learn/getting-started/introduction-to-composable-dxp)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
