### PR TITLE
Adding missing Sitecore Developer Newsletters - And Fixing Sorting

### DIFF
--- a/apps/devportal/data/newsletters/2022/12.json
+++ b/apps/devportal/data/newsletters/2022/12.json
@@ -1,0 +1,100 @@
+{
+  "title": "Sitecore Developers",
+  "description": "Find out the latest news and updates in the Sitecore community.",
+  "content": [
+    {
+      "title": "SUGCON Europe 2023 Call for Speakers",
+      "copy": "SUGCON Europe is back! Join the Sitecore Community in beautiful Málaga, Spain, from March 23rd to 24th. If you are interested in speaking at SUGCON 2023, submit your topic by clicking the link below. More details are coming soon.",
+      "image": "https://go.sitecore.com/l/857953/2022-12-17/tdlvg1/857953/167132999600OcLtLV/Untitled_design__2_.png",
+      "link": {
+        "text": "Become a speaker",
+        "href": "https://sessionize.com/sugcon-europe-2023"
+      },
+      "variant": "full-width"
+    },
+    {
+      "title": "XM Cloud Recommended Practices",
+      "copy": "Learn tips for teams working on XM Cloud projects from developers in the field.",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5c7/857953/1658870987UUkRlEYe/2.png",
+      "link": {
+        "href": "https://developers.sitecore.com/learn/faq/xm-cloud-recommended-practices"
+      }
+    },
+    {
+      "title": "Capturing Additional Data in a View Event in Sitecore CDP/Personalize",
+      "copy": "Learn the different approaches to capture arbitrary information in CDP so that you can then use Sitecore Personalize to create a Decision Model and a Unique Web Experience based on that arbitrary data",
+      "image": "https://go.sitecore.com/l/857953/2022-06-26/l5czn4/857953/1656293027HOmT1QJR/Untitled_design__12_.png",
+      "link": {
+        "href": "https://dylanyoung.dev/insights/sitecore-cdp-personalize-capture-additional-data-in-a-view-event/"
+      }
+    },
+    {
+      "title": "A new way to wire up integrations",
+      "copy": "Sitecore 10.3. is now out, and one of the many changes is that the server-side event model for CMS has been extended in Webhooks. Learn what this means and how you make use of them!",
+      "image": "https://go.sitecore.com/l/857953/2022-04-21/ggvc2w/857953/1650590313tUyZoKqL/4.png",
+      "link": {
+        "href": "https://blog.jermdavis.dev/posts/2022/sitecore-10-3-webhooks-integration"
+      }
+    },
+    {
+      "title": "Sitecore - Safely Use HttpClient",
+      "copy": "This is a follow up from a SUGCON Europe presentation on safe usage of the .NET HttpClient in Sitecore.",
+      "image": "https://go.sitecore.com/l/857953/2022-10-15/r7d59n/857953/1665890761FaqRUiNi/Pink_Inspirational_Instagram_Quote__2_.png",
+      "link": {
+        "href": "https://www.coreysmith.co/sitecore-safely-use-httpclient/"
+      }
+    },
+    {
+      "title": "Sitecore Content Hub ONE for Developers",
+      "copy": "Content Hub ONE is a headless and agile “Software as a Service” content management system with a simple management interface and APIs to consume and manage the content.",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5cb/857953/16588710277UW1trZc/3.png",
+      "link": {
+        "text": "Watch Now",
+        "href": "https://www.youtube.com/watch?v=cP2BBlgKZS8"
+      }
+    },
+    {
+      "title": "Path to XM Cloud featuring 10.3 Updates",
+      "copy": "Josh Hover is joined by Jake Hookom, VP of Commerce and Platforms at Sitecore. Learn about the path to XM Cloud from XP solutions, anticipated 10.3 release date, XM Cloud sandbox release date, headless, and more.",
+      "image": "https://go.sitecore.com/l/857953/2022-06-26/l5d1bb/857953/1656295790L4iFnrCN/Untitled_design__4_.png",
+      "link": {
+        "text": "Listen Now",
+        "href": "https://www.buzzsprout.com/2049944/11747999-path-to-xm-cloud-featuring-10-3-updates"
+      }
+    },
+    {
+      "title": "Send guest information to your marketing tool with Sitecore CDP Audience Sync",
+      "copy": "Learn how to inspect the payload that an Audience Sync Flow receives and how to use Freemarker to walk through it.",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5cx/857953/1658871118S3sIFHp6/4.png",
+      "link": {
+        "href": "https://www.linkedin.com/pulse/send-guest-information-your-marketing-tool-sitecore-cdp-serpico/"
+      }
+    },
+    {
+      "title": "SearchStax Cloud – Recommended Mitigation for Solr Vulnerability from CVE-2022-39135",
+      "copy": "The NIST National Vulnerability Database has published a new vulnerability – CVE-2022-39135, which affects Apache Solr versions 6.5 to 8.11.2. This vulnerability is classified as Critical with a CVSS score of 9.8.",
+      "image": "https://go.sitecore.com/l/857953/2022-06-26/l5czp1/857953/1656293079sSwvv9lq/Untitled_design__11_.png",
+      "link": {
+        "href": "https://www.searchstax.com/blog/searchstax-cloud-recommended-mitigation-for-solr-vulnerability-from-cve-2022-39135/"
+      }
+    },
+    {
+      "title": "Sitecore JSS: Exploring the SitecoreContext object",
+      "copy": "This is part of a short series covering SitecoreContext Object. Learn about SitecoreContext and Sitecore JSS.",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5hm/857953/1658871187EaGFBnKo/Pink_Floral_Motivational_Instagram_Post.png",
+      "link": {
+        "href": "https://www.kayee.nl/2022/12/12/sitecore-jss-exploring-the-sitecorecontext-object/"
+      }
+    },
+    {
+      "title": "Sitecore Hackathon 2023",
+      "copy": "Sitecore Hackathon is a free online community-driven event organized by Akshay Sura and supported by Sitecore. Sign your team up by 6 pm EST on February 17, 2023, for the opportunity to participate in a contest.",
+      "image": "https://go.sitecore.com/l/857953/2022-10-15/r7d55k/857953/1665888525QVNM1kKz/Pink_Inspirational_Instagram_Quote.png",
+      "link": {
+        "text": "Sign up now",
+        "href": "https://sitecorehackathon.org/sitecore-hackathon-2023/"
+      },
+      "variant": "full-width"
+    }
+  ]
+}

