### PR TITLE
Triggering Search Entity Click Event for external sources

### DIFF
--- a/apps/devportal/src/components/integrations/sitecore-search/PreviewSearchInput.tsx
+++ b/apps/devportal/src/components/integrations/sitecore-search/PreviewSearchInput.tsx
@@ -1,6 +1,6 @@
 import { GetProductLogo } from '@/../../packages/ui/common/assets';
 import { toClass } from '@/../../packages/ui/common/text-util';
-import { ActionPropPayload, ItemIndexActionPayload, PreviewSearchSuggestionQuery, SearchResponseSuggestion, WidgetAction, WidgetDataType, usePreviewSearch, widget } from '@sitecore-search/react';
+import { ActionPropPayload, ItemIndexActionPayload, PreviewSearchSuggestionQuery, SearchResponseSuggestion, WidgetAction, WidgetDataType, trackEntityPageViewEvent, usePreviewSearch, widget } from '@sitecore-search/react';
 import { ArticleCard, NavMenu, Presence } from '@sitecore-search/ui';
 import type { PreviewSearchActionProps } from '@sitecore-search/widgets';
 import Image from 'next/image';
@@ -38,6 +38,8 @@ const Articles = ({ loading = false, articles, onItemClick, suggestionsReturned 
               onClick={(e) => {
                 e.preventDefault();
                 onItemClick({ id: article.id || '', index: index });
+                if(article.index_name != 'sitecore-devportal-v2') 
+                  trackEntityPageViewEvent("content", [{ id: article.id }]);
                 window.open(article.url, '_blank');
               }}
             >

--- a/apps/devportal/src/components/integrations/sitecore-search/SearchResults.tsx
+++ b/apps/devportal/src/components/integrations/sitecore-search/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { useSearchResults, widget, WidgetDataType } from '@sitecore-search/react';
+import { trackEntityPageViewEvent, useSearchResults, widget, WidgetDataType } from '@sitecore-search/react';
 import { WidgetComponentProps } from '@sitecore-search/react/types';
 import Image from 'next/image';
 import { ComponentType } from 'react';
@@ -75,6 +75,8 @@ export const SearchResults = (props: SearchResultsType) => {
                           onClick={(e) => {
                             e.preventDefault();
                             onItemClick({ id: result.id || '', index });
+                            if(result.index_name != 'sitecore-devportal-v2') 
+                              trackEntityPageViewEvent("content", [{ id: result.id }]);
                             window.open(result.url, '_blank');
                           }}
                         >


### PR DESCRIPTION
Currently we're only triggering Entity View events for entities hosted on the developer portal. This change also fires that events for search results that are clicked on, hosted on external sources.

We have to ensure we don't fire this event on clicks for documents from the dev portal though as we'll end up double tracking the event then.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM

Closes #474 