### PR TITLE
Removed trailing slashes from Search Page View calls

### DIFF
--- a/apps/devportal/src/pages/_app.tsx
+++ b/apps/devportal/src/pages/_app.tsx
@@ -41,7 +41,7 @@ function SCDPApp({ Component, pageProps }: AppProps) {
     TagManager.initialize(tagManagerArgs);
     PageController.getContext().setLocaleLanguage('en');
     PageController.getContext().setLocale({ country: 'us', language: 'en' });
-    trackEntityPageViewEvent("content", [{ id: process.env.NEXT_PUBLIC_SEARCH_DOMAIN_ID_PREFIX + document.location.pathname.replace(/[/:.]/g, '_') }]);
+    trackEntityPageViewEvent("content", [{ id: process.env.NEXT_PUBLIC_SEARCH_DOMAIN_ID_PREFIX + document.location.pathname.replace(/[/:.]/g, '_').replace(/_+$/,'') }]);
   });
 
   return (


### PR DESCRIPTION
Fixes current bug where homepage is adding a trailing `/` to the Search Entity Page View call, meaning its ID doesn't match.

Changed to drop all trailing slashes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