--- a/apps/devportal/data/newsletters/2023/01.json
+++ b/apps/devportal/data/newsletters/2023/01.json
@@ -1,0 +1,109 @@
+{
+  "title": "Sitecore Developers",
+  "description": "Find out the latest news and updates in the Sitecore community.",
+  "content": [
+    {
+      "title": "SUGCON Europe 2023 Early Bird Tickets on Sale",
+      "copy": "Join the Sitecore Community in  Málaga, Spain, on March 23-24. Early bird tickets are now on sale. Buy your ticket before February 1st and save €121.",
+      "image": "https://go.sitecore.com/l/857953/2023-01-15/tvy1yn/857953/16738271176pjpzu4H/Untitled_design__4_.png",
+      "link": {
+        "text": "Save your spot",
+        "href": "https://www.eventbrite.co.uk/e/sitecore-user-group-conference-sugcon-europe-2023-tickets-502549066787"
+      },
+      "variant": "full-width"
+    },
+    {
+      "title": "Sitecore SOLR Search",
+      "copy": "Sitecore SOLR Search in multiselect lists fails unless you add the field to the default SolrIndexConfiguration config",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5c7/857953/1658870987UUkRlEYe/2.png",
+      "link": {
+        "href": "https://briancaos.wordpress.com/2022/12/21/sitecore-solr-search-in-multiselect-lists-fails-unless-you-add-the-field-to-the-defaultsolrindexconfiguration-config/"
+      }
+    },
+    {
+      "title": "Implement the WebFinger Protocol on a NextJS site",
+      "copy": "Learn how to implement the WebFinger Protocol on a NextJS site. This is great as it will allow you to have a single entry point for my Mastodon presence that can remain static even if moved to a new server down the track.",
+      "image": "https://go.sitecore.com/l/857953/2022-06-26/l5czn4/857953/1656293027HOmT1QJR/Untitled_design__12_.png",
+      "link": {
+        "href": "https://robearlam.com/blog/webfinger-on-nextjs"
+      }
+    },
+    {
+      "title": "Sitecore Send and Moosend certified by CSA",
+      "copy": "Sitecore Send and Moosend, one of the most powerful email marketing platforms and marketing automation systems with world-class features, state-of-the-art automation, and the best Support and Deliverability Teams, is proud to announce that it has been certified by CSA - Certified Senders Alliance.",
+      "image": "https://go.sitecore.com/l/857953/2023-01-15/tvy1yr/857953/1673827336JUlTKyhw/Untitled_design__5_.png",
+      "link": {
+        "href": "https://community.sitecore.com/community?id=community_blog&sys_id=cce80bf31bb79150722d4042b24bcb8d"
+      }
+    },
+    {
+      "title": "All about Sitecore Experience Edge",
+      "copy": "To support the composable journey of your organization in the recent past, Sitecore invested more in outstanding products to become a market leader in the composable digital experience platform (DXP) space. Learn more from this quick guide covering Sitecore Experience Edge.",
+      "image": "https://go.sitecore.com/l/857953/2022-10-15/r7d59n/857953/1665890761FaqRUiNi/Pink_Inspirational_Instagram_Quote__2_.png",
+      "link": {
+        "href": "http://amitkumarmca04.blogspot.com/2022/12/sitecore-experience-edge.html"
+      }
+    },
+    {
+      "title": "Sitecore CDP Developer Artifacts Release Process",
+      "copy": "If you are one of those sophisticated customer technical teams looking to set up DevOps for the resources that are being customized in a tenant you can start here utilizing starter template and set up a project in source control.",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5cb/857953/16588710277UW1trZc/3.png",
+      "link": {
+        "href": "https://venuvustipalli.com/get-started-on-sitecore-cdp-automated-ci-cd/"
+      }
+    },
+    {
+      "title": "Personalization Capabilities of Sitecore XM Cloud",
+      "copy": "As organizations look toward their next Sitecore upgrade, many will consider the implications of moving to XM Cloud. Learn what personalization looks like on the XM Cloud Platform.",
+      "image": "https://go.sitecore.com/l/857953/2022-06-26/l5d1bb/857953/1656295790L4iFnrCN/Untitled_design__4_.png",
+      "link": {
+        "href": "https://blogs.perficient.com/2022/12/30/personalization-capabilities-of-sitecore-xm-cloud/"
+      }
+    },
+    {
+      "title": "Sitecore Community Mentor Program",
+      "copy": "Sign up to be a mentee in the community mentor program. This program matches self-motivated and high-achieving Sitecore community members with Sitecore 2023 MVPs.The program is designed to help mentees attain their goal of contributing more meaningfully to the Sitecore community and overcoming challenges. Email the MVP program if you are interested at mvp-program@sitecore.net.",
+      "image": "https://go.sitecore.com/l/857953/2023-01-15/tvy1yy/857953/16738282144vgJ6Qze/Untitled_design__6_.png",
+      "link": {
+        "text": "Learn more",
+        "href": "https://mvp.sitecore.com/Mentor-Program"
+      },
+      "variant": "full-width"
+    },
+    {
+      "title": "XM Cloud: Embedded Personalization FAQ",
+      "copy": "Provided for informational purposes only, this FAQ addresses common questions customers or partners may have regarding the roadmap vision for taking Sitecore to the next level of SaaS. The information provided is general in nature and not intended to provide an exhaustive explanation of Sitecore’s development plans.",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5cx/857953/1658871118S3sIFHp6/4.png",
+      "link": {
+        "href": "https://developers.sitecore.com/learn/faq/xm-cloud-embedded-personalization/general"
+      }
+    },
+    {
+      "title": "Sitecore Discover Introduction",
+      "copy": "Sitecore Discover provides intelligent product search powered by AI, but what does it include? And how can you get started developing with it today? Learn about the features, integration options, and more.",
+      "image": "https://go.sitecore.com/l/857953/2022-06-26/l5czp1/857953/1656293079sSwvv9lq/Untitled_design__11_.png",
+      "link": {
+        "href": "https://developers.sitecore.com/learn/getting-started/discover-introduction"
+      }
+    },
+    {
+      "title": "Adding Flexibility to Jamstack with Vercel Edge Middleware",
+      "copy": "Jamstack applications are known for being extremely fast, but lacking flexibility. That ends now! Do more with Jamstack by pushing logic to the edge with Vercel Edge Middleware. Keep the speed by moving logic to the Content Delivery Network (CDN) layer and add flexibility by having more information available to you about your visitors at run time.",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5hm/857953/1658871187EaGFBnKo/Pink_Floral_Motivational_Instagram_Post.png",
+      "link": {
+        "text": "Watch Now",
+        "href": "https://blogs.perficient.com/2022/12/30/personalization-capabilities-of-sitecore-xm-cloud/"
+      }
+    },
+    {
+      "title": "Sitecore Hackathon 2023",
+      "copy": "Sitecore Hackathon is a free online community-driven event organized by Akshay Sura and supported by Sitecore. Sign your team up by 6 pm EST on February 17, 2023, for the opportunity to participate in a contest.",
+      "image": "https://go.sitecore.com/l/857953/2022-10-15/r7d55k/857953/1665888525QVNM1kKz/Pink_Inspirational_Instagram_Quote.png",
+      "link": {
+        "text": "Sign up now",
+        "href": "https://sitecorehackathon.org/sitecore-hackathon-2023/"
+      },
+      "variant": "full-width"
+    }
+  ]
+}

