### PR TITLE
Adding Managed Cloud playlist to the metadata

### DIFF
--- a/data/markdown/pages/solution/devops/product/managed-cloud/index.md
+++ b/data/markdown/pages/solution/devops/product/managed-cloud/index.md
@@ -4,5 +4,6 @@ product: ['Managed Cloud']
 title: 'Managed Cloud'
 description: 'Have Sitecore manage your infrastructure in the cloud, allowing you to focus on your customizations to Sitecore.  Advantages of a Managed Cloud option includes faster time to market, increased uptime and the peace of mind of knowing Sitecore is managing your infrastructure.'
 stackexchange: ['#sitecore-managed-cloud']
+youtube: 'PL1jJVFm_lGnyhZPj0d1ZCNgNApMaaKDuv'
 partials: ['solution/devops/managed-cloud']
 ---


### PR DESCRIPTION
## Description / Motivation
Playlist was created on Discover Sitecore, metadata was updated for the Managed Cloud page to display the YouTube playlist on the page.

Fixes #255 

## How Has This Been Tested?
Tested on Vercel preview site to ensure the playlist displays.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
