### PR TITLE
Date restriction in GraphQL search request

### DIFF
--- a/packages/sc-changelog/lib/search.ts
+++ b/packages/sc-changelog/lib/search.ts
@@ -82,7 +82,7 @@ function buildWhereClause(searchTerm?: string, productId?: string, changeTypeId?
 
   whereClause += buildSearchTermClause(searchTerm);
 
-  //whereClause += `AND: { releaseDate_lt: ${new Date().toISOString()} }`;
+  whereClause += `AND: { releaseDate_lt: ${new Date().toISOString()} }`;
 
   whereClause += closeWHERE;
   return whereClause;


### PR DESCRIPTION
## Description / Motivation
Put back the date restriction on GraphQL request

## How Has This Been Tested?
Local

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
