### PR TITLE
Bumped minor version of Search SDK

### DIFF
--- a/apps/devportal/package.json
+++ b/apps/devportal/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@remark-embedder/core": "^3.0.1",
     "@remark-embedder/transformer-oembed": "^3.0.0",
-    "@sitecore-search/react": "^1.2.0-alpha.0",
-    "@sitecore-search/ui": "^1.2.0-alpha.0",
+    "@sitecore-search/react": "^1.2.0-alpha.1",
+    "@sitecore-search/ui": "^1.2.0-alpha.1",
     "@types/lodash.throttle": "^4.1.7",
     "axios": "^1.3.5",
     "eslint-config-next": "^13.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
       "dependencies": {
         "@remark-embedder/core": "^3.0.1",
         "@remark-embedder/transformer-oembed": "^3.0.0",
-        "@sitecore-search/react": "^1.2.0-alpha.0",
-        "@sitecore-search/ui": "^1.2.0-alpha.0",
+        "@sitecore-search/react": "^1.2.0-alpha.1",
+        "@sitecore-search/ui": "^1.2.0-alpha.1",
         "@types/lodash.throttle": "^4.1.7",
         "axios": "^1.3.5",
         "eslint-config-next": "^13.4.2",
@@ -1946,9 +1946,9 @@
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
     },
     "node_modules/@sitecore-search/common": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/common/-/common-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-Ss3BkBpZQU+b/2TO8wdPa+TYRbYJwdgKqxtw4CMvX6HR/V9eqdgwz+beTh9psVj36rvi7G2pP3e78uKorStefA==",
+      "version": "1.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/common/-/common-1.2.0-alpha.1.tgz",
+      "integrity": "sha512-JQI1nKeZm6VHvANYGZePGvU3ziLrIOg+cVliwdDvr0AnRG4CpFGYDgZ9UywSITLiSIo1OjbsPSZindYAZUlqwA==",
       "dependencies": {
         "dot-prop": "^8.0.0",
         "filter-obj": "^5.1.0",
@@ -1959,13 +1959,13 @@
       }
     },
     "node_modules/@sitecore-search/core": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/core/-/core-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-8EoiQ96GuT4++hBpNelLxQF5fq1NJR0lnT4+79tcRdy8nKwDkhoEONpUG2kCcz6xdNQMyRU1MRGpBMLl8PiJeQ==",
+      "version": "1.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/core/-/core-1.2.0-alpha.1.tgz",
+      "integrity": "sha512-Xj/3xCkIL/2I10FWaielTDeNPn5z74YYFr/LIBvgtY+KSpQEWJv82aEIpNWanXbziy2EvYZc7iV1unrGPLJxUg==",
       "dependencies": {
-        "@sitecore-search/common": "^1.2.0-alpha.0",
-        "@sitecore-search/data": "^1.2.0-alpha.0",
-        "@sitecore-search/models": "^1.2.0-alpha.0",
+        "@sitecore-search/common": "^1.2.0-alpha.1",
+        "@sitecore-search/data": "^1.2.0-alpha.1",
+        "@sitecore-search/models": "^1.2.0-alpha.1",
         "debounce-promise": "^3.1.2"
       },
       "engines": {
@@ -1973,12 +1973,12 @@
       }
     },
     "node_modules/@sitecore-search/data": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/data/-/data-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-MOCn00d9LDbVX8DOI2wMXSgz+JOr0hGDaG6i3k3rVSJPP52p2YIWBN8ZoDZgxWIKrLwKnuZ2KrueNVeW1QowDw==",
+      "version": "1.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/data/-/data-1.2.0-alpha.1.tgz",
+      "integrity": "sha512-SGiPqEY4crxiKV2LvQstDUcOKqvwILTzvtF1q1FdC7pd8q4ixCHjdSY6i1svxGLtXRqi8LjzuQb/S6sgxL5V5Q==",
       "dependencies": {
-        "@sitecore-search/common": "^1.2.0-alpha.0",
-        "@sitecore-search/models": "^1.2.0-alpha.0",
+        "@sitecore-search/common": "^1.2.0-alpha.1",
+        "@sitecore-search/models": "^1.2.0-alpha.1",
         "axios": "^0.27.2",
         "js-sha256": "^0.9.0"
       },
@@ -2009,23 +2009,23 @@
       }
     },
     "node_modules/@sitecore-search/models": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/models/-/models-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-4bjt/f0UK+USaiUap2rZoLkYjkE9HLHDW65bwuLaQxeADTWmD+oyicoKd4Gx6Df7M197irywesOunUDpvWhasQ==",
