### PR TITLE
Remove Incorrect YouTube Playlist from Sitecore Search product page

### DIFF
--- a/apps/devportal/data/markdown/pages/solution/content-management/product/search/index.md
+++ b/apps/devportal/data/markdown/pages/solution/content-management/product/search/index.md
@@ -7,5 +7,4 @@ description: 'Intelligent, blazing-fast search.'
 twitter: ['#SitecoreSearch']
 stackexchange: ['#Sitecore-Search']
 partials: ['solution/content-management/search']
-youtube: PL1jJVFm_lGnzqYagW1UahIBeqTIYSBQMc
 ---


### PR DESCRIPTION
Removes the incorrect YouTube playlist from the Sitecore Search product page. There isn't currently a PlayLIst for search videos, once one is created then we can add this back in.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [ x I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM

Closes #441 
