### PR TITLE
Hero banner improvements

### DIFF
--- a/apps/devportal/data/markdown/pages/home/index.md
+++ b/apps/devportal/data/markdown/pages/home/index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sitecore Developer Portal'
-description: 'Enjoy direct access to the tools and information you need most in a portal created to enhance your developer experience.'
+description: 'Direct access to the tools and information you need most in a portal created to enhance your developer experience.'
 stackexchange: ['/questions?tab=Newest']
 youtube: 'UUJrNXcAEmZrqbf2suxbfIkg'
 youtubeTitle: 'Latest "Discover Sitecore" videos'

--- a/apps/devportal/src/components/changelog/ChangelogList.tsx
+++ b/apps/devportal/src/components/changelog/ChangelogList.tsx
@@ -70,7 +70,7 @@ const ChangelogList = ({ initialProduct }: ChangelogListProps): JSX.Element => {
       </div>
       {!error && data && <ChangelogResultsList entries={items} isLoading={false} hasNext={data[data.length - 1].hasNext} onEndTriggered={() => setSize(size + 1)} />}
 
-      {data && !data[data.length - 1].hasNext && <span className={`border-violet text-violet dark:border-teal dark:text-teal mt-5 inline-block w-full border-2 py-2 px-3 text-center text-sm`}>No more results</span>}
+      {data && !data[data.length - 1].hasNext && <span className={`border-violet text-violet dark:border-teal dark:text-teal mt-5 inline-block w-full border-2 px-3 py-2 text-center text-sm`}>No more results</span>}
     </div>
   );
 };

--- a/apps/devportal/src/pages/changelog/[product]/[entry].tsx
+++ b/apps/devportal/src/pages/changelog/[product]/[entry].tsx
@@ -1,15 +1,17 @@
-import { ChangelogEntryByTitle, GetProducts } from '@/../../packages/sc-changelog/changelog';
-import Product from '@/../../packages/sc-changelog/types/product';
-import { getSlug, slugify } from '@/../../packages/sc-changelog/utils/stringUtils';
-import Container from '@/../../packages/ui/components/common/Container';
-import TextLink from '@/../../packages/ui/components/common/TextLink';
-import VerticalGroup from '@/../../packages/ui/components/common/VerticalGroup';
-import Hero from '@/../../packages/ui/components/heros/Hero';
-import Layout from '@/../../packages/ui/layouts/Layout';
 import ChangelogByMonth from '@/src/components/changelog/ChangelogByMonth';
 import { ChangelogItemMeta } from '@/src/components/changelog/ChangelogItemMeta';
 import Image from 'next/image';
