### PR TITLE
Renaming app to 'Content Migration'

### DIFF
--- a/apps/devportal/data/markdown/pages/content-management/xm-cloud.md
+++ b/apps/devportal/data/markdown/pages/content-management/xm-cloud.md
@@ -59,7 +59,7 @@ The importance of your company's growth comes with the:
 ## Downloads
 
 <Row columns={2}>
-<Article title="XM to XMC Migration tool" description="Move content, media and user data from a source XM on-premises instance to a target XM Cloud environment." link="/downloads/xm-cloud#xm-to-xmc-migration-tool" maxWidth="sm" linktext="Download"  />
+<Article title="XM to XMC Content Migration tool" description="Move content, media and user data from a source XM on-premises instance to a target XM Cloud environment." link="/downloads/xm-cloud#xm-to-xmc-migration-tool" maxWidth="sm" linktext="Download"  />
 </Row>
 
 ## Learn & Examples

--- a/apps/devportal/data/markdown/pages/downloads/xm-cloud/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/xm-cloud/index.md
@@ -20,9 +20,9 @@ This page will provide you with the downloads of new and updated resources to he
   linkHref="/content-management/xm-cloud" isImageLeft={false}
 />
 
-## XM to XM Cloud Migration tool
+## XM to XM Cloud Content Migration tool
 
-Use the XM to XM Cloud Migration tool to help move content, media and user data from a source XM on-premises instance to a target XM Cloud environment. This tool acts as middleware that simplifies the task of entering and selecting data, and orchestrating the migration. Our first version is based on the underlying Sitecore CLI and Sitecore Content Serialization (SCS) technologies.
+Use the XM to XM Cloud Content Migration tool to help move content, media and user data from a source XM on-premises instance to a target XM Cloud environment. This tool acts as middleware that simplifies the task of entering and selecting data, and orchestrating the migration. Our first version is based on the underlying Sitecore CLI and Sitecore Content Serialization (SCS) technologies.
 
 - **Supported versions**: Sitecore platform on-premise releases **10.1 and later**.
 


### PR DESCRIPTION
## Description / Motivation
After feedback from the field, doing a slight rename to focus in on the 'content' part and make sure people are not confused between different migration tools.

## How Has This Been Tested?
On Vercel preview site.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
