### PR TITLE
add underline to product in meta info

### DIFF
--- a/apps/devportal/src/components/changelog/ChangelogItemMeta.tsx
+++ b/apps/devportal/src/components/changelog/ChangelogItemMeta.tsx
@@ -21,9 +21,9 @@ export const ChangelogItemMeta = ({ item, loading }: ChangelogItemMetaProps) => 
         ) : (
           <React.Fragment>
             <Link href={`/changelog/${getSlug(item.productName)}`} className="">
-              <div className={` text-sm ${loading ? 'w-12' && skeletonLoaderClasses : ''}`}>
-                <div className="absolute h-5 w-5 dark:hidden">
-                  <Image src={item.lightIcon} alt={item.productName} className={`${loading ? 'hidden' : ''}`} width={20} height={20} priority={true} />
+              <div className={` text-sm ${loading ? 'w-12' && skeletonLoaderClasses : ''} hover:underline`}>
+                <div className="absolute h-5 w-5 dark:hidden ">
+                  <Image src={item.lightIcon} alt={item.productName} className={`${loading ? 'hidden' : ''} `} width={20} height={20} priority={true} />
                 </div>
                 <div className="absolute hidden h-5 w-5 dark:block">
                   <Image src={item.darkIcon} alt={item.productName} className={`${loading ? 'hidden' : ''}`} width={20} height={20} priority={true} />


### PR DESCRIPTION
## Description / Motivation
Underline link to product page on changelog entry

## How Has This Been Tested?
Local

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
