### PR TITLE
Configured Search to be gracefully disabled when ENV VARS are missing

### DIFF
--- a/apps/devportal/src/common/search.ts
+++ b/apps/devportal/src/common/search.ts
@@ -1,0 +1,10 @@
+import { Environment } from "@sitecore-search/react";
+
+export const SEARCH_CONFIG = {
+  env: process.env.NEXT_PUBLIC_SEARCH_APP_ENV as Environment,
+  customerKey: process.env.NEXT_PUBLIC_SEARCH_APP_CUSTOMER_KEY,
+  apiKey: process.env.NEXT_PUBLIC_SEARCH_APP_API_KEY,
+  useToken: true,
+};
+
+export const IsSearchEnabled = () => SEARCH_CONFIG.env && SEARCH_CONFIG.customerKey && SEARCH_CONFIG.apiKey ? true : false;

--- a/apps/devportal/src/components/integrations/sitecore-search/SearchInputSwitcher.tsx
+++ b/apps/devportal/src/components/integrations/sitecore-search/SearchInputSwitcher.tsx
@@ -1,3 +1,4 @@
+import { IsSearchEnabled } from '@/src/common/search';
 import PreviewSearchInput from './PreviewSearchInput';
 import SearchInput from './SearchInput';
 
@@ -13,7 +14,7 @@ const Disabled = () => {
 
 const SearchInputSwitcher = () => {
   const renderMode: SearchInputRenderMode =
-    !process.env.NEXT_PUBLIC_SEARCH_APP_ENV || !process.env.NEXT_PUBLIC_SEARCH_APP_CUSTOMER_KEY || !process.env.NEXT_PUBLIC_SEARCH_APP_API_KEY
+    !IsSearchEnabled()
       ? SearchInputRenderMode.Disabled
       : process.env.NEXT_PUBLIC_SEARCH_ENABLE_PREVIEW_SEARCH === 'true'
       ? SearchInputRenderMode.PreviewSearchInput

--- a/apps/devportal/src/pages/_app.tsx
+++ b/apps/devportal/src/pages/_app.tsx
@@ -14,18 +14,13 @@ import Nav from 'ui/layouts/components/header/Nav';
 import '@/src/styles/global.css';
 import React from 'react';
 // Fonts
-import { Environment, PageController, WidgetsProvider, trackEntityPageViewEvent } from '@sitecore-search/react';
+import { PageController, WidgetsProvider, trackEntityPageViewEvent } from '@sitecore-search/react';
 import { ThemeProvider } from 'next-themes';
 import { AvenirNextLTPro } from 'ui/common/fonts/avenirNextLTPro';
 import { AvenirNextR } from 'ui/common/fonts/avenirNextR';
+import { IsSearchEnabled, SEARCH_CONFIG } from '../common/search';
 import PreviewNotification from '../components/common/PreviewNotification';
 import SearchInputSwitcher from '../components/integrations/sitecore-search/SearchInputSwitcher';
-const SEARCH_CONFIG = {
-  env: process.env.NEXT_PUBLIC_SEARCH_APP_ENV as Environment,
-  customerKey: process.env.NEXT_PUBLIC_SEARCH_APP_CUSTOMER_KEY,
-  apiKey: process.env.NEXT_PUBLIC_SEARCH_APP_API_KEY,
-  useToken: true,
-};
 
 function SCDPApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -39,13 +34,18 @@ function SCDPApp({ Component, pageProps }: AppProps) {
       preview: process.env.NEXT_PUBLIC_GTM_ENVIRONMENT as string,
     };
     TagManager.initialize(tagManagerArgs);
-    PageController.getContext().setLocaleLanguage('en');
-    PageController.getContext().setLocale({ country: 'us', language: 'en' });
-    trackEntityPageViewEvent("content", [{ id: process.env.NEXT_PUBLIC_SEARCH_DOMAIN_ID_PREFIX + document.location.pathname.replace(/[/:.]/g, '_').replace(/_+$/,'') }]);
+    
+    if (IsSearchEnabled()) {
+      PageController.getContext().setLocaleLanguage('en');
+      PageController.getContext().setLocale({ country: 'us', language: 'en' }); 
+      trackEntityPageViewEvent("content", [{ id: process.env.NEXT_PUBLIC_SEARCH_DOMAIN_ID_PREFIX + document.location.pathname.replace(/[/:.]/g, '_').replace(/_+$/,'') }]);
+    }
   });
 
+  const SearchWrapper = ({ children }: any) => (IsSearchEnabled()) ? <WidgetsProvider {...SEARCH_CONFIG}>{children}</WidgetsProvider> : children;
+  
   return (
-    <WidgetsProvider {...SEARCH_CONFIG}>
+    <SearchWrapper>
       <ThemeProvider storageKey="SDPDarkMode" attribute="class">
         <React.StrictMode>
           <Head>
@@ -63,7 +63,7 @@ function SCDPApp({ Component, pageProps }: AppProps) {
           </div>
         </React.StrictMode>
       </ThemeProvider>
-    </WidgetsProvider>
+    </SearchWrapper>
   );
 }
 


### PR DESCRIPTION
Enabled graceful fallback when Search ENV VARS aren't populated.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM

Closes #489 