### PR TITLE
Reordered products by cloud

### DIFF
--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -294,7 +294,7 @@ const NavigationData: NavigationData[] = [
         ],
       },
       {
-        title: 'Sitecore SmartHub CDP',
+        title: 'Sitecore Personalize/CDP',
         children: [
           {
             title: 'Customer Data Management',
@@ -303,6 +303,46 @@ const NavigationData: NavigationData[] = [
           {
             title: 'Personalization and Testing',
             url: '/personalization-testing/personalize',
+          },
+        ],
+      },
+      {
+        title: 'Moosend',
+        url: '/marketing-automation/send',
+        children: [
+          {
+            title: 'Marketing Automation',
+            url: '/marketing-automation/send',
+          },
+          {
+            title: 'Get your free Moosend account',
+            url: 'https://identity.moosend.com/register/',
+            external: true,
+          },
+        ],
+      },
+      {
+        title: 'Sitecore OrderCloud',
+        url: '/commerce/ordercloud',
+        children: [
+          {
+            title: 'Order Management, Storefronts and Marketplaces, and Merchandizing',
+            url: '/commerce/ordercloud',
+          },
+          {
+            title: 'Start on the OrderCloud Portal for free',
+            url: 'https://portal.ordercloud.io',
+            external: true,
+          },
+        ],
+      },
+      {
+        title: 'Sitecore Discover',
+        url: '/commerce/discover',
+        children: [
+          {
+            title: 'Data driven product discovery',
+            url: '/commerce/discover',
           },
         ],
       },
@@ -367,36 +407,6 @@ const NavigationData: NavigationData[] = [
         ],
       },
       {
-        title: 'Moosend',
-        url: '/marketing-automation/send',
-        children: [
-          {
-            title: 'Marketing Automation',
-            url: '/marketing-automation/send',
-          },
-          {
-            title: 'Get your free Moosend account',
-            url: 'https://identity.moosend.com/register/',
-            external: true,
-          },
-        ],
-      },
-      {
-        title: 'Sitecore OrderCloud',
-        url: '/commerce/ordercloud',
-        children: [
-          {
-            title: 'Order Management, Storefronts and Marketplaces, and Merchandizing',
-            url: '/commerce/ordercloud',
-          },
-          {
-            title: 'Start on the OrderCloud Portal for free',
-            url: 'https://portal.ordercloud.io',
-            external: true,
-          },
-        ],
-      },
-      {
         title: 'Sitecore Experience Commerce',
         url: '/commerce/experience-commerce',
         children: [
@@ -412,16 +422,6 @@ const NavigationData: NavigationData[] = [
             title: 'Downloads',
             url: 'https://dev.sitecore.net/Downloads/Sitecore_Commerce.aspx',
             external: true,
-          },
-        ],
-      },
-      {
-        title: 'Sitecore Discover',
-        url: '/commerce/discover',
-        children: [
-          {
-            title: 'Data driven product discovery',
-            url: '/commerce/discover',
           },
         ],
       },

--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -294,12 +294,19 @@ const NavigationData: NavigationData[] = [
         ],
       },
       {
-        title: 'Sitecore Personalize/CDP',
+        title: 'Sitecore CDP',
+        url: '/customer-data-management/cdp',
         children: [
           {
             title: 'Customer Data Management',
             url: '/customer-data-management/cdp',
           },
+        ],
+      },
+      {
+        title: 'Sitecore Personalize',
+        url: '/personalization-testing/personalize',
+        children: [
           {
             title: 'Personalization and Testing',
             url: '/personalization-testing/personalize',


### PR DESCRIPTION
Renamed the SmartHub CDP and then reordered the menu to be Content Cloud/Engagement Cloud/Commerce Cloud/Platform Cloud

Fixes #315 and #325 

## How Has This Been Tested?
Tested locally and on Vercel preview site.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
