### PR TITLE
Fixes invalid selected facet value state

### DIFF
--- a/apps/devportal/src/components/integrations/sitecore-search/SearchFacets.tsx
+++ b/apps/devportal/src/components/integrations/sitecore-search/SearchFacets.tsx
@@ -11,9 +11,9 @@ export const SearchFacets = (props: SearchFacetsType) => {
 
   return (
     <AccordionFacets.Root defaultFacetTypesExpandedList={facets.map((x) => x.name)} onFacetValueClick={onFacetClick}>
-      {facets.map((facet, index) => (
-        <div className="bg-theme-bg-alt mb-6 pt-4 pb-4 pl-4" key={index}>
-          <AccordionFacets.Facet key={index} facetId={facet.name}>
+      {facets.map((facet) => (
+        <div className="bg-theme-bg-alt mb-6 pt-4 pb-4 pl-4" key={facet.name}>
+          <AccordionFacets.Facet facetId={facet.name}>
             <AccordionFacets.Header className="font-ltpro mb-1">
               <AccordionFacets.Trigger className="w-full text-left text-sm font-semibold uppercase">{facet.label}</AccordionFacets.Trigger>
             </AccordionFacets.Header>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes invalid selected facet value state in search results page

## Description / Motivation

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
### Steps to reproduce:

- Open https://developer-portal-git-sitecore-search-sitecoretechnicalmarketing.vercel.app/search?q=dxp
- Check `Type -> Video`
- Wait until results for the selected facet are rendered

#### Expected result:

`Type -> Video` should be still checked

#### Current result:

`Type -> Video` is un-ckecked
<img width="1240" alt="image" src="https://user-images.githubusercontent.com/29154192/233411283-2b753306-2073-440f-baa0-f2f2012e636e.png">

### Why?

An index `key` is used for facet components causing wrong node mapping by the VirtualDOM after re-rendering the received facets (see https://articles.wesionary.team/using-index-as-a-key-is-an-anti-pattern-in-react-8e5db3aea3a9)

### Fix

Use the `facet` name as the facet component `key`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
