### PR TITLE
Updated footer Legal link from /trust to /legal

### DIFF
--- a/src/layouts/components/footer/Footer.tsx
+++ b/src/layouts/components/footer/Footer.tsx
@@ -109,7 +109,7 @@ const Footer = (): JSX.Element => {
             >
               <a
                 className={classnames('font-semibold')}
-                href="https://www.sitecore.com/trust"
+                href="https://www.sitecore.com/legal"
                 rel="noopener noreferrer"
                 target="_blank"
               >


### PR DESCRIPTION
## Description / Motivation
At request of sitecore.com team, updating the footer link to Legal from /trust to /legal. 
⚠This PR should not be published to production until sitecore.com/legal has been published! ⚠

Fixes #344 

## How Has This Been Tested?
Checked on local and preview site, but sitecore.com/legal has not been published so a 404 is found. Needs to be revalidated before merging once sitecore.com/legal publishes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