-import { ChangelogEntry } from '../../../../../../packages/sc-changelog/types/changeLogEntry';
+import Link from 'next/link';
+import { ChangelogEntryByTitle, GetProducts } from 'sc-changelog/changelog';
+import { ChangelogEntry } from 'sc-changelog/types/changeLogEntry';
+import Product from 'sc-changelog/types/product';
+import { getSlug, slugify } from 'sc-changelog/utils/stringUtils';
+import { Alert } from 'ui/components/common/Alert';
+import Container from 'ui/components/common/Container';
+import TextLink from 'ui/components/common/TextLink';
+import VerticalGroup from 'ui/components/common/VerticalGroup';
+import Hero from 'ui/components/heros/Hero';
+import Layout from 'ui/layouts/Layout';
 
 type ChangelogProps = {
   currentProduct: Product;
@@ -43,12 +45,34 @@ export async function getServerSideProps(context: any) {
 const ChangelogProduct = ({ currentProduct, changelogEntry }: ChangelogProps) => {
   return (
     <Layout title={`Release Notes ${currentProduct.name}`} description="Empty">
-      <Hero title={`${currentProduct.name} Changelog`} description={`Learn more about new versions, changes and improvements we made to ${currentProduct.name}`} />
+      <Hero title={`${currentProduct.name} Changelog`} description={`Learn more about new versions, changes and improvements we made to ${currentProduct.name}`}>
+        <div className="absolute flex h-8 flex-row dark:hidden">
+          <span className="mr-1 text-xs">Powered by</span>
+          <Link href="/content-management/content-hub-one" title="Visit the Content Hub ONE product page to learn more">
+            <Image src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/91c3d57209b042ff9aacfee56125ef0e" className="transition hover:scale-105" alt="Powered by Content Hub ONE" width={150} height={18} priority={true} />
+          </Link>
+        </div>
+        <div className="absolute hidden h-8 flex-row dark:flex">
+          <span className="mr-1 text-xs">Powered by</span>
+          <Link href="/content-management/content-hub-one" title="Visit the Content Hub ONE product page to learn more">
+            <Image src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/d5e8689d29cc4ef49a74b96e2149af13" className="transition hover:scale-105" alt="Powered by Content Hub ONE" width={150} height={18} priority={true} />
+          </Link>
+        </div>
+      </Hero>
       <VerticalGroup>
         <Container>
+          <Alert icon="info">
+            <p>
+              You are viewing the public preview of the upcoming Sitecore global changelog.
+              <Link href="/changelog/current" title="View the list of current release notes per product" className="mx-1 font-bold hover:underline">
+                Click here
+              </Link>
+              for the current release notes per product
+            </p>
+          </Alert>
           <div className="mt-8 grid gap-16 md:grid-cols-5">
             <div className="changelog-item col-span-3">
-              <nav className="mt-4 mb-8 flex" aria-label="Breadcrumb">
+              <nav className="mb-8 mt-4 flex" aria-label="Breadcrumb">
                 <ol className="inline-flex items-center space-x-1 md:space-x-3">
                   <li className="inline-flex items-center">
                     <a href="/changelog" className="text-theme-text-alt inline-flex items-center text-sm font-medium">

--- a/apps/devportal/src/pages/changelog/[product]/index.tsx
+++ b/apps/devportal/src/pages/changelog/[product]/index.tsx
@@ -1,11 +1,14 @@
 import { getChangelogProductPaths } from '@/src/common/static-paths';
 import ChangelogByMonth from '@/src/components/changelog/ChangelogByMonth';
 import ChangelogList from '@/src/components/changelog/ChangelogList';
+import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { GetProducts } from 'sc-changelog/changelog';
 import Product from 'sc-changelog/types/product';
 import { slugify } from 'sc-changelog/utils/stringUtils';
 import SmallLinkButton from 'ui/components/buttons/SmallLinkButton';
+import { Alert } from 'ui/components/common/Alert';
 import Container from 'ui/components/common/Container';
 import VerticalGroup from 'ui/components/common/VerticalGroup';
 import Hero from 'ui/components/heros/Hero';
@@ -44,9 +47,31 @@ const ChangelogProduct = ({ currentProduct }: ChangelogProps) => {
   const router = useRouter();
   return (
     <Layout title="Release Notes - Home" description="Empty">
-      <Hero title="Changelog" description="Learn more about new versions, changes and improvements" />
+      <Hero title="Changelog" description="Learn more about new versions, changes and improvements">
+        <div className="absolute flex h-8 flex-row dark:hidden">
+          <span className="mr-1 text-xs">Powered by</span>
+          <Link href="/content-management/content-hub-one" title="Visit the Content Hub ONE product page to learn more">
+            <Image src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/91c3d57209b042ff9aacfee56125ef0e" className="transition hover:scale-105" alt="Powered by Content Hub ONE" width={150} height={18} priority={true} />
+          </Link>
+        </div>
+        <div className="absolute hidden h-8 flex-row dark:flex">
+          <span className="mr-1 text-xs">Powered by</span>
+          <Link href="/content-management/content-hub-one" title="Visit the Content Hub ONE product page to learn more">
+            <Image src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/d5e8689d29cc4ef49a74b96e2149af13" className="transition hover:scale-105" alt="Powered by Content Hub ONE" width={150} height={18} priority={true} />
+          </Link>
+        </div>
+      </Hero>
       <VerticalGroup>
         <Container>
+          <Alert icon="info">
+            <p>
+              You are viewing the public preview of the upcoming Sitecore global changelog.
+              <Link href="/changelog/current" title="View the list of current release notes per product" className="mx-1 font-bold hover:underline">
+                Click here
+              </Link>
+              for the current release notes per product
+            </p>
+          </Alert>
           <div className="mt-8 grid gap-16 md:grid-cols-5">
             <div className="col-span-3">
               <ChangelogList initialProduct={currentProduct} />

--- a/apps/devportal/src/pages/changelog/index.tsx
+++ b/apps/devportal/src/pages/changelog/index.tsx
@@ -1,6 +1,7 @@
 import { ChangelogEntriesPaginated } from '@/../../packages/sc-changelog/changelog';
 import ChangelogByMonth from '@/src/components/changelog/ChangelogByMonth';
 import Head from 'next/head';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { SWRConfig } from 'swr';
@@ -24,7 +25,20 @@ export default function ChangelogHome({ fallback }: ChangelogHomeProps) {
         <link rel="preload" href="/api/changelog/all?" as="fetch" crossOrigin="anonymous" />
       </Head>
       <Layout title="Sitecore's global changelog" description="Learn more about new versions, changes and improvements">
-        <Hero title="Changelog" description="Learn more about new versions, changes and improvements" />
+        <Hero title="Changelog" description="Learn more about new versions, changes and improvements">
+          <div className="absolute flex h-8 flex-row dark:hidden">
+            <span className="mr-1 text-xs">Powered by</span>
+            <Link href="/content-management/content-hub-one" title="Visit the Content Hub ONE product page to learn more">
+              <Image src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/91c3d57209b042ff9aacfee56125ef0e" className="transition hover:scale-105" alt="Powered by Content Hub ONE" width={150} height={18} priority={true} />
+            </Link>
+          </div>
+          <div className="absolute hidden h-8 flex-row dark:flex">
+            <span className="mr-1 text-xs">Powered by</span>
+            <Link href="/content-management/content-hub-one" title="Visit the Content Hub ONE product page to learn more">
+              <Image src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/d5e8689d29cc4ef49a74b96e2149af13" className="transition hover:scale-105" alt="Powered by Content Hub ONE" width={150} height={18} priority={true} />
+            </Link>
+          </div>
+        </Hero>
         <VerticalGroup>
           <Container>
             <Alert icon="info">

--- a/packages/ui/components/buttons/EditButton.tsx
+++ b/packages/ui/components/buttons/EditButton.tsx
@@ -5,7 +5,7 @@ type EditButtonProps = {
 };
 
 const EditButton = ({ editUrl, classes }: EditButtonProps): JSX.Element => {
-  return <SmallLinkButton text={'Suggets an edit'} href={editUrl} icon={'edit'} className={classes} />;
+  return <SmallLinkButton text={'Suggest an edit'} href={editUrl} icon={'edit'} className={classes} />;
 };
 
 export default EditButton;

--- a/packages/ui/components/common/ProductImage.tsx
+++ b/packages/ui/components/common/ProductImage.tsx
@@ -8,12 +8,12 @@ export type ProductImageProps = {
 
 const ProductImage = ({ productLogo, className }: ProductImageProps): JSX.Element => (
   <React.Fragment>
-    <div className="relative hidden md:col-span-4 md:block">
+    <div className="relative md:col-span-4 md:block">
       <div className={`hidden h-16 w-full dark:block ${className != undefined ? className : ''}`}>
-        <ProductLogo product={productLogo} variant="Dark" className="h-16" />
+        <ProductLogo product={productLogo} variant="Dark" width={400} height={100} />
       </div>
       <div className={`h-16 w-full dark:hidden ${className}`}>
-        <ProductLogo product={productLogo} variant="Light" className="h-16" />
+        <ProductLogo product={productLogo} variant="Light" width={400} height={100} />
       </div>
     </div>
   </React.Fragment>

--- a/packages/ui/components/common/ProductLogo.tsx
+++ b/packages/ui/components/common/ProductLogo.tsx
@@ -1,28 +1,20 @@
 import Image from 'next/image';
 import { GetProductLogo } from '../../common/assets';
-
 export type ProductLogoProps = {
   product: string;
   variant: string;
   alt?: string;
   className?: string;
+  width?: number;
+  height?: number;
 };
 
-const ProductLogo = ({ product, variant, alt, className }: ProductLogoProps): JSX.Element => {
+const ProductLogo = ({ product, variant, alt, className, width, height }: ProductLogoProps): JSX.Element => {
   const productImage = GetProductLogo(product, variant);
 
-  return (
-    <Image
-      src={productImage}
-      alt={alt != null ? alt : ''}
-      className={`relative z-10 ${className}`}
-      fill
-      sizes="(max-width: 768px) 100vw,
-          (max-width: 1200px) 50vw,
-          33vw"
-      priority={true}
-    />
-  );
+  //return <img src={productImage} alt={alt != null ? alt : ''} width={width} height={height} />;
+
+  return <Image src={productImage} alt={alt != null ? alt : ''} className={`relative z-10 ${className}`} fill={width && height ? false : true} priority={true} width={width} height={height} />;
 };
 
 ProductLogo.defaultProps = {

--- a/packages/ui/components/heros/Hero.styles.css
+++ b/packages/ui/components/heros/Hero.styles.css
@@ -1,11 +1,11 @@
 @layer components {
   .theme-light .wide-hero {
     background-image: url('/images/heros/hero-wide-light.webp');
-    height: 212px;
+    /*height: 212px;*/
   }
 
   .theme-dark .wide-hero {
     background-image: url('/images/heros/hero-wide-dark.webp');
-    height: 212px;
+    /*height: 212px;*/
   }
 }

--- a/packages/ui/components/heros/Hero.tsx
+++ b/packages/ui/components/heros/Hero.tsx
@@ -23,7 +23,7 @@ const Hero = ({ description, headingLevel = 'h1', title, image, productLogo, chi
       <Container size="standard" className="grid gap-16 lg:items-center">
         <div className="flex flex-col md:col-span-5 lg:pr-24">
           <h1 className="heading-md md:heading-lg relative mb-4 md:mt-5 ">{title}</h1>
-          <h2 className="text-theme-text-alt md:order-first md:uppercase md:tracking-widest">{description}</h2>
+          <h2 className="text-theme-text-alt text-xs md:order-first md:uppercase md:tracking-widest">{description}</h2>
           <div className="order-last mt-2 md:mt-0">{children}</div>
         </div>
       </Container>

--- a/packages/ui/components/heros/Hero.tsx
+++ b/packages/ui/components/heros/Hero.tsx
@@ -10,19 +10,21 @@ export type HeroProps = {
   description?: string;
   image?: string;
   productLogo?: string;
+  children?: React.ReactNode | React.ReactNode[];
 };
 
-const Hero = ({ description, headingLevel = 'h1', title, image, productLogo }: HeroProps): JSX.Element => {
+const Hero = ({ description, headingLevel = 'h1', title, image, productLogo, children }: HeroProps): JSX.Element => {
   if (productLogo != null || image != null) {
     return <ProductHero title={title} description={description} image={image} productLogo={productLogo} headingLevel={headingLevel} />;
   }
 
   return (
-    <header className="wide-hero relative bg-cover py-14">
+    <header className="wide-hero relative bg-cover py-8">
       <Container size="standard" className="grid gap-16 lg:items-center">
-        <div className="md:col-span-5 lg:pr-24">
-          <h1 className="heading-lg relative mb-5">{title}</h1>
-          <h2 className="text-theme-text-alt">{description}</h2>
+        <div className="flex flex-col md:col-span-5 lg:pr-24">
+          <h1 className="heading-md md:heading-lg relative mb-4 md:mt-5 ">{title}</h1>
+          <h2 className="text-theme-text-alt md:order-first md:uppercase md:tracking-widest">{description}</h2>
+          <div className="order-last mt-2 md:mt-0">{children}</div>
         </div>
       </Container>
     </header>

--- a/packages/ui/components/heros/ProductHero.tsx
+++ b/packages/ui/components/heros/ProductHero.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { ValidHeadingLevels } from 'ui/common/types/heading-levels';
 import Container from 'ui/components/common/Container';
 import DynamicTag from 'ui/components/common/DynamicTag';
-import ProductLogo from 'ui/components/common/ProductLogo';
+import ProductImage from '../common/ProductImage';
 // Components
 
 export type ProductHeroProps = {
@@ -25,26 +25,20 @@ const ProductHero = ({ description, headingLevel = 'h1', title, image, productLo
       <link rel="preload" href="/images/heros/hero-wide-light.webp" as="image" />
       <link rel="preload" href="/images/heros/hero-wide-dark.webp" as="image" />
     </Head>
-    <header className={` relative py-14 ${!image || !!productLogo ? HeroWithBackgroundImageClasses : ''}`}>
-      <Container size="standard" className={`grid gap-16 lg:items-center ${!!image || !!productLogo ? HeroWithImageClasses : ''}`}>
-        <div className={`lg:pr-24 ${!!image || !!productLogo ? ['md:col-span-5'] : ''}`}>
-          <DynamicTag tag={headingLevel} className="heading-lg relative mb-5">
+    <header className={` relative py-2 md:py-8 ${!image || !!productLogo ? HeroWithBackgroundImageClasses : ''}`}>
+      <Container size="standard" className={`grid gap-16 ${!!image || !!productLogo ? HeroWithImageClasses : ''}`}>
+        <div className={`flex flex-col lg:pr-24 ${!!image || !!productLogo ? ['md:col-span-9'] : ''}`}>
+          <DynamicTag tag={headingLevel} className={`heading-lg relative mb-5 ${productLogo ? 'sr-only' : 'not-sr-only'}`}>
             {title}
           </DynamicTag>
-          <h2 className="text-theme-text-alt">{description}</h2>
-        </div>
-        {productLogo && (
-          <React.Fragment>
-            <div className="relative hidden md:col-span-4 md:block">
-              <div className="hidden h-20 w-full dark:block">
-                <ProductLogo product={productLogo} variant="Dark" />
-              </div>
-              <div className="h-20 w-full dark:hidden">
-                <ProductLogo product={productLogo} variant="Light" />
-              </div>
+          {productLogo && productLogo?.length > 0 && (
+            <div className="relative mb-4 md:col-span-5 md:mb-0">
+              <ProductImage productLogo={productLogo} />
             </div>
-          </React.Fragment>
-        )}
+          )}
+          <h2 className="text-theme-text-alt text-xs uppercase tracking-widest md:order-first md:text-base">{description}</h2>
+        </div>
+
         {image && (
           <React.Fragment>
             <div className="relative hidden md:col-span-4 md:block">

--- a/packages/ui/components/heros/ProductHero.tsx
+++ b/packages/ui/components/heros/ProductHero.tsx
@@ -36,7 +36,7 @@ const ProductHero = ({ description, headingLevel = 'h1', title, image, productLo
               <ProductImage productLogo={productLogo} />
             </div>
           )}
-          <h2 className="text-theme-text-alt text-xs uppercase tracking-widest md:order-first md:text-base">{description}</h2>
+          <h2 className="text-theme-text-alt text-xs uppercase tracking-widest md:order-first">{description}</h2>
         </div>
 
         {image && (

--- a/packages/ui/styles/buttons.css
+++ b/packages/ui/styles/buttons.css
@@ -7,11 +7,11 @@
     @apply btn-primary-500 hover:border-theme-border text-theme-text-alt hover:bg-theme-bg bg-theme-bg mr-3 flex items-center border border-white px-4 py-2 text-xs font-medium transition-all hover:border hover:text-gray-300 focus:z-10 focus:outline-none focus:ring-2 dark:hover:text-gray-500 dark:focus:ring-gray-500;
   }
   .btn-secondary-invert {
-    @apply bg-blackAlpha-800 hover:bg-blackAlpha-400 mt-4 mr-0 flex transform-gpu items-center rounded-lg px-2 py-2 text-xs text-white transition-colors dark:hover:bg-teal-500 dark:hover:text-white;
+    @apply bg-blackAlpha-800 hover:bg-blackAlpha-400 mr-0 mt-4 flex transform-gpu items-center rounded-lg px-2 py-2 text-xs text-white transition-colors dark:hover:bg-teal-500 dark:hover:text-white;
   }
 
   .btn-textlink {
-    @apply hover:bg-primary-500 mt-4 mr-0 flex items-center rounded-full px-2 py-1 text-xs text-gray-600 hover:text-white dark:text-teal-500 dark:hover:bg-teal-500;
+    @apply hover:bg-primary-500 mr-0 mt-4 flex items-center rounded-full px-2 py-1 text-xs text-gray-600 hover:text-white dark:text-teal-500 dark:hover:bg-teal-500;
   }
   .play-button-outside {
     @apply ml-1 inline-block h-5 w-5 transform-gpu transition-transform duration-300 group-hover:translate-x-1 group-focus:translate-x-1;
@@ -29,13 +29,13 @@
     @apply inline-flex items-center text-sm font-bold no-underline hover:underline focus:underline;
   }
   .btn-iconlink {
-    @apply hover:bg-theme-bg text-2xs m-1 inline-flex items-center rounded-2xl border border-white fill-gray-500 px-4 py-2 font-medium text-gray-500 no-underline transition-all duration-500 hover:border hover:border-gray-300 hover:text-gray-500 focus:z-10 focus:outline-none focus:ring-2 dark:focus:ring-gray-500;
+    @apply hover:bg-theme-bg text-2xs m-1 inline-flex items-center rounded-2xl border border-white fill-gray-500 px-4 py-2 font-medium text-gray-500 no-underline transition-all duration-500 hover:border hover:border-gray-300 focus:z-10 focus:outline-none focus:ring-2 dark:text-gray-100 dark:hover:bg-gray-700 dark:hover:text-gray-100 dark:focus:ring-gray-500;
   }
   .btn-nav-back {
     @apply bg-primary-500 hover:bg-primary-700 relative h-14 w-full transform-gpu pl-10 pr-4 text-left font-semibold text-white transition-colors lg:hidden;
   }
   .btn-nav-back-icon-outer {
-    @apply h-em w-em pointer-events-none absolute top-5 left-4 block;
+    @apply h-em w-em pointer-events-none absolute left-4 top-5 block;
   }
   .btn-nav-back-icon {
     @apply h-inherit w-inherit top-5 transform-gpu transition-transform group-hover:-translate-x-1;

--- a/packages/ui/styles/buttons.css
+++ b/packages/ui/styles/buttons.css
@@ -29,7 +29,7 @@
     @apply inline-flex items-center text-sm font-bold no-underline hover:underline focus:underline;
   }
   .btn-iconlink {
-    @apply hover:bg-theme-bg text-2xs m-1 inline-flex items-center rounded-2xl border border-white fill-gray-500 px-4 py-2 font-medium text-gray-500 no-underline transition-all duration-500 hover:border hover:border-gray-300 focus:z-10 focus:outline-none focus:ring-2 dark:text-gray-100 dark:hover:bg-gray-700 dark:hover:text-gray-100 dark:focus:ring-gray-500;
+    @apply hover:bg-theme-bg text-2xs m-1 inline-flex items-center rounded-2xl border border-white fill-gray-500 px-4 py-2 font-medium text-gray-500 no-underline transition-all duration-500 hover:border hover:border-gray-300 focus:z-10 focus:outline-none dark:border-0 dark:text-gray-100 dark:hover:bg-gray-700 dark:hover:text-gray-100;
   }
   .btn-nav-back {
     @apply bg-primary-500 hover:bg-primary-700 relative h-14 w-full transform-gpu pl-10 pr-4 text-left font-semibold text-white transition-colors lg:hidden;


### PR DESCRIPTION
## Description / Motivation
This PR introduces new functionality for the Hero banner used on all pages. 
- Visual changes to align hero with sitecore.com style
- Using product images as title when image specified (renders title for screen readers)
- Introduced option to add "children" to the hero component for custom messaging
- Adds powered by CH ONE to Changelog

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-git-feature-cc06b5-sitecoretechnicalmarketing.vercel.app/)

The Hero banner has three different "modes"

- **Simple version with title and description** [(Example)](https://developer-portal-git-feature-cc06b5-sitecoretechnicalmarketing.vercel.app/learn)
In desktop mode the description is shown first, all caps and with a wider character spacing to match the style used on sitecore.com

- **Product version** [(old)](https://developers.sitecore.com/content-management/xm-cloud) vs [(new)](https://developer-portal-git-feature-cc06b5-sitecoretechnicalmarketing.vercel.app/content-management/xm-cloud)
The product version of the component only shows the actual product logo and description, instead of showing both the title and logo as it was previously. 

- **Custom content version** [(example)](https://developer-portal-git-feature-cc06b5-sitecoretechnicalmarketing.vercel.app/changelog)
The Hero component now has the ability to use custom content defined as children of the component. In this particular case its being used to highlight that the Changelog is power by CH ONE. 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