--- a/apps/devportal/data/newsletters/2023/02.json
+++ b/apps/devportal/data/newsletters/2023/02.json
@@ -1,0 +1,134 @@
+{
+  "title": "Sitecore Developers",
+  "description": "Find out the latest news and updates in the Sitecore community.",
+  "content": [
+    {
+      "title": "Closing Keynote Speaker at SUGCON - Scott Hanselman",
+      "copy": "If you did not hear the news, Scott Hanselman from Microsoft is virtually joining us as the closing keynote speaker at SUGCON Europe 2023. Don’t miss out. Join us on March 23-24 in Malaga, Spain. Tickets are limited; save your spot now.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b6k/857953/1677195523V9twTyhL/6.png",
+      "link": {
+        "text": "Get your ticket now",
+        "href": "https://www.eventbrite.co.uk/e/sitecore-user-group-conference-sugcon-europe-2023-tickets-502549066787"
+      },
+      "variant": "full-width"
+    },
+    {
+      "title": "What is new on the Developer Portal",
+      "copy": "The Developer Portal has an open source repo on GitHub because we want you to be able to contribute and help other developers in the community. Learn about all the changes made since November.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b6v/857953/16771956411tPzfZ2h/7.png",
+      "link": {
+        "href": "https://community.sitecore.com/community?id=community_blog&sys_id=9432e53a1bf42d5038a46421b24bcb4d"
+      }
+    },
+    {
+      "title": "Finding our way with Sitecore Search",
+      "copy": "Learn how the Sitecore team took searching on Sitecore.com to the next level by delivering personalized results across multiple sites.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b6n/857953/16771955851YM0tZHZ/1.png",
+      "link": {
+        "href": "https://www.sitecore.com/dx/finding-our-way-with-sitecore-search"
+      }
+    },
+    {
+      "title": "Sitecore Personalize and Mobile App Projects Series",
+      "copy": "This series of blog posts will cover all aspects of delivering personalized content to end users of a mobile app.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b6r/857953/1677195616bBljtKpD/3.png",
+      "link": {
+        "href": "https://360agileweb.dev/2023/02/03/sitecore-personalize-and-mobile-app-projects-series-part-2/"
+      }
+    },
+    {
+      "title": "Coresampler 200th Episode ft. Dave O'Flanagan",
+      "copy": "Dave O'Flanagan, the Chief Product Officer at Sitecore joins Tamas and Jason on Coresampler to celebrate the 200th episode. Learn about his background, insights on leadership, thoughts on the Sitecore community, industry predictions for 2023, and much more!",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b6y/857953/1677195836lBpzmy2o/Untitled_design__1_.png",
+      "link": {
+        "text": "Listen now",
+        "href": "https://coresampler.fm/200"
+      },
+      "variant": "full-width"
+    },
+    {
+      "title": "Creating a Security Center of Excellence With Elastic",
+      "copy": "Discover how Sitecore uses Elastic SIEM for their new ‘Security Operations Center as a Service’ offering (SOCaaS), which has allowed the company to automate more than 91% of their workflows, increasing productivity in security and compliance, which has reduced time-to-fix issues with minimal human capital.",
+      "image": "https://go.sitecore.com/l/857953/2022-08-28/p367y4/857953/1661735383bBfR66Yb/3.png",
+      "link": {
+        "href": "https://www.elastic.co/elasticon/archive/2022/amsterdam/sitecore"
+      }
+    },
+    {
+      "title": "Content Hub One to Drive Content in Sitecore Personalize",
+      "copy": "Sitecore Personalize is an excellent tool for managing the execution of a personalization solution. However, it doesn’t do a great job of managing the content for those experiences. Check out some techniques described for integrating Content Hub One with Sitecore Personalize",
+      "image": "https://go.sitecore.com/l/857953/2022-08-28/p367yb/857953/1661735436uMJcQfid/4.png",
+      "link": {
+        "href": "https://blogs.perficient.com/2023/02/14/using-content-hub-one-to-drive-content-in-sitecore-personalize/"
+      }
+    },
+    {
+      "title": "Sitecore Basic CDP Project",
+      "copy": "Check out this Sitecore CDP project. This project was developed using ASP.NET MVC and created/tested using Sitecore 10.2 and 10.3.",
+      "image": "https://go.sitecore.com/l/857953/2022-07-26/mjr5hm/857953/1658871187EaGFBnKo/Pink_Floral_Motivational_Instagram_Post.png",
+      "link": {
+        "href": "https://coderslifeline.blogspot.com/2023/02/sitecore-basic-cdp-project.html"
+      }
+    },
+    {
+      "title": "3 Big Changes in The New Next.js App Folder Architecture",
+      "copy": "In Next.js 13.1, the new app directory-based architecture beta was released. The new architecture is a significant change to Next.js. Learn how component rendering, data fetching, and routing have changed inside the app directory.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b7y/857953/1677197080Z4pe4UVH/GettyImages_924212022.jpg",
+      "link": {
+        "href": "https://thetombomb.com/posts/nextjs-app-architecture"
+      }
+    },
+    {
+      "title": "Mastering XM Cloud series",
+      "copy": "If you are just curious about Sitecore XM Cloud, or are taking early steps with this platform, read through the Mastering XM Cloud series. Learn about the new SaaS offering from Sitecore as of today.",
+      "image": "https://go.sitecore.com/l/857953/2022-08-28/p367z1/857953/1661735576D5cjrN65/6.png",
+      "link": {
+        "href": "https://www.linkedin.com/posts/martin-miles_sitecore-xmcloud-activity-7018269087663341568-RKWU/"
+      }
+    },
+    {
+      "title": "A first look at Sitecore Connect",
+      "copy": "In this episode Josh Hover is joined by Ivan Lieckens, Product Manager, Product Connectors at Sitecore. Ivan leads the product delivery team for Sitecore Connect, and in this episode, they discuss Connect and an overview of how it can best be leveraged.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b85/857953/16771971614uABjMou/GettyImages_1333935767.jpg",
+      "link": {
+        "text": "Listen now",
+        "href": "https://fireside-sitecore-community-discussion.buzzsprout.com/2049944/12294302-a-first-look-at-sitecore-connect"
+      }
+    },
+    {
+      "title": "Join the Sitecore Community Mentor Program",
+      "copy": "The Community Mentor Program pairs existing Sitecore MVPs with Sitecore enthusiasts looking to kick-start their journey in contributing to the community. The deadline to join this program as a mentor or mentee is the end of February.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b9n/857953/1677200391rWq2RkMq/2.png",
+      "link": {
+        "text": "Learn more",
+        "href": "https://mvp.sitecore.com/Mentor-Program"
+      },
+      "variant": "full-width"
+    },
+    {
+      "title": "XM Cloud, PowerShell, and remoting",
+      "copy": "Sitecore XM / XM Cloud wouldn’t be as powerful as it is without the power of PowerShell. Learn how to enable PowerShell ISE (disabled by default) and PowerShell remoting.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b8r/857953/1677198494H7T4Waq0/4.png",
+      "link": {
+        "href": "https://www.sergevandenoever.nl/XM_Cloud_PowerShell_And_Remoting/"
+      }
+    },
+    {
+      "title": "Sitecore Connect FAQ",
+      "copy": "This FAQ addresses common questions customers or partners may have regarding the roadmap vision for taking Sitecore to the next level of SaaS.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b8y/857953/16771986915dZZt8cw/Untitled_design__2_.png",
+      "link": {
+        "href": "https://developers.sitecore.com/learn/faq/sitecore-connect"
+      }
+    },
+    {
+      "title": "Sitecore Content Hub one: Crawl, Walk & Run",
+      "copy": "Learn through an introduction to modeling, content creation, using the CLI, and using Content Management-, Delivery- and Preview API.",
+      "image": "https://go.sitecore.com/l/857953/2023-02-23/tw3b72/857953/1677195885uutYtt2O/GettyImages_1340755880.jpg",
+      "link": {
+        "text": "Watch now",
+        "href": "https://www.youtube.com/watch?v=hwJ06833_qM"
+      }
+    }
+  ]
+}