+      "version": "1.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/models/-/models-1.2.0-alpha.1.tgz",
+      "integrity": "sha512-rbjaylYZfwTjZaGaW45m955MJO913Dz2kwSd6aQoWS5ADPswpLkZwLJ3SZyQrVLLbubb9XKX+o02/xNu61IjXw==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sitecore-search/react": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/react/-/react-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-BwPaC0D7SU6F9lIZouFgYQv07y4NDALnJSISINzjeLQ+aV+0LMVtOYNF/CTbQwtWu5Q4skQTEqGcr8l3BpjFJA==",
+      "version": "1.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/react/-/react-1.2.0-alpha.1.tgz",
+      "integrity": "sha512-AWQ/TKq1kWf8veIn5EBA1iTkkl2xRhZJJyaIc7A7EAGhbBJYm1qiYwkAjWll2v82FTrb3VL7PUCKRzgcDpYEow==",
       "dependencies": {
-        "@sitecore-search/common": "^1.2.0-alpha.0",
-        "@sitecore-search/core": "^1.2.0-alpha.0",
-        "@sitecore-search/data": "^1.2.0-alpha.0",
-        "@sitecore-search/models": "^1.2.0-alpha.0",
-        "@sitecore-search/widgets": "^1.2.0-alpha.0",
+        "@sitecore-search/common": "^1.2.0-alpha.1",
+        "@sitecore-search/core": "^1.2.0-alpha.1",
+        "@sitecore-search/data": "^1.2.0-alpha.1",
+        "@sitecore-search/models": "^1.2.0-alpha.1",
+        "@sitecore-search/widgets": "^1.2.0-alpha.1",
         "@tanstack/react-query": "^4.20.2",
         "htm": "^3.0.4",
         "react-intersection-observer": "^8.32.0"
@@ -2039,9 +2039,9 @@
       }
     },
     "node_modules/@sitecore-search/ui": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/ui/-/ui-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-A6gy5I//9fkKpHciuYzgiIdCMbtfZGmYH5UAz2U7OFrHnjVL3uzCxFPzsPZRtvtDfxRNqsbe+ZtaFnwbNUHRzg==",
+      "version": "1.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/ui/-/ui-1.2.0-alpha.1.tgz",
+      "integrity": "sha512-z1mc3aGWA7VK6LyRv5sNKO9GluG8Yuu9UyRGnieIjyt1Yg4Grq9hD+dwE6k+uFRnZ4KC6whAPiAsncSJSqQbMg==",
       "dependencies": {
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/primitive": "^1.0.0",
@@ -2066,8 +2066,8 @@
         "@radix-ui/react-use-previous": "^1.0.0",
         "@react-hook/passive-layout-effect": "^1.2.1",
         "@react-hook/resize-observer": "^1.2.6",
-        "@sitecore-search/common": "^1.2.0-alpha.0",
-        "@sitecore-search/react": "^1.2.0-alpha.0",
+        "@sitecore-search/common": "^1.2.0-alpha.1",
+        "@sitecore-search/react": "^1.2.0-alpha.1",
         "smoothscroll-polyfill": "^0.4.4"
       },
       "engines": {
@@ -2079,13 +2079,13 @@
       }
     },
     "node_modules/@sitecore-search/widgets": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sitecore-search/widgets/-/widgets-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-R19JR5rTU91eWJjYyMR2tlTvCyQ79eAJ5DmiJ348zLRdYdIDtqX41AeHV2241FyPm77sPR8uUlQiK3/n//S26A==",
+      "version": "1.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@sitecore-search/widgets/-/widgets-1.2.0-alpha.1.tgz",
+      "integrity": "sha512-7OUU2HO2CQPSh26kSBln2uRoqpmCd0O3xp0tqVhYwHrPjQDnJahBCBkyAZE3FiQQj/d9UbykbF8W5hHkcjFmog==",
       "dependencies": {
-        "@sitecore-search/core": "^1.2.0-alpha.0",
-        "@sitecore-search/data": "^1.2.0-alpha.0",
-        "@sitecore-search/models": "^1.2.0-alpha.0"
+        "@sitecore-search/core": "^1.2.0-alpha.1",
+        "@sitecore-search/data": "^1.2.0-alpha.1",
+        "@sitecore-search/models": "^1.2.0-alpha.1"
       },
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
Bumped minor version of the Search SDK. This introduces support for the APJ region for the SDK. We had an issue where a partner here wanted to test the developer portal against their Search instance in the APJ region and could not.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
