### PR TITLE
Add link to XM Cloud upgrades docs

### DIFF
--- a/apps/devportal/data/markdown/partials/learn/faq/xm-cloud/upgrades.md
+++ b/apps/devportal/data/markdown/partials/learn/faq/xm-cloud/upgrades.md
@@ -3,8 +3,8 @@ title: 'Upgrades'
 hasInPageNav: true
 ---
 
-## Will Sitecore keep Sitecore XM Cloud up to date, including XM itself?
-Sitecore will deliver XM Cloud as a cloud-native service, so all aspects of the platform will be kept up-to-date, secure, and performant by Sitecore. Customers will have the option of performing self-service Experience Manager updates or opting to receive automatic updates from Sitecore in the future. Clarification coming after Sitecore Symposium 2022.
+## Will Sitecore keep Sitecore XM Cloud up to date?
+Sitecore will deliver XM Cloud as a cloud-native service, so all aspects of the platform will be kept up-to-date, secure, and performant by Sitecore. Additional details on the environment updates are available in the documentation: [SaaS Environment Updates](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-manager-cloud.html#saas-environment-updates)
 
 ## Will upgrading my current XM/XP now to the latest version, prepare me for moving into the XM Cloud solution later?
 By upgrading to Sitecore Experience Manager 10.2 now, you will be better positioned to transition to XM Cloud because XM Cloud will use a derivative of the 10.2 release. However, note that XM Cloud will only support a headless Experience Manager implementation using the Sitecore JavaScript Rendering SDK (JSS), publishing to Sitecore Experience Edge. If your current XM/XP site is MVC-based, you will need to convert it to a JSS and Experience Edge-based implementation before it can be run in XM Cloud.  
@@ -26,7 +26,7 @@ Sitecore anticipates two types of Experience Manager releases in the XM Cloud fo
 
 Sitecore’s goal with these releases is to ensure that customers and their implementation partners benefit from the latest version of Experience Manager as easily as possible.
 
-Sitecore will notify customers and partners in advance of the releases whenever possible for planning purposes. More clarification coming after Sitecore Symposium 2022.
+Sitecore will notify customers and partners in advance of the releases whenever possible for planning purposes. Additional details on the environment updates are available in the documentation: [SaaS Environment Updates](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-manager-cloud.html#saas-environment-updates)
 
 ## Will Data Exchange Framework be available?
 Adoption and usage scenarios with XM Cloud and Data Exchange Framework are currently being evaluated.


### PR DESCRIPTION
Removed confusing reference to XM in the XM Cloud FAQ. No longer implying there is a possibility for automatic updates of XM. Also added links to existing docs about upgrades instead of "more clarification after Symposium 2022"

## How Has This Been Tested?
Tested on Vercel preview site.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
