### PR TITLE
Support for multiple frameworks in repository

### DIFF
--- a/apps/devportal/data/markdown/partials/solution/content-management/xm-cloud.md
+++ b/apps/devportal/data/markdown/partials/solution/content-management/xm-cloud.md
@@ -56,7 +56,7 @@ The importance of your company's growth comes with the:
 <Row columns={3}>
 <Repository framework="Nextjs" name="Headless SXA Starter Kit" description="This solution is designed to help developers learn and get started quickly with XM Cloud + SXA." repositoryUrl="https://github.com/sitecorelabs/xmcloud-foundation-head" />
 <Repository framework="Nextjs" name="Sitecore PlaySummit Demo" description="The official Sitecore demo used to demo Sitecore DXP including Content Hub and JSS" repositoryUrl="https://github.com/Sitecore/Sitecore.Demo.XmCloud.PlaySummit" />
-<Repository framework="Nextjs" name="Example implementation" description="This repository contains the codebase for a series of sites managed by the developer relations at Sitecore" repositoryUrl="https://github.com/Sitecore/XM-Cloud-Introduction" />
+<Repository framework="Nextjs|DotNET" name="Example implementation" description="This repository contains the codebase for a series of sites managed by the developer relations at Sitecore" repositoryUrl="https://github.com/Sitecore/XM-Cloud-Introduction" />
 </Row>
 
 ### Other Learning

--- a/packages/ui/components/cards/Repository.tsx
+++ b/packages/ui/components/cards/Repository.tsx
@@ -12,8 +12,8 @@ export const Repository = ({ name, description, repositoryUrl, framework }: Repo
   const frameworks = framework.split('|');
   const frameworkLogos: string[] = [];
 
-  frameworks.forEach((x) => {
-    if (isValidLogo(x)) frameworkLogos.push(x);
+  frameworks.forEach((logo) => {
+    if (isValidLogo(logo)) frameworkLogos.push(logo);
   });
 
   return (
@@ -21,8 +21,8 @@ export const Repository = ({ name, description, repositoryUrl, framework }: Repo
       <div className="px-5">
         <div className="ml-auto mr-0 flex flex-row justify-end opacity-75 ">
           {frameworks &&
-            frameworkLogos.map((framework) => {
-              return <SvgLogo logo={framework as Logo} className={`ml-2 h-6`} />;
+            frameworkLogos.map((framework, index) => {
+              return <SvgLogo logo={framework as Logo} className={`ml-4 h-6`} key={index} />;
             })}
         </div>
         {name && <h4>{name}</h4>}


### PR DESCRIPTION
## Description / Motivation
Fixes #398 

Multiple frameworks are supported by using the | separator in the framework property 

`<Repository framework="Nextjs|DotNET" .... />`

## How Has This Been Tested?
Local

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
