### PR TITLE
Adding in link to the Mobile App Tagging Overview doc on the knowledge base

### DIFF
--- a/apps/devportal/data/markdown/pages/customer-data-management/cdp.md
+++ b/apps/devportal/data/markdown/pages/customer-data-management/cdp.md
@@ -52,6 +52,7 @@ If you are interested and want to learn more, please visit Learning@Sitecore.
 ## Resources
 
 - [XM Cloud: Embedded Personalization FAQ](/learn/faq/xm-cloud-embedded-personalization)
+- [CDP Mobile App Tagging Overview](https://sitecore.cdpknowledgehub.com/docs/mobile-app-tagging-overview)
 - [Blog: Sitecore CDP Audience Sync Automation](https://community.sitecore.com/community?id=community_blog&sys_id=46a5fcc11be15d10b8954371b24bcb85)
 - [Blog: Product Comparisons](https://community.sitecore.com/community?id=community_blog&sys_id=d8fdc45d1bb6811038a46421b24bcbb7)
 - [Blog: Product Specifications/Comparisons part 2](https://community.sitecore.com/community?id=community_blog&sys_id=f0862b751bf6491038a46421b24bcb65)


### PR DESCRIPTION
## Description / Motivation
Been asked a few times about CDP mobile tagging. Adding the link to the dev portal page as a Resource.

## How Has This Been Tested?
Tested on Vercel

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
