### PR TITLE
Remove xm cloud from list

### DIFF
--- a/apps/devportal/src/pages/changelog/current.tsx
+++ b/apps/devportal/src/pages/changelog/current.tsx
@@ -31,7 +31,6 @@ export default function ChangelogCurrent() {
               <p>Please check this list to find the current release notes per product</p>
 
               <Row columns={2}>
-                <LinkItem title="Sitecore XM Cloud" link="https://doc.sitecore.com/xmc/en/developers/xm-cloud/what-s-new-in-sitecore-xm-cloud.html" />
                 <LinkItem title="Sitecore Content Hub" link="https://doc.sitecore.com/ch/en/users/latest/content-hub/release-notes.html" />
                 <LinkItem title="Sitecore Content Hub ONE" link="https://doc.sitecore.com/ch-one/en/users/content-hub-one/whats-new-in-content-hub-one.html" />
                 <LinkItem title="Sitecore OrderCloud" link="https://ordercloud.io/release-notes/" />


### PR DESCRIPTION
## Description / Motivation
Remove link to what's new pages for XM Cloud

## How Has This Been Tested?
Local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
