### PR TITLE
Add XMC migration tool to migration resources page

### DIFF
--- a/apps/devportal/data/markdown/pages/content-management/xm-cloud.md
+++ b/apps/devportal/data/markdown/pages/content-management/xm-cloud.md
@@ -59,7 +59,7 @@ The importance of your company's growth comes with the:
 ## Downloads
 
 <Row columns={2}>
-<Article title="XM to XMC Content Migration tool" description="Move content, media and user data from a source XM on-premises instance to a target XM Cloud environment." link="/downloads/xm-cloud#xm-to-xmc-migration-tool" maxWidth="sm" linktext="Download"  />
+<Article title="XM to XM Cloud Content Migration tool" description="Move content, media and user data from a source XM on-premises instance to a target XM Cloud environment." link="/downloads/xm-cloud#xm-to-xm-cloud-content-migration-tool" maxWidth="sm" linktext="Download"  />
 </Row>
 
 ## Learn & Examples

--- a/apps/devportal/data/markdown/pages/learn/getting-started/migrating-to-the-sitecore-composable-dxp/index.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/migrating-to-the-sitecore-composable-dxp/index.md
@@ -26,7 +26,13 @@ This guide provides an overview for existing customers of the Platform DXP (XP, 
 <Repository framework="Nextjs" name="XM Cloud Introduction" description="An example of a real XM Cloud implementation that can be useful with your own XM Cloud migration projects." repositoryUrl="https://github.com/sitecore/xm-cloud-introduction" />
 </Row>
 
-### Resources
+### Tools
+
+<Row columns={2}>
+  <Article title="XM to XM Cloud Content Migration tool" description="Move content, media and user data from a source XM on-premises instance to a target XM Cloud environment." link="/downloads/xm-cloud#xm-to-xm-cloud-content-migration-tool" linktext="Download" />
+</Row>
+
+### Articles
 
 <Row columns={2}>
   <Article title="Migrating the Sitecore MVP site" description="An introduction to the purpose of the series and the initial steps to migrate from XM on-Prem to XM Cloud." link="https://robearlam.com/blog/migrating-the-sitecore-mvp-site-to-xm-cloud-part-1" />


### PR DESCRIPTION
## Description / Motivation
Now that the migration tool download is available, we need to make it available on the migration resources page. 

**NOTE:** At the same time, a small fix to the title and link to the tool on the XMC product page was made.

## How Has This Been Tested?
Tested locally and on Vercel that the page loads and that the links work.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
