### PR TITLE
Updating title for changelog to match the H1

### DIFF
--- a/apps/devportal/src/pages/changelog/[product]/[entry].tsx
+++ b/apps/devportal/src/pages/changelog/[product]/[entry].tsx
@@ -46,7 +46,7 @@ export async function getServerSideProps(context: any) {
 
 const ChangelogProduct = ({ currentProduct, changelogEntry }: ChangelogProps) => {
   return (
-    <Layout title={`Release Notes ${currentProduct.name}`} description="Empty">
+    <Layout title={`${currentProduct.name} Changelog`} description="Empty">
       <Hero title={`${currentProduct.name} Changelog`} description={`Learn more about new versions, changes and improvements we made to ${currentProduct.name}`}>
         <div className="absolute flex h-8 flex-row dark:hidden">
           <span className="mr-1 text-xs">Powered by</span>

--- a/apps/devportal/src/pages/changelog/[product]/index.tsx
+++ b/apps/devportal/src/pages/changelog/[product]/index.tsx
@@ -47,7 +47,7 @@ export async function getStaticProps(context: any) {
 const ChangelogProduct = ({ currentProduct }: ChangelogProps) => {
   const router = useRouter();
   return (
-    <Layout title="Release Notes - Home" description="Empty">
+    <Layout title="Changelog - Home" description="Empty">
       <Hero title="Changelog" description="Learn more about new versions, changes and improvements">
         <div className="absolute flex h-8 flex-row dark:hidden">
           <span className="mr-1 text-xs">Powered by</span>


### PR DESCRIPTION
## Description / Motivation

The title for the Changelog listing and detailed entry page read "Release Notes" instead of "Changelog". This change aligns the page's <title> with the H1 hero title.

## How Has This Been Tested?

Tested on the Vercel branch.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
