### PR TITLE
Extended the Changelog API to include full product info

### DIFF
--- a/apps/devportal/src/pages/api/changelog/v1/indexing.ts
+++ b/apps/devportal/src/pages/api/changelog/v1/indexing.ts
@@ -16,7 +16,7 @@ type IndexingList = {
 type IndexResult = {
   title: string;
   changeTypes: string[];
-  products: string[];
+  products: IndexProduct[];
   date: string;
   description: string;
   fullArticle?: string | null;
@@ -25,6 +25,14 @@ type IndexResult = {
   image?: string | null;
   url: string;
 };
+
+type IndexProduct = {
+  name: string;
+  description: string;
+  darkIcon: string;
+  lightIcon: string;
+  sitecoreClouds: string[];
+}
 
 const handler = async (req: NextApiRequest, res: NextApiResponse<IndexingList>) => {
   // Default Edge pageSize is 10, use parameter to override
@@ -46,7 +54,13 @@ async function GetEntries(list: IndexResult[], end: string, limit: string) {
     list.push({
       title: entry.title,
       changeTypes: entry.changeType.map((obj) => obj.changeType),
-      products: entry.sitecoreProduct.map((obj) => obj.productName),
+      products: entry.sitecoreProduct.map((obj) => <IndexProduct>{
+        name: obj.productName,
+        description: obj.productDescription,
+        darkIcon: obj.darkIcon,
+        lightIcon: obj.lightIcon,
+        sitecoreClouds: obj.sitecoreCloud.results.map((cloud) => cloud.cloudName)
+      }),
       date: entry.releaseDate,
       image: entry.image[0] != null ? entry.image[0].fileUrl : null,
       description: entry.description,


### PR DESCRIPTION
In order to build out the ChangeLog API with Search, it's going to be simpler to include all of the product information in the response that in Indexed, instead of having to request it again from CH-ONE.

This change will enable that, and will make it simpler to switch the UI over to be based on Sitecore Search

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
