### PR TITLE
Use next-share for social sharing

### DIFF
--- a/apps/devportal/package.json
+++ b/apps/devportal/package.json
@@ -45,6 +45,7 @@
     "lodash.throttle": "^4.1.1",
     "next": "^13.4.2",
     "next-mdx-remote": "^4.4.1",
+    "next-share": "^0.20.0",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -58,7 +59,7 @@
     "remark-gfm": "^3.0.1",
     "sharp": "^0.32.0",
     "swr": "^2.1.3",
-    "ui": "^0.0.0",
+    "ui": "*",
     "unist-util-visit": "^4.1.2"
   },
   "devDependencies": {

--- a/apps/devportal/src/components/changelog/ChangeLogItem.tsx
+++ b/apps/devportal/src/components/changelog/ChangeLogItem.tsx
@@ -6,6 +6,7 @@ import { getSlug } from 'sc-changelog/utils/stringUtils';
 import { getChangelogEntryUrl } from 'sc-changelog/utils/urlBuilder';
 import { Loading } from 'ui/components/common/Loading';
 import TextLink from 'ui/components/common/TextLink';
+import SocialShare from '../common/SocialShare';
 import { ChangelogItemMeta } from './ChangelogItemMeta';
 
 export type ChangeLogItemProps = {
@@ -71,7 +72,10 @@ const ChangeLogItem = ({ item, loading, loadEntries, isLast, isMore }: ChangeLog
         )}
 
         <div className="prose dark:prose-invert prose-table:mt-0 my-3 max-w-none text-sm" dangerouslySetInnerHTML={{ __html: item.description }} />
-        <span>{item.readMoreLink && <TextLink className="font-medium" href={item.readMoreLink} text="Read more" title={`Read more about ${item.title}`} />}</span>
+        <div className="flex flex-row">
+          <div className="grow">{item.readMoreLink && <TextLink className="mt-2 font-medium" href={item.readMoreLink} text="Read more" title={`Read more about ${item.title}`} />}</div>
+          <SocialShare className="w-30" url={getChangelogEntryUrl(item, true)} title={item.title} />
+        </div>
       </div>
 
       {isLast && isMore && <Loading />}

--- a/apps/devportal/src/components/common/SocialShare.tsx
+++ b/apps/devportal/src/components/common/SocialShare.tsx
@@ -1,0 +1,31 @@
+import { EmailIcon, EmailShareButton, LinkedinIcon, LinkedinShareButton, TwitterIcon, TwitterShareButton } from 'next-share';
+
+type SocialShareProps = {
+  url: string;
+  title: string;
+  className?: string;
+};
+
+const SocialShare = ({ className, title, url }: SocialShareProps): JSX.Element => {
+  return (
+    <div className={`social-share ${className} flex gap-2`}>
+      <span className="fill-none opacity-30 transition-opacity duration-150 hover:opacity-100">
+        <EmailShareButton url={url} subject={'Share'} body="body">
+          <EmailIcon size={32} round />
+        </EmailShareButton>
+      </span>
+      <span className="fill-none opacity-30 transition-opacity duration-150 hover:opacity-100">
+        <LinkedinShareButton url={url} title={title} className="mr-2">
+          <LinkedinIcon size={32} round />
+        </LinkedinShareButton>
+      </span>
+      <span className="fill-none opacity-30 transition-opacity duration-150 hover:opacity-100">
+        <TwitterShareButton url={url} title={title}>
+          <TwitterIcon size={32} round />
+        </TwitterShareButton>
+      </span>
+    </div>
+  );
+};
+
+export default SocialShare;

--- a/apps/devportal/src/pages/changelog/[product]/[entry].tsx
+++ b/apps/devportal/src/pages/changelog/[product]/[entry].tsx
@@ -1,5 +1,7 @@
+import { getChangelogEntryUrl } from '@/../../packages/sc-changelog/utils/urlBuilder';
 import ChangelogByMonth from '@/src/components/changelog/ChangelogByMonth';
 import { ChangelogItemMeta } from '@/src/components/changelog/ChangelogItemMeta';
+import SocialShare from '@/src/components/common/SocialShare';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -128,7 +130,10 @@ const ChangelogProduct = ({ currentProduct, changelogEntry }: ChangelogProps) =>
               <div className={`prose dark:prose-invert my-3 max-w-none text-sm`} dangerouslySetInnerHTML={{ __html: changelogEntry.description }} />
               {changelogEntry.fullArticle && <div className={`prose dark:prose-invert my-3 max-w-none text-sm`} dangerouslySetInnerHTML={{ __html: changelogEntry.fullArticle }} />}
 
-              {changelogEntry.readMoreLink && <TextLink className="font-medium" href={changelogEntry.readMoreLink} text="Read more" title={`Read more about ${changelogEntry.title}`} />}
+              <div className="flex flex-row">
+                <div className="grow">{changelogEntry.readMoreLink && <TextLink className="font-medium" href={changelogEntry.readMoreLink} text="Read more" title={`Read more about ${changelogEntry.title}`} />}</div>
+                <SocialShare className="w-30" url={getChangelogEntryUrl(changelogEntry, true)} title={changelogEntry.title} />
+              </div>
             </div>
             <div className="col-span-2 hidden md:block">
               <ChangelogByMonth product={currentProduct} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,10 @@
         "eslint-plugin-import": "^2.27.5",
         "prettier": "latest",
         "prettier-plugin-tailwindcss": "^0.2.7",
+        "sc-changelog": "*",
         "shx": "^0.3.4",
-        "turbo": "^1.9.3"
+        "turbo": "^1.9.3",
+        "ui": "*"
       }
     },
     "apps/devportal": {
@@ -40,6 +42,7 @@
         "lodash.throttle": "^4.1.1",
         "next": "^13.4.2",
         "next-mdx-remote": "^4.4.1",
+        "next-share": "^0.20.0",
         "next-themes": "^0.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -53,7 +56,7 @@
         "remark-gfm": "^3.0.1",
         "sharp": "^0.32.0",
         "swr": "^2.1.3",
-        "ui": "^0.0.0",
+        "ui": "*",
         "unist-util-visit": "^4.1.2"
       },
       "devDependencies": {
@@ -6915,6 +6918,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
@@ -8782,6 +8806,21 @@
       "peerDependencies": {
         "react": ">=16.x <=18.x",
         "react-dom": ">=16.x <=18.x"
+      }
+    },
+    "node_modules/next-share": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/next-share/-/next-share-0.20.0.tgz",
+      "integrity": "sha512-7EZem/fJe9QljTt4SrhKzKjC5i+aiBw5YxIGJNH1+G+El0tKzwAYcrm35KWe+R3j4apqWl+Bpyjo2FKbpj7fow==",
+      "dependencies": {
+        "jsonp": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.2"
       }
     },
     "node_modules/next-sitemap": {

--- a/packages/sc-changelog/utils/urlBuilder.ts
+++ b/packages/sc-changelog/utils/urlBuilder.ts
@@ -1,6 +1,8 @@
 import { ChangelogEntry, ChangelogEntrySummary } from 'sc-changelog/types/changeLogEntry';
 import { slugify } from 'sc-changelog/utils/stringUtils';
 
+const publicUrl = process.env.NEXT_PUBLIC_PUBLIC_URL ? process.env.NEXT_PUBLIC_PUBLIC_URL : '';
+
 export function getChangelogEntryUrlSegments(entry: ChangelogEntry | ChangelogEntrySummary): string[] {
   const segments: string[] = [];
 
@@ -11,10 +13,13 @@ export function getChangelogEntryUrlSegments(entry: ChangelogEntry | ChangelogEn
   return segments;
 }
 
-export function getChangelogEntryUrl(entry: ChangelogEntry | ChangelogEntrySummary): string {
+export function getChangelogEntryUrl(entry: ChangelogEntry | ChangelogEntrySummary, includeServerUrl?: boolean): string {
   const url: string[] = [];
 
   url.push('/changelog');
   url.push(...getChangelogEntryUrlSegments(entry));
+
+  if (includeServerUrl) return `${publicUrl + url.join('/')}`;
+
   return url.join('/');
 }


### PR DESCRIPTION
## Description / Motivation
Adds social buttons to the changelog entries for sharing purposes (#472) 

## How Has This Been Tested?
Local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
