### PR TITLE
Attempting to align "Latest Blogs" link generation 

### DIFF
--- a/packages/ui/components/sitecoreCommunity/SitecoreCommunityBlogOrQuestion.tsx
+++ b/packages/ui/components/sitecoreCommunity/SitecoreCommunityBlogOrQuestion.tsx
@@ -62,7 +62,7 @@ export const SitecoreCommunityBlogOrQuestionSidebar = ({ item, contentType, load
         </div>
         <div className="">
           <span className={`hover:text-violet dark:hover:text-teal  line-clamp-1 font-semibold hover:underline`}>
-            <Link href={item.url} title={item.title}>
+            <Link href={`${SITECORE_COMMUNITY_URL}${item.url}`} title={item.title} rel="noreferrer noopener" target="_blank">
               {item.title}
             </Link>
           </span>


### PR DESCRIPTION
## Description / Motivation

On the current production, the links for the blog articles on the home page do not work. They are all relative and do not go to the Community site. Other blog listing components use a constant for the Community link, and this PR is intended to bring that into alignment.

Fixes #507 

## How Has This Been Tested?

Testing on preview Vercel environment to ensure links work.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
