### PR TITLE
Feature/replace moosend with send

### DIFF
--- a/apps/devportal/data/data-navigation.ts
+++ b/apps/devportal/data/data-navigation.ts
@@ -172,7 +172,7 @@ export const mainNavigation: NavigationData[] = [
         url: '/marketing-automation',
         children: [
           {
-            title: 'Moosend',
+            title: 'Sitecore Send',
             url: '/marketing-automation/send',
           },
           {
@@ -336,7 +336,7 @@ export const mainNavigation: NavigationData[] = [
         ],
       },
       {
-        title: 'Moosend',
+        title: 'Sitecore Send',
         url: '/marketing-automation/send',
         children: [
           {

--- a/apps/devportal/data/markdown/pages/solution/marketing-automation/product/send/index.md
+++ b/apps/devportal/data/markdown/pages/solution/marketing-automation/product/send/index.md
@@ -7,6 +7,7 @@ description: 'Connecting with customers with Send marketing automation'
 twitter: ['@Moosend', '#Moosend', '@SitecoreSend', '#SitecoreSend']
 youtube: 'PLAKrWBcgVt6M4Ia_bECQVOyxUe1eDFpG6'
 youtubeTitle: 'Latest Marketing Automation videos'
+stackexchange: ['#moosend']
 partials: ['solution/marketing-automation/send']
 sitecoreCommunityQuestions: true
 sitecoreCommunityQuestionsCategory: ['marketingAutomation']

--- a/apps/devportal/data/markdown/pages/solution/marketing-automation/product/send/index.md
+++ b/apps/devportal/data/markdown/pages/solution/marketing-automation/product/send/index.md
@@ -1,9 +1,10 @@
 ---
 solution: ['marketing-automation']
 product: ['send']
-title: 'Moosend'
-description: 'Connecting with customers with Moosend marketing automation'
-twitter: ['@Moosend', '#Moosend']
+productLogo: 'Send'
+title: 'Sitecore Send'
+description: 'Connecting with customers with Send marketing automation'
+twitter: ['@Moosend', '#Moosend', '@SitecoreSend', '#SitecoreSend']
 youtube: 'PLAKrWBcgVt6M4Ia_bECQVOyxUe1eDFpG6'
 youtubeTitle: 'Latest Marketing Automation videos'
 partials: ['solution/marketing-automation/send']

--- a/apps/devportal/data/markdown/partials/learn/getting-started/composable-dxp.md
+++ b/apps/devportal/data/markdown/partials/learn/getting-started/composable-dxp.md
@@ -10,7 +10,7 @@
 - [Getting Started with Sitecore CDP](https://doc.sitecore.com/cdp/en/users/sitecore-customer-data-platform/introduction-to-sitecore-cdp.html)
 - [Getting Started with OrderCloud](https://ordercloud.io/learn/getting-started/welcome-to-ordercloud)
 - [Getting Started with Content Hub](https://doc.sitecore.com/ch/en/users/latest/content-hub/started-get-started.html)
-- [Getting Started with Moosend](https://help.moosend.com/hc/en-us/articles/208076445-How-do-I-get-started-with-my-Moosend-account-)
+- [Getting Started with Sitecore Send](https://doc.sitecore.com/send/en/users/sitecore-send/getting-started-with-sitecore-send.html)
 - [Getting started with Experience Edge for ContentHub](https://doc.sitecore.com/ch/en/users/latest/content-hub/quickstart-guide.html)
 - [Getting started with Experience Edge for XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html)
 - [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials)

--- a/apps/devportal/data/markdown/partials/solution/marketing-automation/send.md
+++ b/apps/devportal/data/markdown/partials/solution/marketing-automation/send.md
@@ -1,26 +1,27 @@
 ---
 solution: ['marketing-automation']
 product: ['send']
-title: 'Moosend'
-description: 'Connecting with customers with Moosend marketing automation'
+title: 'Sitecore Send'
+description: 'Connecting with customers with Send marketing automation'
 ---
 
 ## Introduction
 
 <img src="/images/products/send/pixel-perfect-emails-faster.svg" alt="Pixel perfect emails faster" className="ml-4 inline w-1/3" align="right" />
-With Moosend you can dive into the world of email marketing and create the most responsive newsletters to amaze your subscribers. However, sending email campaigns is not the only thing you can do. By leveraging state-of-the-art marketing automation features you can save valuable time by scheduling your campaigns and tracking their performance based on your recipients’ behavior through advanced Reporting Capabilities.
+With Send you can dive into the world of email marketing and create the most responsive newsletters to amaze your subscribers. However, sending email campaigns is not the only thing you can do. By leveraging state-of-the-art marketing automation features you can save valuable time by scheduling your campaigns and tracking their performance based on your recipients’ behavior through advanced Reporting Capabilities.
 
 ## Documentation
 
 <Row columns={3}>
-<Link title="Knowledge Base" link="https://moosend.com/help/" />
-<Link title="Integrations" link="https://moosend.com/integrations/" />
-<Link title="Documentation" link="https://moosendapp.docs.apiary.io/" />
+<Link title="Developer Documentation" link="https://doc.sitecore.com/send/en/developers/api-documentation/index-en.html" />
+<Link title="User Documentation" link="https://doc.sitecore.com/send/en/users/sitecore-send/introduction-to-sitecore-send.html" />
+<Link title="What's New in Documentation" link="https://doc.sitecore.com/send/en/users/sitecore-send/what-s-new-in-sitecore-send.html" />
 </Row>
 
 ## Learn
 
 <Row columns={2}>
+<Link title="Sitecore Send for Marketers" link="https://learning.sitecore.com/learn/learning_plan/view/39/send-for-marketers" />
 <Link title="Moosend Academy" link="https://academy.moosend.com/" />
 <Link title="How do I get started with Moosend" link="https://help.moosend.com/hc/en-us/articles/208076445-How-do-I-get-started-with-my-Moosend-account-" />
 <Link title="Extra tools" link="https://moosend.com/resources/fancy-toolshed/" />


### PR DESCRIPTION
## Description / Motivation

This has been in my queue for a while, so I spent Focus Friday adding this in.  This is all documentation updates that include:

- Replacing Moosend with Sitecore Send
- Adding Send logo to the Product page
- Updating documentation links with Send docs (including new Dev Docs)
- Added New Sitecore Learning course for Send for Marketers.  Looks like there is one for developers coming soon, will update when that's available.

In a few places, I left references for Moosend because it's still good information that relates to Send.  For example, left the training content for Moosend under the Send product page, because those courses are still applicable to Send.

## How Has This Been Tested?

Tested this locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
