### PR TITLE
Bumped Search SDK version

### DIFF
--- a/apps/devportal/package.json
+++ b/apps/devportal/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@remark-embedder/core": "^3.0.1",
     "@remark-embedder/transformer-oembed": "^3.0.0",
-    "@sitecore-search/react": "^1.0.4-alpha.2",
-    "@sitecore-search/ui": "^1.0.4-alpha.2",
+    "@sitecore-search/react": "^1.2.0-alpha.0",
+    "@sitecore-search/ui": "^1.2.0-alpha.0",
     "@types/lodash.throttle": "^4.1.7",
     "axios": "^1.3.5",
     "eslint-config-next": "^13.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
       "dependencies": {
         "@remark-embedder/core": "^3.0.1",
         "@remark-embedder/transformer-oembed": "^3.0.0",
-        "@sitecore-search/react": "^1.0.4-alpha.2",
-        "@sitecore-search/ui": "^1.0.4-alpha.2",
+        "@sitecore-search/react": "^1.2.0-alpha.0",
+        "@sitecore-search/ui": "^1.2.0-alpha.0",
         "@types/lodash.throttle": "^4.1.7",
         "axios": "^1.3.5",
         "eslint-config-next": "^13.4.2",
@@ -1946,21 +1946,26 @@
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
     },
     "node_modules/@sitecore-search/common": {
-      "version": "1.0.4-alpha.2",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/common/-/common-1.0.4-alpha.2.tgz",
-      "integrity": "sha512-yCBVEjketoIQju777cEMCAQM/gL3Aa3e/W/yC9ZRBPQ7N3iJS//httdTPBU42mlUCBEud9TkI+Oj00TPVs3REQ==",
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/common/-/common-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-Ss3BkBpZQU+b/2TO8wdPa+TYRbYJwdgKqxtw4CMvX6HR/V9eqdgwz+beTh9psVj36rvi7G2pP3e78uKorStefA==",
+      "dependencies": {
+        "dot-prop": "^8.0.0",
+        "filter-obj": "^5.1.0",
+        "object.pick": "^1.3.0"
+      },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sitecore-search/core": {
-      "version": "1.0.4-alpha.2",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/core/-/core-1.0.4-alpha.2.tgz",
-      "integrity": "sha512-um2uyvcqpwKxwpNoWm250jDluiqWX8PqMEC/QZSPq68oRNRAY5oVnAcypty34Z2bpATbGKO1mDc0dSrIxC6/3A==",
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/core/-/core-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-8EoiQ96GuT4++hBpNelLxQF5fq1NJR0lnT4+79tcRdy8nKwDkhoEONpUG2kCcz6xdNQMyRU1MRGpBMLl8PiJeQ==",
       "dependencies": {
-        "@sitecore-search/common": "^1.0.4-alpha.2",
-        "@sitecore-search/data": "^1.0.4-alpha.2",
-        "@sitecore-search/models": "^1.0.4-alpha.2",
+        "@sitecore-search/common": "^1.2.0-alpha.0",
+        "@sitecore-search/data": "^1.2.0-alpha.0",
+        "@sitecore-search/models": "^1.2.0-alpha.0",
         "debounce-promise": "^3.1.2"
       },
       "engines": {
@@ -1968,12 +1973,12 @@
       }
     },
     "node_modules/@sitecore-search/data": {
-      "version": "1.0.4-alpha.2",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/data/-/data-1.0.4-alpha.2.tgz",
-      "integrity": "sha512-Bqc002ByuRISVOqpa+hX6/dD6aNGJYUHtAuD5CGtKoE/6iGbREl1A//6bDgHQjBUMtGD+RncHAe8NnFzQxI+ng==",
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/data/-/data-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-MOCn00d9LDbVX8DOI2wMXSgz+JOr0hGDaG6i3k3rVSJPP52p2YIWBN8ZoDZgxWIKrLwKnuZ2KrueNVeW1QowDw==",
       "dependencies": {
-        "@sitecore-search/common": "^1.0.4-alpha.2",
-        "@sitecore-search/models": "^1.0.4-alpha.2",
+        "@sitecore-search/common": "^1.2.0-alpha.0",
+        "@sitecore-search/models": "^1.2.0-alpha.0",
         "axios": "^0.27.2",
         "js-sha256": "^0.9.0"
       },
@@ -2004,23 +2009,23 @@
       }
     },
     "node_modules/@sitecore-search/models": {
-      "version": "1.0.4-alpha.2",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/models/-/models-1.0.4-alpha.2.tgz",
-      "integrity": "sha512-L2ecTCnqpE4eGCdtsI26qmhmmLckshIYgt2kZVlVSZlKvMJ0/eEI0sOGUwfCWbszs9WoMXslirnu1cjtp7AIBw==",
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/models/-/models-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-4bjt/f0UK+USaiUap2rZoLkYjkE9HLHDW65bwuLaQxeADTWmD+oyicoKd4Gx6Df7M197irywesOunUDpvWhasQ==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sitecore-search/react": {
-      "version": "1.0.4-alpha.2",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/react/-/react-1.0.4-alpha.2.tgz",
-      "integrity": "sha512-3nUDD7wp7DuMhiPCZfzmhCKPUeAG1m6oEWAua/ZMtw74ASWN/T2v74Uo/oIQCYKVhBzdvxVTIk4ryUZNf9SS1Q==",
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/react/-/react-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-BwPaC0D7SU6F9lIZouFgYQv07y4NDALnJSISINzjeLQ+aV+0LMVtOYNF/CTbQwtWu5Q4skQTEqGcr8l3BpjFJA==",
       "dependencies": {
-        "@sitecore-search/common": "^1.0.4-alpha.2",
-        "@sitecore-search/core": "^1.0.4-alpha.2",
-        "@sitecore-search/data": "^1.0.4-alpha.2",
-        "@sitecore-search/models": "^1.0.4-alpha.2",
-        "@sitecore-search/widgets": "^1.0.4-alpha.2",
+        "@sitecore-search/common": "^1.2.0-alpha.0",
+        "@sitecore-search/core": "^1.2.0-alpha.0",
+        "@sitecore-search/data": "^1.2.0-alpha.0",
+        "@sitecore-search/models": "^1.2.0-alpha.0",
+        "@sitecore-search/widgets": "^1.2.0-alpha.0",
         "@tanstack/react-query": "^4.20.2",
         "htm": "^3.0.4",
         "react-intersection-observer": "^8.32.0"
@@ -2034,9 +2039,9 @@
       }
     },
     "node_modules/@sitecore-search/ui": {
-      "version": "1.0.4-alpha.2",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/ui/-/ui-1.0.4-alpha.2.tgz",
-      "integrity": "sha512-n8NOR50gNganG40i5eBgyzoKRhFZY0pxDTBLpNywEGqdoM6rDmLFgBjP1ngl/xw7tw+WnjCjqGm1uy3mwrImZw==",
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/ui/-/ui-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-A6gy5I//9fkKpHciuYzgiIdCMbtfZGmYH5UAz2U7OFrHnjVL3uzCxFPzsPZRtvtDfxRNqsbe+ZtaFnwbNUHRzg==",
       "dependencies": {
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/primitive": "^1.0.0",
@@ -2061,8 +2066,8 @@
         "@radix-ui/react-use-previous": "^1.0.0",
         "@react-hook/passive-layout-effect": "^1.2.1",
         "@react-hook/resize-observer": "^1.2.6",
-        "@sitecore-search/common": "^1.0.4-alpha.2",
-        "@sitecore-search/react": "^1.0.4-alpha.2",
+        "@sitecore-search/common": "^1.2.0-alpha.0",
+        "@sitecore-search/react": "^1.2.0-alpha.0",
         "smoothscroll-polyfill": "^0.4.4"
       },
       "engines": {
@@ -2074,13 +2079,13 @@
       }
     },
     "node_modules/@sitecore-search/widgets": {
-      "version": "1.0.4-alpha.2",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/widgets/-/widgets-1.0.4-alpha.2.tgz",
-      "integrity": "sha512-5pdF1t2rXi54D1RDyl+G6fqRMvdf4vpE2bNQJuM85XHKXtODvyW1q1fQqymj0uZrjMgcXF24gf1dwKyZYVSYDA==",
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/widgets/-/widgets-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-R19JR5rTU91eWJjYyMR2tlTvCyQ79eAJ5DmiJ348zLRdYdIDtqX41AeHV2241FyPm77sPR8uUlQiK3/n//S26A==",
       "dependencies": {
-        "@sitecore-search/core": "^1.0.4-alpha.2",
-        "@sitecore-search/data": "^1.0.4-alpha.2",
-        "@sitecore-search/models": "^1.0.4-alpha.2"
+        "@sitecore-search/core": "^1.2.0-alpha.0",
+        "@sitecore-search/data": "^1.2.0-alpha.0",
+        "@sitecore-search/models": "^1.2.0-alpha.0"
       },
       "engines": {
         "node": ">=12"
@@ -4370,6 +4375,31 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-8.0.0.tgz",
+      "integrity": "sha512-XHcoBL9YPvqIz6K9m9TLf9+6Iyf2ix6yYN+sZ4AI8JPg+8XQpm05V6qzPFZYzyuHfr496TqKlhzHuEvW4ME7Pw==",
+      "dependencies": {
+        "type-fest": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.11.1.tgz",
+      "integrity": "sha512-aCuRNRERRVh33lgQaJRlUxZqzfhzwTrsE98Mc3o3VXqmiaQdHacgUtJ0esp+7MvZ92qhtzKPeusaX6vIEcoreA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -5426,6 +5456,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-root": {
@@ -6793,7 +6834,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8989,7 +9029,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
-      "peer": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },


### PR DESCRIPTION
Bumped the SDK version for Search, this adds a fix to ensure that facets matches the 'and/or' rules defined in the CEC. The previous version was hardcoded to 'and'

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
