### PR TITLE
Add XM Cloud docs to the Developer Portal

### DIFF
--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -272,9 +272,10 @@ const NavigationData: NavigationData[] = [
       },
       {
         title: 'Sitecore XM Cloud',
+        url: '/content-management/xm-cloud',
         children: [
           {
-            title: 'Headless Web Content management',
+            title: 'Developer Resources',
             url: '/content-management/xm-cloud',
           },
           {

--- a/data/markdown/partials/docs/cms/headless.md
+++ b/data/markdown/partials/docs/cms/headless.md
@@ -1,8 +1,9 @@
 ### Headless
 
 - [Headless Services](https://doc.sitecore.com/en/developers/hd/200/sitecore-headless-development/sitecore-headless-services.html)
+- [Experience Edge for XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html)
 - [Experience Edge for XM](https://doc.sitecore.com/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html)
+- [Experience Edge for Content Hub](https://docs.stylelabs.com/contenthub/latest/content/user-documentation/experience-edge/caas-intro.html)z
 - [ASP.NET Rendering SDK](https://doc.sitecore.com/en/developers/hd/200/sitecore-headless-development/sitecore-asp-net-rendering-sdk.html)
 - [JavaScript SDK (JSS)](https://doc.sitecore.com/en/developers/hd/200/sitecore-headless-development/sitecore-javascript-rendering-sdks--jss-.html)
 - [Convert existing MVC apps to Jamstack](https://doc.sitecore.com/en/developers/hd/200/sitecore-headless-development/converting-existing-sitecore-mvc-applications-to-the-jamstack-architecture-with-headless-rendering.html)
-- [Experience Edge for Content Hub](https://docs.stylelabs.com/contenthub/latest/content/user-documentation/experience-edge/caas-intro.html)

--- a/data/markdown/partials/docs/cms/sitecore-experience-manager.md
+++ b/data/markdown/partials/docs/cms/sitecore-experience-manager.md
@@ -1,5 +1,5 @@
 ### Sitecore Experience Manager (XM)
 
-- [Developer Documentation](https://doc.sitecore.com/en/developers/101/index.html)
-- [Developer Tools](https://doc.sitecore.com/en/developers/101/developer-tools/index-en.html)
-- [Containers](https://doc.sitecore.com/en/developers/101/developer-tools/containers-in-sitecore-development.html)
+- [Developer Documentation](https://doc.sitecore.com/en/developers/102/index.html)
+- [Developer Tools](https://doc.sitecore.com/en/developers/102/developer-tools/index-en.html)
+- [Containers](https://doc.sitecore.com/en/developers/102/developer-tools/containers-in-sitecore-development.html)

--- a/data/markdown/partials/docs/cms/sitecore-xm-cloud.md
+++ b/data/markdown/partials/docs/cms/sitecore-xm-cloud.md
@@ -1,0 +1,7 @@
+### Sitecore XM Cloud
+
+- [Developer Documentation](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-manager-cloud.html)
+- [XM Cloud Build Configuration](https://doc.sitecore.com/xmc/en/developers/xm-cloud/the-xm-cloud-build-configuration.html)
+- [XM Cloud Deploy App](https://doc.sitecore.com/xmc/en/developers/xm-cloud/xm-cloud-deploy-app.html)
+- [Developer Tools](https://doc.sitecore.com/xmc/en/developers/xm-cloud/developer-tools.html)
+- [XM Cloud development](https://doc.sitecore.com/xmc/en/developers/xm-cloud/xm-cloud-development.html)

--- a/data/markdown/partials/docs/cms/sitecore-xm-cloud.md
+++ b/data/markdown/partials/docs/cms/sitecore-xm-cloud.md
@@ -5,3 +5,4 @@
 - [XM Cloud Deploy App](https://doc.sitecore.com/xmc/en/developers/xm-cloud/xm-cloud-deploy-app.html)
 - [Developer Tools](https://doc.sitecore.com/xmc/en/developers/xm-cloud/developer-tools.html)
 - [XM Cloud development](https://doc.sitecore.com/xmc/en/developers/xm-cloud/xm-cloud-development.html)
+- [Cloud Portal developer docs](https://doc.sitecore.com/portal/en/developers/sitecore-cloud-portal/introduction-to-the-sitecore-cloud-portal.html)

--- a/data/markdown/partials/learn/getting-started/composable-dxp.md
+++ b/data/markdown/partials/learn/getting-started/composable-dxp.md
@@ -1,16 +1,19 @@
 ### Getting Started with the Sitecore Composable DXP
 
 - [Introduction to Composable DXP](/learn/getting-started/introduction-to-composable-dxp)
+- [Introduction to the Sitecore Cloud Portal](https://doc.sitecore.com/portal/en/developers/sitecore-cloud-portal/introduction-to-the-sitecore-cloud-portal.html)
 - [Introduction to XM Cloud](/learn/getting-started/xm-cloud-introduction)
+- [Getting Started with Sitecore XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/getting-started-with-xm-cloud.html)
 - [Getting Started with Sitecore CDP](https://doc.sitecore.com/cdp/en/users/sitecore-customer-data-platform/introduction-to-sitecore-cdp.html)
 - [Getting Started with OrderCloud](https://ordercloud.io/learn/getting-started/welcome-to-ordercloud)
 - [Getting Started with Content Hub](https://docs.stylelabs.com/contenthub/latest/content/user-documentation/get-started/get-started.html)
 - [Getting Started with Moosend](https://help.moosend.com/hc/en-us/articles/208076445-How-do-I-get-started-with-my-Moosend-account-)
 - [Getting started with Experience Edge for ContentHub](https://docs.stylelabs.com/content/4.0.x/user-documentation/experience-edge/content-delivery/quickstart-guide.html)
-- [Getting started with Experience Edge for XM](https://doc.sitecore.com/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html)
+- [Getting started with Experience Edge for XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html)
 - [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials)
   - Introduction to Sitecore Content Hub
   - Introduction to Sitecore OrderCloud
   - Introduction to Sitecore CDP and Personalize
 - [XM - Personalize FAQ](/learn/faq/xm-personalize)
 - [Cloud Portal FAQ](/learn/faq/cloud-portal)
+

--- a/data/markdown/partials/solution/content-management/xm-cloud.md
+++ b/data/markdown/partials/solution/content-management/xm-cloud.md
@@ -24,11 +24,17 @@ The importance of your company's growth comes with the:
 ## Getting Started
 
 - [XM Cloud Introduction](/learn/getting-started/xm-cloud-introduction)
+- [Getting started with XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/getting-started-with-xm-cloud.html)
 
 ## Documentation
 
-- [User Documentation]() [Coming soon!]
-- [Developer Documentation]() [Coming soon!]
+- [User Documentation](https://doc.sitecore.com/xmc/en/users/xm-cloud/index-en.html)
+- [Developer Documentation](https://doc.sitecore.com/xmc/en/developers/xm-cloud/index-en.html)
+- [XM Cloud Build Configuration](https://doc.sitecore.com/xmc/en/developers/xm-cloud/the-xm-cloud-build-configuration.html)
+- [XM Cloud Deploy App](https://doc.sitecore.com/xmc/en/developers/xm-cloud/xm-cloud-deploy-app.html)
+- [Developer Tools](https://doc.sitecore.com/xmc/en/developers/xm-cloud/developer-tools.html)
+- [XM Cloud development](https://doc.sitecore.com/xmc/en/developers/xm-cloud/xm-cloud-development.html)
+- [Cloud Portal developer docs](https://doc.sitecore.com/portal/en/developers/sitecore-cloud-portal/introduction-to-the-sitecore-cloud-portal.html)
 
 ## Learn & Examples
 

--- a/data/markdown/partials/solution/content-management/xm-cloud.md
+++ b/data/markdown/partials/solution/content-management/xm-cloud.md
@@ -25,6 +25,7 @@ The importance of your company's growth comes with the:
 
 - [XM Cloud Introduction](/learn/getting-started/xm-cloud-introduction)
 - [Getting started with XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/getting-started-with-xm-cloud.html)
+- [XM Cloud FAQ](/learn/faq/xm-cloud)
 
 ## Documentation
 

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -8,9 +8,10 @@ import GenericContentPage from '@/src/layouts/GenericContentPage';
 export async function getStaticProps() {
   // Partial Groups
   const cms = await getPartialsAsArray([
-    'docs/cms/sitecore-experience-manager',
-    'docs/cms/headless',
+    'docs/cms/sitecore-xm-cloud',
     'docs/cms/sitecore-content-hub',
+    'docs/cms/headless',
+    'docs/cms/sitecore-experience-manager',
   ]);
   const customerDataManagement = await getPartialsAsArray([
     'docs/customer-data-management/sitecore-cdp',


### PR DESCRIPTION
## Description / Motivation
The /learn, /docs, and XM Cloud product page are now updated to link to the documentation on the new XM Cloud docs pages. The menu was slightly updated as well.

This fixes #330 .

## How Has This Been Tested?
Tested locally on developer environment and reviewed on Vercel preview environment.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
