### PR TITLE
Updated OC Learning courses link

### DIFF
--- a/apps/devportal/data/markdown/partials/solution/commerce/ordercloud.md
+++ b/apps/devportal/data/markdown/partials/solution/commerce/ordercloud.md
@@ -66,4 +66,4 @@ We also have some integration guides that will help you connect multiple Sitecor
 
 If you are interested and want to learn more, please consider these courses at Learning@Sitecore
 
-- [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Sitecore OrderCloud
+- [OrderCloud for Developers](https://learning.sitecore.com/learn/learning_plan/view/24/ordercloud-for-developers) - OrderCloud for Developers


### PR DESCRIPTION
Fixes broken learning link on OrderCloud product page

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM

Closes #532 