### PR TITLE
Remove hardcoded black text, default color works in light and dark mode

### DIFF
--- a/packages/ui/components/integrations/sitecoreCommunity/SitecoreCommunityNewsOrEventItem.tsx
+++ b/packages/ui/components/integrations/sitecoreCommunity/SitecoreCommunityNewsOrEventItem.tsx
@@ -51,7 +51,7 @@ export const SitecoreCommunityNewsOrEventItem = ({ categoryTitle, commentCount, 
           {!!categoryTitle && <Heading variant="section">{categoryTitle}</Heading>}
 
           <Heading size={'sm'} my={4}>
-            <LinkOverlay as={NextLink} href={`${SITECORE_COMMUNITY_URL}${url}`} isExternal={true} rel="noreferrer noopener" target="_blank" color={'black'}>
+            <LinkOverlay as={NextLink} href={`${SITECORE_COMMUNITY_URL}${url}`} isExternal={true} rel="noreferrer noopener" target="_blank">
               {title}
             </LinkOverlay>
           </Heading>


### PR DESCRIPTION
The title text in Community News was hardcoded to black. This was difficult to read in dark mode. The default color when no color was set is better.

But on a different note, the "Community News" gets extremely infrequent updates. A single news item in 2023 should it be removed? Or should we make an effort to make more news announcements? 

## Description / Motivation

Improve Readability in dark mode.

## How Has This Been Tested?

Visual

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
