### PR TITLE
Fixed issue where Search API requests were doubling Widget data

### DIFF
--- a/apps/devportal/src/pages/_app.tsx
+++ b/apps/devportal/src/pages/_app.tsx
@@ -13,6 +13,8 @@ import TopBarProgress from 'react-topbar-progress-indicator';
 import { AvenirNextR } from 'ui/common/fonts/avenirNextR';
 import { PreviewProvider } from '../context/PreviewContext';
 
+const SearchWrapper = ({ children }: any) => (IsSearchEnabled() ? <WidgetsProvider {...SEARCH_CONFIG}>{children}</WidgetsProvider> : children);
+
 function MyApp({ Component, pageProps }: AppProps) {
   const [progress, setProgress] = useState(false);
   const [hostname, setHostname] = useState('');
@@ -50,8 +52,6 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
     setHostname(window.location.host);
   });
-
-  const SearchWrapper = ({ children }: any) => (IsSearchEnabled() ? <WidgetsProvider {...SEARCH_CONFIG}>{children}</WidgetsProvider> : children);
 
   return (
     <SearchWrapper>


### PR DESCRIPTION
Currently, there is an issue with how we're conditionally creating/recreating the WidgetProvider used by the Search SDK. This is causing the Widget data in the request to be doubled for each request. Moving the definition outside MyApp fixes this issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM

Closes #561 