### PR TITLE
CDP/Personalize content link updates

### DIFF
--- a/data/markdown/partials/solution/customer-data-management/cdp.md
+++ b/data/markdown/partials/solution/customer-data-management/cdp.md
@@ -29,3 +29,16 @@ Sitecore CDP brings together real-time behavioral insights and all your customer
 
 - [Integrating Sitecore SmartHub CDP with Sitecore XM](/learn/integrations/xm-smarthub-cdp)
 - [Integrating Sitecore CDP with Sitecore OrderCloud](/learn/integrations/oc-cdp)
+
+## Open Source
+
+- [Sitecore CDP/Personalize Serializer](https://github.com/dylanyoung-dev/sitecore-cdp-serializer)
+- [Sitecore CDP/Personalize Examples](https://github.com/dylanyoung-dev/cdp-personalize-examples)
+
+## Resources
+
+- [Blog: Sitecore CDP Audience Sync Automation](https://community.sitecore.com/community?id=community_blog&sys_id=46a5fcc11be15d10b8954371b24bcb85)
+- [Blog: Product Comparisons](https://community.sitecore.com/community?id=community_blog&sys_id=d8fdc45d1bb6811038a46421b24bcbb7)
+- [Blog: Product Specifications/Comparisons part 2](https://community.sitecore.com/community?id=community_blog&sys_id=f0862b751bf6491038a46421b24bcb65)
+- [Blog: Sitecore XP Migration Guide](https://community.sitecore.com/community?id=community_blog&sys_id=f1cc98af1b541590e55241dde54bcb0d)
+- [Blog: Security Considerations When Using the APIs](https://community.sitecore.com/community?id=community_blog&sys_id=6d9601561b12d9d0b8954371b24bcb9b)

--- a/data/markdown/partials/solution/customer-data-management/cdp.md
+++ b/data/markdown/partials/solution/customer-data-management/cdp.md
@@ -14,6 +14,7 @@ Sitecore CDP brings together real-time behavioral insights and all your customer
 - [Developer Docs - Data Model 2.0](https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-0/index-en.html)
 - [Introduction to Sitecore CDP - Managing Users](https://doc.sitecore.com/cdp/en/users/sitecore-customer-data-platform/introduction-to-sitecore-cdp.html)
 - [Sitecore CDP Data retention policy](https://doc.sitecore.com/cdp/en/users/sitecore-cdp/introduction-to-sitecore-cdp-data-retention-policy.html)
+- [What's New in Sitecore CDP](https://doc.sitecore.com/cdp/en/users/sitecore-cdp/what-s-new-in-sitecore-cdp.html)
 - [Knowledge Hub](https://sitecore.cdpknowledgehub.com/docs)
 
 ## Discover

--- a/data/markdown/partials/solution/personalization-testing/personalize.md
+++ b/data/markdown/partials/solution/personalization-testing/personalize.md
@@ -14,6 +14,7 @@ Sitecore Personalize brings together real-time behavioral insights and all your 
 - [Developer Docs - Data Model 2.0](https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-0/index-en.html)
 - [Introduction to Sitecore CDP - Managing Users](https://doc.sitecore.com/cdp/en/users/sitecore-customer-data-platform/introduction-to-sitecore-cdp.html)
 - [Sitecore Personalize - Intro](https://doc.sitecore.com/cdp/en/users/sitecore-personalize/introduction-to-sitecore-personalize.html)
+- [What's New in Sitecore Personalize](https://doc.sitecore.com/cdp/en/users/sitecore-personalize/what-s-new-in-sitecore-personalize.html)
 - [Knowledge Hub](https://sitecore.cdpknowledgehub.com/docs)
 
 ## Discover

--- a/data/markdown/partials/solution/personalization-testing/personalize.md
+++ b/data/markdown/partials/solution/personalization-testing/personalize.md
@@ -13,6 +13,7 @@ Sitecore Personalize brings together real-time behavioral insights and all your 
 - [Developer Docs - Data Model 2.1](https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-1/index-en.html)
 - [Developer Docs - Data Model 2.0](https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-0/index-en.html)
 - [Introduction to Sitecore CDP - Managing Users](https://doc.sitecore.com/cdp/en/users/sitecore-customer-data-platform/introduction-to-sitecore-cdp.html)
+- [Sitecore Personalize - Intro](https://doc.sitecore.com/cdp/en/users/sitecore-personalize/introduction-to-sitecore-personalize.html)
 - [Knowledge Hub](https://sitecore.cdpknowledgehub.com/docs)
 
 ## Discover
@@ -21,9 +22,21 @@ Sitecore Personalize brings together real-time behavioral insights and all your 
 
 ## Learn
 
+- [Preparing for Sitecore CDP/Personalize Certification Exam](https://community.sitecore.com/community?id=community_blog&sys_id=b64c74421b7b8d50e55241dde54bcb84)
 - [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Sitecore CDP and Personalize
-- [Boxever Training path](https://learning.sitecore.com/pathway/boxever-training)
 
 ## Integrations
 
 - [Integrating Sitecore SmartHub CDP with Sitecore XM](/learn/integrations/xm-smarthub-cdp)
+
+## Open Source
+
+- [Sitecore CDP/Personalize Serializer](https://github.com/dylanyoung-dev/sitecore-cdp-serializer)
+- [Sitecore CDP/Personalize Examples](https://github.com/dylanyoung-dev/cdp-personalize-examples)
+
+## Resources
+
+- [Blog: Product Comparisons](https://community.sitecore.com/community?id=community_blog&sys_id=d8fdc45d1bb6811038a46421b24bcbb7)
+- [Blog: Product Specifications/Comparisons part 2](https://community.sitecore.com/community?id=community_blog&sys_id=f0862b751bf6491038a46421b24bcb65)
+- [Blog: Sitecore XP Migration Guide](https://community.sitecore.com/community?id=community_blog&sys_id=f1cc98af1b541590e55241dde54bcb0d)
+- [Blog: Security Considerations When Using the APIs](https://community.sitecore.com/community?id=community_blog&sys_id=6d9601561b12d9d0b8954371b24bcb9b)


### PR DESCRIPTION
## Description / Motivation

Added an update to the documentation and links on CDP/Personalize pages.  Includes community blogs, documentation updates, links to open source repos, and other resources, important to CDP/Personalize developers.  I left the learning content alone, although most of the links are currently broken.  I could've optionally removed the broken links until I had working links, but decided to leave them alone.  

## How Has This Been Tested?

Tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
