### PR TITLE
Use full size images for changelog entries

### DIFF
--- a/apps/devportal/src/components/changelog/ChangeLogItem.tsx
+++ b/apps/devportal/src/components/changelog/ChangeLogItem.tsx
@@ -52,7 +52,7 @@ const ChangeLogItem = ({ item, loading, loadEntries, isLast, isMore }: ChangeLog
         <CardBody py={0}>
           {item.image.length > 0 && (
             <>
-              <Image src={`${item.image[0].fileUrl}?width=665&fit=contain&transform=true`} alt={item.title || ''} borderRadius={'lg'} onClick={onOpen} cursor={'zoom-in'} mb={4} maxW={'full'} maxH={'450'} />
+              <Image src={`${item.image[0].fileUrl}`} alt={item.title || ''} borderRadius={'lg'} onClick={onOpen} cursor={'zoom-in'} mb={4} maxW={'full'} />
 
               <Modal isOpen={isOpen} onClose={onClose} isCentered closeOnOverlayClick size={'6xl'}>
                 <ModalOverlay />

--- a/apps/devportal/src/pages/changelog/[product]/[entry].tsx
+++ b/apps/devportal/src/pages/changelog/[product]/[entry].tsx
@@ -119,7 +119,7 @@ const ChangelogProduct = ({ currentProduct, changelogEntry }: ChangelogProps) =>
                 <CardBody py={0}>
                   {changelogEntry.image.length > 0 && (
                     <>
-                      <Image src={`${changelogEntry.image[0].fileUrl}?width=665&fit=contain&transform=true`} alt={changelogEntry.title || ''} borderRadius={'lg'} onClick={onOpen} cursor={'zoom-in'} mb={4} maxW={'full'} />
+                      <Image src={`${changelogEntry.image[0].fileUrl}`} alt={changelogEntry.title || ''} borderRadius={'lg'} onClick={onOpen} cursor={'zoom-in'} mb={4} maxW={'full'} />
 
                       <Modal isOpen={isOpen} onClose={onClose} isCentered closeOnOverlayClick size={'6xl'}>
                         <ModalOverlay />


### PR DESCRIPTION
## Description / Motivation
To workaround the 'blury' transformation generated by Cloudflare we are now using full size images

## How Has This Been Tested?
Local and Vercel

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
