### PR TITLE
Adding links to XM Cloud dev courses

### DIFF
--- a/apps/devportal/data/markdown/partials/solution/content-management/xm-cloud.md
+++ b/apps/devportal/data/markdown/partials/solution/content-management/xm-cloud.md
@@ -67,7 +67,11 @@ The importance of your company's growth comes with the:
 
 ### Official Sitecore Training
 
-- [Coming soon!]
+<Row columns={3}>
+  <Link title="XM Cloud for JSS Headless Developers" link="https://learning.sitecore.com/learn/learning_plan/view/50/xm-cloud-for-jss-headless-developers" />
+  <Link title="XM Cloud for .NET Headless Developers" link="https://learning.sitecore.com/internal/learn/learning_plan/view/51/xm-cloud-for-net-headless-developers" />
+  <Link title="Sitecore XM Cloud Developer Fundamentals ILT" link="https://shop.learning.sitecore.com/products/1243" />
+</Row>
 
 ## Access the Portal
 

--- a/apps/devportal/data/markdown/partials/solution/content-management/xm-cloud.md
+++ b/apps/devportal/data/markdown/partials/solution/content-management/xm-cloud.md
@@ -69,7 +69,7 @@ The importance of your company's growth comes with the:
 
 <Row columns={3}>
   <Link title="XM Cloud for JSS Headless Developers" link="https://learning.sitecore.com/learn/learning_plan/view/50/xm-cloud-for-jss-headless-developers" />
-  <Link title="XM Cloud for .NET Headless Developers" link="https://learning.sitecore.com/internal/learn/learning_plan/view/51/xm-cloud-for-net-headless-developers" />
+  <Link title="XM Cloud for .NET Headless Developers" link="https://learning.sitecore.com/learn/learning_plan/view/51/xm-cloud-for-net-headless-developers" />
   <Link title="Sitecore XM Cloud Developer Fundamentals ILT" link="https://shop.learning.sitecore.com/products/1243" />
 </Row>
 


### PR DESCRIPTION
## Description / Motivation

Added links to XM Cloud courses to replace the "COMING SOON!" text. Uses the 'cards', similar to how documentation is listed.

## How Has This Been Tested?
Tested locally and on Vercel.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