--- a/apps/devportal/src/common/static-paths.ts
+++ b/apps/devportal/src/common/static-paths.ts
@@ -125,6 +125,7 @@ export const NEWSLETTER_DATA_DIRECTORY = path.join(process.cwd(), 'data/newslett
 
 export const getNewsletterStaticPaths = (): NewsletterPath[] => {
   const years = fs.readdirSync(NEWSLETTER_DATA_DIRECTORY);
+  years.sort().reverse();
 
   const paths: NewsletterPath[] = [];
 
@@ -132,6 +133,7 @@ export const getNewsletterStaticPaths = (): NewsletterPath[] => {
     const yearPath = path.resolve(NEWSLETTER_DATA_DIRECTORY, year);
     const months = fs.readdirSync(yearPath);
 
+    months.sort().reverse();
     months.forEach((month) => {
       paths.push({ params: { year, month: month.substring(0, month.length - 5) } });
     });

--- a/apps/devportal/src/pages/newsletter/index.tsx
+++ b/apps/devportal/src/pages/newsletter/index.tsx
@@ -35,7 +35,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
     const newsletters = [];
 
-    years.sort();
+    years.sort().reverse();
 
     // Using for loops to shortcut early
     for (let i = 0; i < years.length; i++) {


### PR DESCRIPTION

## Description / Motivation

The developer portal was missing December 2022, January 2023, and February 2023. Also, sorting was fixed on /newsletter page and nav bar when reading newsletters.  Adding new year of 2023 was not handled properly and also sorting changes need to be made now that more than the max 12 newsletters in navbar are present. 

## How Has This Been Tested?

Manual testing on branch

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
