### PR TITLE
309 create product page for xm cloud

### DIFF
--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -278,6 +278,14 @@ const NavigationData: NavigationData[] = [
             url: '/content-management/xm-cloud',
           },
           {
+            title: 'Experience Edge for XM',
+            url: '/content-management/edge-xm',
+          },
+          {
+            title: 'Headless Services & JSS',
+            url: '/content-management/headless',
+          },
+          {
             title: 'Access the Portal',
             url: 'https://portal.sitecorecloud.io/',
             external: true,

--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -122,6 +122,10 @@ const NavigationData: NavigationData[] = [
         url: '/content-management',
         children: [
           {
+            title: 'Sitecore XM Cloud',
+            url: '/content-management/xm-cloud',
+          },
+          {
             title: 'Sitecore Experience Manager',
             url: '/content-management/experience-manager',
           },
@@ -263,6 +267,20 @@ const NavigationData: NavigationData[] = [
           {
             title: 'Experience Edge for Content Hub',
             url: '/content-management/edge-content-hub',
+          },
+        ],
+      },
+      {
+        title: 'Sitecore XM Cloud',
+        children: [
+          {
+            title: 'Headless Web Content management',
+            url: '/content-management/xm-cloud',
+          },
+          {
+            title: 'Access the Portal',
+            url: 'https://portal.sitecorecloud.io/',
+            external: true,
           },
         ],
       },

--- a/data/markdown/pages/solution/content-management/product/xm-cloud/index.md
+++ b/data/markdown/pages/solution/content-management/product/xm-cloud/index.md
@@ -1,0 +1,9 @@
+---
+solution: ['content-management']
+product: ['xm-cloud']
+title: 'XM Cloud'
+description: 'Manage the full web experience with a cloud-hosted headless Web CMS.'
+twitter: ['#XMCloud']
+partials: ['solution/content-management/xm-cloud']
+youtube: PL1jJVFm_lGnzqYagW1UahIBeqTIYSBQMc
+---

--- a/data/markdown/pages/solution/content-management/product/xm-cloud/index.md
+++ b/data/markdown/pages/solution/content-management/product/xm-cloud/index.md
@@ -4,6 +4,7 @@ product: ['xm-cloud']
 title: 'XM Cloud'
 description: 'Manage the full web experience with a cloud-hosted headless Web CMS.'
 twitter: ['#XMCloud']
+stackexchange: ['#xm-cloud']
 partials: ['solution/content-management/xm-cloud']
 youtube: PL1jJVFm_lGnzqYagW1UahIBeqTIYSBQMc
 ---

--- a/data/markdown/partials/learn/starter-kits/ordercloud.md
+++ b/data/markdown/partials/learn/starter-kits/ordercloud.md
@@ -1,3 +1,3 @@
-### OrderCloud Starter Kits
+### Sitecore OrderCloud Starter Kits
 
 - [Headstart](https://github.com/ordercloud-api/headstart)

--- a/data/markdown/partials/learn/starter-kits/xm-cloud.md
+++ b/data/markdown/partials/learn/starter-kits/xm-cloud.md
@@ -1,0 +1,5 @@
+### Sitecore XM Cloud Examples and Starter Kits
+
+- [Headless SXA Starter Kit](https://github.com/sitecorelabs/sxa-starter)
+- [Sitecore PlaySummit Demo - XM Cloud](https://github.com/Sitecore/Sitecore.Demo.XmCloud.PlaySummit)
+- [XM Cloud Introduction - example implementation](https://github.com/Sitecore/XM-Cloud-Introduction)

--- a/data/markdown/partials/solution/content-management/xm-cloud.md
+++ b/data/markdown/partials/solution/content-management/xm-cloud.md
@@ -1,0 +1,47 @@
+---
+solution: ['content-management']
+product: ['xm-cloud']
+title: 'XM Cloud'
+description: 'Manage the full web experience with a cloud-hosted headless Web CMS.'
+---
+
+## Introduction
+
+Sitecore Experience Manager Cloud (XM Cloud) is a fully managed self-service deployment platform for developers and marketers to efficiently launch engaging omnichannel experiences in the Cloud using Sitecore’s headless CMS. Experience Manager Cloud bundles the latest versions of Experience Manager, the Pages editor, Sitecore Headless Experience Accelerator (SXA), Headless Services, the Sitecore Next.js SDK (and other Heads), and Experience Edge.
+
+With an optimized cloud-based strategy, you can rapidly and cost-effectively scale to meet your customers’ needs, shorten your time-to-market, and be more adaptive as new capabilities and functionality are added to your Martech stack. Explore how the right cloud approach will help you thrive now and into the future.
+
+Sitecore Experience Manager Cloud re-imagines Content Management and introduces a no-compromise Content Management System (CMS) that delivers developer agility through the best attributes of the headless CMS while empowering marketers through a visually rich, WYSIWYG page composition experience. With XM Cloud, our customers can deliver relevant experiences at high speed.
+
+Speed: Visitors are greeted with an experience that loads lightning-fast and engages instantly
+Relevance: Customers are recognized and welcomed back to an experience that understands their needs
+The importance of your company's growth comes with the:
+
+* Agility: Marketers can easily orchestrate the overall experience across digital campaigns
+* Flexibility: Developers can rapidly develop and launch new experience types with modern front-end frameworks
+
+
+## Getting Started
+
+- TBD
+
+## Documentation
+
+- [User Documentation] (TBD)
+- [Developer Documentation] (TBD)
+
+## Learn & Examples
+
+### Open Source
+
+- [Headless SXA Starter Kit](https://github.com/sitecorelabs/sxa-starter)
+- [Sitecore PlaySummit Demo - XM Cloud](https://github.com/Sitecore/Sitecore.Demo.XmCloud.PlaySummit)
+- [XM Cloud Introduction - example implementation](https://github.com/Sitecore/XM-Cloud-Introduction)
+
+### Official Sitecore Training
+
+- [Coming soon!]
+
+## Access the Portal
+
+- [Sitecore Portal](https://portal.sitecorecloud.io/)

--- a/data/markdown/partials/solution/content-management/xm-cloud.md
+++ b/data/markdown/partials/solution/content-management/xm-cloud.md
@@ -27,8 +27,8 @@ The importance of your company's growth comes with the:
 
 ## Documentation
 
-- [User Documentation] (TBD)
-- [Developer Documentation] (TBD)
+- [User Documentation]() [Coming soon!]
+- [Developer Documentation]() [Coming soon!]
 
 ## Learn & Examples
 

--- a/data/markdown/partials/solution/content-management/xm-cloud.md
+++ b/data/markdown/partials/solution/content-management/xm-cloud.md
@@ -23,7 +23,7 @@ The importance of your company's growth comes with the:
 
 ## Getting Started
 
-- TBD
+- [XM Cloud Introduction](/learn/getting-started/xm-cloud-introduction)
 
 ## Documentation
 

--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -9,8 +9,9 @@ import GenericContentPage from '@/src/layouts/GenericContentPage';
 
 export async function getStaticProps() {
   const starterKits = await getPartialsAsArray([
-    'learn/starter-kits/sitecore-starter-kits',
+    'learn/starter-kits/xm-cloud',
     'learn/starter-kits/ordercloud',
+    'learn/starter-kits/sitecore-starter-kits',
   ]);
   const gettingStarted = await getPartialsAsArray([
     'learn/getting-started/composable-dxp',


### PR DESCRIPTION
## Description / Motivation
With the launch of XM Cloud, we need a page to hold all developer content and resources for people looking for information about the product. There is an XM Cloud Introduction article, but we need to have an official product resources page as well. This pull request is to add the necessary navigation and markdown partials to create that page, though some content needs GA before being able to be updated (like Docs links and Learning courses)

Additional work will be needed for these pages to be fully complete, but this should be good enough for a first launch and then we can iterate.

Fixes #309  

## How Has This Been Tested?

Tested locally and on Vercel preview environments.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
