### PR TITLE
Add image modal for changelog images

### DIFF
--- a/apps/devportal/src/components/changelog/ChangeLogItem.tsx
+++ b/apps/devportal/src/components/changelog/ChangeLogItem.tsx
@@ -18,7 +18,10 @@ const skeletonLoaderClasses = 'bg-theme-text-alt animate-pulse text-transparent 
 
 const ChangeLogItem = ({ item, loading, loadEntries, isLast, isMore }: ChangeLogItemProps): JSX.Element => {
   const [showModal, setShowModal] = useState(false);
+  const [imgLoading, setImgLoading] = useState(false);
+
   const entryRef = useRef(null);
+
   /**
    * Implement Intersection Observer to check if the last item in the array is visible on the screen, then set a new limit
    */
@@ -63,7 +66,31 @@ const ChangeLogItem = ({ item, loading, loadEntries, isLast, isMore }: ChangeLog
             <div className="fixed inset-0 z-50 overflow-y-auto ">
               <div className="fixed inset-0 h-full w-full cursor-pointer backdrop-blur-sm " onClick={() => setShowModal(false)}>
                 <div className="flex h-screen items-center justify-center drop-shadow-xl ">
-                  <Image src={`${item.image[0].fileUrl}`} alt={item.title || ''} width={item.image[0].fileWidth} height={item.image[0].fileHeight} className={`${loading ? 'hidden' : 'rounded-lg'}`} />
+                  {imgLoading && (
+                    <div role="status" className="position-center relative mt-16 text-center align-middle">
+                      <svg aria-hidden="true" className="fill-primary-500 mr-2 inline h-8 w-8 animate-spin text-white dark:text-gray-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path
+                          d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                          fill="currentColor"
+                        />
+                        <path
+                          d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                          fill="currentFill"
+                        />
+                      </svg>
+                      <span>Loading...</span>
+                    </div>
+                  )}
+
+                  <Image
+                    src={`${item.image[0].fileUrl}`}
+                    alt={item.title || ''}
+                    width={item.image[0].fileWidth}
+                    height={item.image[0].fileHeight}
+                    className="rounded-lg"
+                    onLoad={() => setImgLoading(true)}
+                    onLoadingComplete={() => setImgLoading(false)}
+                  />
                 </div>
               </div>
             </div>

--- a/apps/devportal/src/components/changelog/ChangeLogItem.tsx
+++ b/apps/devportal/src/components/changelog/ChangeLogItem.tsx
@@ -18,8 +18,6 @@ const skeletonLoaderClasses = 'bg-theme-text-alt animate-pulse text-transparent 
 
 const ChangeLogItem = ({ item, loading, loadEntries, isLast, isMore }: ChangeLogItemProps): JSX.Element => {
   const [showModal, setShowModal] = useState(false);
-  const [imgLoading, setImgLoading] = useState(false);
-
   const entryRef = useRef(null);
 
   /**
@@ -66,31 +64,7 @@ const ChangeLogItem = ({ item, loading, loadEntries, isLast, isMore }: ChangeLog
             <div className="fixed inset-0 z-50 overflow-y-auto ">
               <div className="fixed inset-0 h-full w-full cursor-pointer backdrop-blur-sm " onClick={() => setShowModal(false)}>
                 <div className="flex h-screen items-center justify-center drop-shadow-xl ">
-                  {imgLoading && (
-                    <div role="status" className="position-center relative mt-16 text-center align-middle">
-                      <svg aria-hidden="true" className="fill-primary-500 mr-2 inline h-8 w-8 animate-spin text-white dark:text-gray-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path
-                          d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-                          fill="currentColor"
-                        />
-                        <path
-                          d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-                          fill="currentFill"
-                        />
-                      </svg>
-                      <span>Loading...</span>
-                    </div>
-                  )}
-
-                  <Image
-                    src={`${item.image[0].fileUrl}`}
-                    alt={item.title || ''}
-                    width={item.image[0].fileWidth}
-                    height={item.image[0].fileHeight}
-                    className="rounded-lg"
-                    onLoad={() => setImgLoading(true)}
-                    onLoadingComplete={() => setImgLoading(false)}
-                  />
+                  <Image src={`${item.image[0].fileUrl}`} alt={item.title || ''} width={item.image[0].fileWidth} height={item.image[0].fileHeight} className="rounded-lg" />
                 </div>
               </div>
             </div>

--- a/apps/devportal/src/components/changelog/ChangeLogItem.tsx
+++ b/apps/devportal/src/components/changelog/ChangeLogItem.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ChangelogEntry } from 'sc-changelog/types/changeLogEntry';
 import { getSlug } from 'sc-changelog/utils/stringUtils';
 import { getChangelogEntryUrl } from 'sc-changelog/utils/urlBuilder';
@@ -17,6 +17,7 @@ export type ChangeLogItemProps = {
 const skeletonLoaderClasses = 'bg-theme-text-alt animate-pulse text-transparent hover:text-transparent';
 
 const ChangeLogItem = ({ item, loading, loadEntries, isLast, isMore }: ChangeLogItemProps): JSX.Element => {
+  const [showModal, setShowModal] = useState(false);
   const entryRef = useRef(null);
   /**
    * Implement Intersection Observer to check if the last item in the array is visible on the screen, then set a new limit
@@ -45,9 +46,29 @@ const ChangeLogItem = ({ item, loading, loadEntries, isLast, isMore }: ChangeLog
       <ChangelogItemMeta item={item} loading={loading} />
 
       {item.image.length > 0 && (
-        <div className={`mb-4  ${loading ? 'w-12' && skeletonLoaderClasses : ''}`}>
-          <Image src={`${item.image[0].fileUrl}?transform=true&width=670&fit=cover&gravity=auto`} alt={item.title || ''} priority className={`${loading ? 'hidden' : 'rounded-lg'}`} width={670} height={100} />
-        </div>
+        <>
+          <div className={`mb-4  ${loading ? 'w-12' && skeletonLoaderClasses : ''}`}>
+            <Image
+              src={`${item.image[0].fileUrl}?transform=true&width=670&fit=cover&gravity=auto`}
+              alt={item.title || ''}
+              priority
+              className={`${loading ? 'hidden' : 'cursor-pointer rounded-lg'}`}
+              width={670}
+              height={100}
+              onClick={() => setShowModal(true)}
+            />
+          </div>
+
+          {showModal ? (
+            <div className="fixed inset-0 z-50 overflow-y-auto ">
+              <div className="fixed inset-0 h-full w-full cursor-pointer backdrop-blur-sm " onClick={() => setShowModal(false)}>
+                <div className="flex h-screen items-center justify-center drop-shadow-xl ">
+                  <Image src={`${item.image[0].fileUrl}`} alt={item.title || ''} width={item.image[0].fileWidth} height={item.image[0].fileHeight} className={`${loading ? 'hidden' : 'rounded-lg'}`} />
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </>
       )}
 
       <div className={`prose dark:prose-invert prose-table:mt-0 my-3 max-w-none text-sm ${loading ? skeletonLoaderClasses : ''}`} dangerouslySetInnerHTML={{ __html: item.description }} />

--- a/apps/devportal/src/pages/changelog/[product]/[entry].tsx
+++ b/apps/devportal/src/pages/changelog/[product]/[entry].tsx
@@ -2,6 +2,7 @@ import ChangelogByMonth from '@/src/components/changelog/ChangelogByMonth';
 import { ChangelogItemMeta } from '@/src/components/changelog/ChangelogItemMeta';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useState } from 'react';
 import { ChangelogEntryByTitle } from 'sc-changelog/changelog';
 import GetProducts from 'sc-changelog/products';
 import { Product } from 'sc-changelog/types';
@@ -45,6 +46,8 @@ export async function getServerSideProps(context: any) {
 }
 
 const ChangelogProduct = ({ currentProduct, changelogEntry }: ChangelogProps) => {
+  const [showModal, setShowModal] = useState(false);
+
   return (
     <Layout title={`${currentProduct.name} Changelog`} description="Empty">
       <Hero title={`${currentProduct.name} Changelog`} description={`Learn more about new versions, changes and improvements we made to ${currentProduct.name}`}>
@@ -97,9 +100,29 @@ const ChangelogProduct = ({ currentProduct, changelogEntry }: ChangelogProps) =>
               <h2 className={`heading-sm font-bolder`}>{changelogEntry.title}</h2>
               <ChangelogItemMeta item={changelogEntry} />
               {changelogEntry.image.length > 0 && (
-                <div className={`'w-12' my-4 `}>
-                  <Image src={`${changelogEntry.image[0].fileUrl}?transform=true&width=620&fit=cover&gravity=auto`} alt={changelogEntry.title || ''} className={`relative z-10 rounded-lg`} width={620} height={100} />
-                </div>
+                <>
+                  <div className="mb-4">
+                    <Image
+                      src={`${changelogEntry.image[0].fileUrl}?transform=true&width=670&fit=cover&gravity=auto`}
+                      alt={changelogEntry.title || ''}
+                      priority
+                      className="cursor-pointer rounded-lg"
+                      width={670}
+                      height={100}
+                      onClick={() => setShowModal(true)}
+                    />
+                  </div>
+
+                  {showModal ? (
+                    <div className="fixed inset-0 z-50 overflow-y-auto ">
+                      <div className="fixed inset-0 h-full w-full cursor-pointer backdrop-blur-sm " onClick={() => setShowModal(false)}>
+                        <div className="flex h-screen items-center justify-center drop-shadow-xl ">
+                          <Image src={`${changelogEntry.image[0].fileUrl}`} alt={changelogEntry.title || ''} width={changelogEntry.image[0].fileWidth} height={changelogEntry.image[0].fileHeight} className="rounded-lg" />
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
+                </>
               )}
 
               <div className={`prose dark:prose-invert my-3 max-w-none text-sm`} dangerouslySetInnerHTML={{ __html: changelogEntry.description }} />

--- a/packages/sc-changelog/types/common/media.ts
+++ b/packages/sc-changelog/types/common/media.ts
@@ -4,8 +4,8 @@ export type Media = {
   fileName: string;
   fileUrl: string;
   description: string;
-  fileWidth: string;
-  fileHeight: string;
+  fileWidth: number;
+  fileHeight: number;
   fileId: string;
   fileSize: string;
   fileType: string;


### PR DESCRIPTION
## Description / Motivation
Adds behavior that allows the user to click the changelog image to load it full with in a modal popup

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-git-feature-b12715-sitecoretechnicalmarketing.vercel.app/changelog)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
