### PR TITLE
Allow periods in changelog url

### DIFF
--- a/packages/sc-changelog/utils/stringUtils.ts
+++ b/packages/sc-changelog/utils/stringUtils.ts
@@ -5,7 +5,7 @@ export function getSlug(value: string) {
 export function slugify(text: string): string {
   return text
     .toLowerCase()
-    .replace(/[^\w\s-]/g, '') // remove non-alphanumeric characters
+    .replace(/[^\w\s-.]/g, '') // remove non-alphanumeric characters except the period
     .replace(/[\s_-]+/g, '-') // replace spaces, underscores, or hyphens with a single hyphen
     .trim();
 }


### PR DESCRIPTION
## Description / Motivation
Allows for periods in changelog urls (fixes #461)

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-git-issue-46-bab2ae-sitecoretechnicalmarketing.vercel.app/changelog)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
