### PR TITLE
Updated docs to reference XMC instead of XP

### DIFF
--- a/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud-introduction/index.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud-introduction/index.md
@@ -7,7 +7,7 @@ openGraphImage: 'https://mss-p-006-delivery.stylelabs.cloud/api/public/content/1
 
 ## What is XM Cloud?
 
-Sitecore Experience Manager Cloud (XM Cloud) is a fully managed self-service deployment platform for developers and marketers to efficiently launch engaging omnichannel experiences in the Cloud using Sitecore’s headless CMS. Experience Manager Cloud bundles the latest versions of [Experience Manager](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/experience-manager.html), the Pages editor, Sitecore Headless Experience Accelerator ([SXA](https://doc.sitecore.com/xp/en/developers/sxa/102/sitecore-experience-accelerator/index-en.html)), [Headless Services](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-headless-services.html), the [Sitecore Next.js SDK](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-javascript-rendering-sdk--jss--for-next-js.html) (and other Heads), and [Experience Edge](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html).
+Sitecore Experience Manager Cloud (XM Cloud) is a fully managed self-service deployment platform for developers and marketers to efficiently launch engaging omnichannel experiences in the Cloud using Sitecore’s headless CMS. Experience Manager Cloud bundles the latest versions of Experience Manager, the Pages editor, Sitecore Headless Experience Accelerator ([SXA](https://doc.sitecore.com/xmc/en/developers/xm-cloud/using-sxa-for-xm-cloud-development.html)), [Headless Services](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-headless-services.html), the [Sitecore Next.js SDK](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-javascript-rendering-sdk--jss--for-next-js.html) (and other Heads), and [Experience Edge](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html).
 
 With an optimized cloud-based strategy, you can rapidly and cost-effectively scale to meet your customers’ needs, shorten your time-to-market, and be more adaptive as new capabilities and functionality are added to your Martech stack. Explore how the right cloud approach will help you thrive now and into the future.
 
@@ -35,17 +35,16 @@ XM Cloud combines the advantages of both worlds. Building new web experiences ba
 
 ## XM Cloud provides
 
-- Sitecore Unified Identity (SSO across all applications of Composable DXP)
-- [Headless SXA](https://doc.sitecore.com/xp/en/developers/sxa/102/sitecore-experience-accelerator/headless.html) (Accelerator Features to speed up time to market)
-- [JSS](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-javascript-rendering-sdks--jss-.html)
-- [Headless Services](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-headless-services.html)
-- [Management Services](https://doc.sitecore.com/xp/en/developers/102/developer-tools/sitecore-management-services.html)
-- [Layout Service](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/layout-service.html)
-- [GraphQL](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/graphql.html)
+- [Sitecore Unified Identity](https://doc.sitecore.com/portal/en/developers/sitecore-cloud-portal/single-sign-on--sso-.html) (SSO across all applications of Composable DXP)
+- [Headless SXA](https://doc.sitecore.com/xmc/en/developers/xm-cloud/using-sxa-for-xm-cloud-development.html) (Accelerator Features to speed up time to market)
+- [JSS](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-javascript-rendering-sdks--jss-.html)
+- [Headless Services](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-headless-services.html)
+- [Layout Service](https://doc.sitecore.com/xmc/en/developers/xm-cloud/layout-service.html)
+- [GraphQL](https://doc.sitecore.com/xmc/en/developers/xm-cloud/graphql.html)
 - [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-overview) for Media
-- Content Delivery via [Edge](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html) with [Connector](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/the-experience-edge-connector.html)
-- Sitecore Embedded Personalization (Tenant of [CDP](https://doc.sitecore.com/cdp/en/users/sitecore-cdp/introduction-to-sitecore-cdp.html)) for optional usage
-- XM Cloud Deploy (deploy your web experience to XM)
+- Content Delivery via [Edge](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html)
+- [Sitecore Embedded Personalization](https://doc.sitecore.com/xmc/en/users/xm-cloud/personalize-digital-experiences.html)
+- [XM Cloud Deploy](https://doc.sitecore.com/xmc/en/developers/xm-cloud/deploying-xm-cloud.html) (deploy your web experience to XM Cloud)
 - Supports [GitOps](https://www.weave.works/technologies/gitops/)
 - Local Development using containers (same containers used in cloud)
 - Automatic updates to get latest features immediately
@@ -54,13 +53,13 @@ XM Cloud combines the advantages of both worlds. Building new web experiences ba
 
 ![XM Cloud Architecture](https://mss-p-006-delivery.stylelabs.cloud/api/public/content/542ccf865a8344daaa92e1c364ee8dd1?v=522329fa)
 
-XM Cloud comes with a Content Management application based on [Sitecore XM](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/experience-manager.html) including known but also new editing Tools. So, you will be able to use [Content Editor](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/the-content-editor.html) as well as [Experience Editor](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/the-experience-editor.html). In addition to these powerful tools XM Cloud includes Sitecore Pages to manage your content and Design Pages and many other tools.
+XM Cloud comes with a Content Management application based on Sitecore XM including known but also new editing tools. You will be able to use classic tools such as Content Editor as well as Experience Editor. However, XM Cloud introduces new powerful tools for content design and editing through [Sitecore Pages](https://doc.sitecore.com/xmc/en/users/xm-cloud/the-pages-editor.html), [Content manager](https://doc.sitecore.com/xmc/en/users/xm-cloud/content.html), and many other tools.
 
-The content delivery is provided by publishing to [Edge](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html). That can be [Sitecore Edge](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html) (configured as default) but also other edge vendors.
+The content delivery is provided by publishing to [Edge](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html). That can be Sitecore Edge (configured as default) but also other edge vendors.
 
-[Edge](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html) delivers content and design information headlessly through the GraphQL endpoint and can be consumed by any head technology such as Next.js, ASP.NET core, Angular, Vue or React.
+[Edge](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html) delivers content and design information headlessly through the GraphQL endpoint and can be consumed by any head technology such as Next.js, ASP.NET core, Angular, Vue or React.
 
-Developers and System Administrators can manage the XM Cloud instances and deploy the custom CM (Content Management) customizations using the “build and deployment services” as well as the Deploy App that provides the functionalities via UI.
+Developers and System Administrators can manage the XM Cloud instances and [deploy the custom CM](https://doc.sitecore.com/xmc/en/developers/xm-cloud/deploying-xm-cloud.html) (Content Management) customizations using the “build and deployment services” as well as the Deploy App that provides the functionalities via UI.
 
 ## Setting up an XM Cloud environment
 
@@ -89,7 +88,7 @@ XM Cloud Deploy is bundled with XM Cloud and offers REST API first deployment to
 
 ## Getting prepared for XM Cloud
 
-You might have recognized that a lot of technologies that we have come across are involved in XM Cloud development. [Edge](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html), [serialization](https://doc.sitecore.com/xp/en/developers/102/sitecore-experience-manager/serialization-in-sitecore.html), [headless](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/overview-of-headless-development-with-sitecore.html), [containers](https://doc.sitecore.com/xp/en/developers/102/developer-tools/containers-in-sitecore-development.html), [JSS](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-javascript-rendering-sdks--jss-.html), [SXA](https://doc.sitecore.com/xp/en/developers/sxa/102/sitecore-experience-accelerator/index-en.html). So, it definitely makes sense to close some of the knowledge gaps in these areas to get prepared for XM Cloud.
+You might have recognized that a lot of technologies that we have come across are involved in XM Cloud development. [Edge](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html), [serialization](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-content-serialization.html), [headless services](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-headless-services.html), [containers](https://doc.sitecore.com/xmc/en/developers/xm-cloud/walkthrough--setting-up-your-full-stack-xm-cloud-local-development-environment.html), [JSS](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-javascript-rendering-sdks--jss-.html), [SXA](https://doc.sitecore.com/xmc/en/developers/xm-cloud/using-sxa-for-xm-cloud-development.html). So, it definitely makes sense to close some of the knowledge gaps in these areas to get prepared for XM Cloud.
 
 ![Getting prepared for XM Cloud learning SXA, JSS, Containers, Headless, Edge, Sitecore Serialize](https://mss-p-006-delivery.stylelabs.cloud/api/public/content/d2ba91e41cd846f19bc6ba8b8f6d29fe?v=0a1eb452)
 
@@ -118,32 +117,32 @@ Here’s a list of great resources that I found helpful.
 - [[Article] **Docker: A Quick overview** - by Rob Earlam](https://www.sitecore.com/knowledge-center/getting-started/docker-a-quick-overview)
 - [[Video] **Docker for beginners** - by Travis Media](https://www.youtube.com/watch?v=3c-iBn73dDE)
 - [[Documentation] **Containers in Sitecore development** -
-  documentation](https://doc.sitecore.com/xp/en/developers/100/developer-tools/containers-in-sitecore-development.html)
+  documentation](https://doc.sitecore.com/xmc/en/developers/xm-cloud/walkthrough--setting-up-your-full-stack-xm-cloud-local-development-environment.html)
 
 ### Headless
 
 - [[Video] **Sitecore Headless Development with Next.js** - by Nick Wesselman - Create a headless App, create components using JSS and deployment to Vercel.](https://www.youtube.com/watch?v=ugPy7BjH0H0)
-- [[Documentation] **Walkthrough: Deploying JSS Next.js apps to Vercel** - Documentation and video by Nick Wesselman.](https://doc.sitecore.com/xp/en/developers/hd/190/sitecore-headless-development/walkthrough--deploying-jss-next-js-apps-to-vercel.html)
+- [[Documentation] **Walkthrough: Deploying your front-end application to Vercel**](https://doc.sitecore.com/xmc/en/developers/xm-cloud/walkthrough--deploying-your-front-end-application-to-vercel.html)
 - [[Video] **The ASP.NET Core Rendering SDK** - by Nick Wesselman and Oleg Jytnik](https://www.youtube.com/watch?v=FYyYpmODiBY)
 - [[Video] **Render here, render there, render everywhere** - by Thomas Desmond](https://www.youtube.com/watch?v=zu8qpbtNasg)
 - [[Documentation] **Converting existing Sitecore MVC applications to the Jamstack architecture with Headless Rendering** -
-  Documentation, walkthroughs and a video by nastasiya Flynn](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/converting-existing-sitecore-mvc-applications-to-the-jamstack-architecture-with-headless-rendering.html)
+  Documentation, walkthroughs and a video by Nicole Flynn](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/converting-existing-sitecore-mvc-applications-to-the-jamstack-architecture-with-headless-rendering.html)
 
 ### Serialization
 
 - [[Video] **Sitecore 10 – Introducing Sitecore Serialization** by Rob Earlam](https://www.youtube.com/watch?v=CzQbwvKX1Cc)
-- [[Documentation] **Create a content serialization Module** - ](https://doc.sitecore.com/xp/en/developers/100/developer-tools/create-a-sitecore-content-serialization-module.html/)
+- [[Documentation] **Create a content serialization Module** - ](https://doc.sitecore.com/xmc/en/developers/xm-cloud/create-a-sitecore-content-serialization-module.html)
 
 ### Edge
 
-- [[Documentation] **Architecture for Experience Edge for XM**](https://doc.sitecore.com/xp/en/developers/101/developer-tools/the-architecture-of-sitecore-experience-edge-for-xm.html)
+- [[Documentation] **Architecture for Experience Edge for XM**](https://doc.sitecore.com/xmc/en/developers/xm-cloud/the-architecture-of-sitecore-experience-edge-for-xm.html)
 - [[Video] **Sitecore Experience Edge** - by Pieter Brinkman](https://www.youtube.com/watch?v=_xw-02PZQTE)
 - [[Video] **Getting started with Vercel Edge Functions in Next.js** by Thomas Desmond](https://www.youtube.com/watch?v=nt4FYgJRbTc)
 - [[Video] **Making GraphQL requests on your frontend with Next.js** by Thomas Desmond](https://www.youtube.com/watch?v=F3BWdFXEJPk)
 
 ### SXA
 
-- [[Documentation] **Rendering Variants** - official documentation](https://doc.sitecore.com/xp/en/developers/sxa/102/sitecore-experience-accelerator/create-a-rendering-variant.html)
+- [[Documentation] **Rendering Variants** - official documentation](https://doc.sitecore.com/xmc/en/developers/xm-cloud/create-a-rendering-variant.html)
 - [[Video] **Page and Partial Designs** - Demo of using Page and Partial Designs](https://www.youtube.com/watch?v=0LqngaF5i1U)
 - [[Video] **Tenant and Site Creation** - by Sebastian Winter and Mark van Aalst](https://www.youtube.com/watch?v=Od8B1tG1ivs)
 - [[Video] **SXA Modules** - by Sebastian Winter and Mark van Aalst - Introduction](https://www.youtube.com/watch?v=usLWZHiWGZI) -

--- a/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud-introduction/index.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud-introduction/index.md
@@ -131,7 +131,7 @@ Here’s a list of great resources that I found helpful.
 ### Serialization
 
 - [[Video] **Sitecore 10 – Introducing Sitecore Serialization** by Rob Earlam](https://www.youtube.com/watch?v=CzQbwvKX1Cc)
-- [[Documentation] **Create a content serialization Module** - ](https://doc.sitecore.com/xmc/en/developers/xm-cloud/create-a-sitecore-content-serialization-module.html)
+- [[Documentation] **Create a content serialization Module**](https://doc.sitecore.com/xmc/en/developers/xm-cloud/create-a-sitecore-content-serialization-module.html)
 
 ### Edge
 
@@ -146,4 +146,4 @@ Here’s a list of great resources that I found helpful.
 - [[Video] **Page and Partial Designs** - Demo of using Page and Partial Designs](https://www.youtube.com/watch?v=0LqngaF5i1U)
 - [[Video] **Tenant and Site Creation** - by Sebastian Winter and Mark van Aalst](https://www.youtube.com/watch?v=Od8B1tG1ivs)
 - [[Video] **SXA Modules** - by Sebastian Winter and Mark van Aalst - Introduction](https://www.youtube.com/watch?v=usLWZHiWGZI) -
-  - [Demo video](https://www.youtube.com/watch?v=A4NiQzZ-yJo)
+- [Demo video](https://www.youtube.com/watch?v=A4NiQzZ-yJo)

--- a/apps/devportal/data/markdown/partials/learn/faq/xm-cloud-embedded-personalization/feature-matrix.md
+++ b/apps/devportal/data/markdown/partials/learn/faq/xm-cloud-embedded-personalization/feature-matrix.md
@@ -22,7 +22,7 @@ _Real time web data collection for 30 days of view events_
 
 ### What features do I get if I license full Sitecore Personalize in addition to XM Cloud?
 
-The embedded personalization functionality within XM Cloud provides a simple way to implement the most common website personalization use case through personalizing pages (Targeting experience). If a customer is looking to have more control over customized personalization rules, experiences APIs access, or for direct ability to configure and tailor Sitecore Personalize tenant, they should license Sitecore Personalize. With XM Cloud, the content delivery is provided by publishing to [Experience Edge](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/sitecore-experience-edge-for-xm.html).
+The embedded personalization functionality within XM Cloud provides a simple way to implement the most common website personalization use case through personalizing pages (Targeting experience). If a customer is looking to have more control over customized personalization rules, experiences APIs access, or for direct ability to configure and tailor Sitecore Personalize tenant, they should license Sitecore Personalize. With XM Cloud, the content delivery is provided by publishing to [Experience Edge](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html).
 
 Licensing Sitecore Personalize gives access to all the features included in the XM Cloud Embedded Personalization in addition to Sitecore Personalize features including custom personalization conditions that can be used in XM Cloud, decisioning, and longer data retention limits. Here is a list of features empowered by XM Cloud + Sitecore Personalize:
 

--- a/apps/devportal/data/markdown/partials/learn/faq/xm-cloud-recommended-practices/getting-started.md
+++ b/apps/devportal/data/markdown/partials/learn/faq/xm-cloud-recommended-practices/getting-started.md
@@ -24,7 +24,7 @@ And second, it helps to start with just the essentials - **don’t try to learn 
 
 Many devs coming to the Sitecore world are used to building components for webpages. But Sitecore is a CMS for marketers, so in Sitecore you are not building for webpages directly; you are building for the authoring interface, and this requires extra considerations. 
 
-[Content authoring concepts for developers new to Sitecore](https://doc.sitecore.com/xp/en/developers/hd/201/sitecore-headless-development/content-authoring-concepts-for-developers-new-to-sitecore.html) - It is critical to understand these key concepts before designing or building front-end components for a Sitecore XM Cloud backend.
+[Content authoring concepts for developers new to Sitecore](https://doc.sitecore.com/xmc/en/developers/xm-cloud/content-authoring-concepts-for-developers-new-to-sitecore.html) - It is critical to understand these key concepts before designing or building front-end components for a Sitecore XM Cloud backend.
 
 > ✅ DO acquire access to your XM Cloud instance and **try out the authoring workflow yourself** before building components.
 

--- a/apps/devportal/data/markdown/partials/learn/faq/xm-cloud/development.md
+++ b/apps/devportal/data/markdown/partials/learn/faq/xm-cloud/development.md
@@ -13,7 +13,7 @@ Alternatively, developers will be able to trigger the creation and deployment of
 ## We have Sitecore and UI developers. How do we get them setup? 
 The first prerequisites are that every Developer should register at https://portal.sitecorecloud.io and, ideally, be added to an Organization. You can watch [Setup your first Headless SXA Site in XM Cloud](https://www.youtube.com/watch?v=zot3G52F2ts) for a walkthrough. 
 
-Sitecore recommends starting from one of the existing Sitecore starter kits. These starter kits provide all the configuration to get up and running easily. If starting your own project from scratch, it is recommended to use [Headless SXA](https://doc.sitecore.com/xmc/en/developers/xm-cloud/using-sxa-for-xm-cloud-development.html) and [JSS](https://doc.sitecore.com/xp/en/developers/hd/201/sitecore-headless-development/index-en.html). 
+Sitecore recommends starting from one of the existing Sitecore starter kits. These starter kits provide all the configuration to get up and running easily. If starting your own project from scratch, it is recommended to use [Headless SXA](https://doc.sitecore.com/xmc/en/developers/xm-cloud/using-sxa-for-xm-cloud-development.html) and [JSS](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-javascript-rendering-sdks--jss-.html). 
 
 For developers there are two ways suggested to interact with XM Cloud and implement customer requirements. Developers can either build using “Edge Mode” or using XM Cloud “fully local”.
 


### PR DESCRIPTION
## Description / Motivation

Developers learning about XM Cloud are currently directed to XM and XP docs, instead of XM Cloud. This causes the developer to get lost in multiple doc sites. This change attempts to correct links to reference XM Cloud versions of the docs and removes links that would take the user to XM-only docs unless relevant.

Fixes #515 

## How Has This Been Tested?

Tested locally and on Vercel.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
