### PR TITLE
Wrap entire button in Link

### DIFF
--- a/packages/ui/components/cards/Article.tsx
+++ b/packages/ui/components/cards/Article.tsx
@@ -38,11 +38,11 @@ export const Article = ({ title, description, link, linktext, imageUrl, hideLink
       </CardBody>
       {link && !hideLinkText && (
         <CardFooter pt={0}>
-          <Button rightIcon={<Icon path={mdiArrowRight} size={0.8} />}>
-            <Link as={NextLink} href={link} color={useColorModeValue('white', 'black !important')}>
+          <Link as={NextLink} href={link} color={useColorModeValue('white', 'black !important')}>
+            <Button rightIcon={<Icon path={mdiArrowRight} size={0.8} />}>
               {linktext ?? 'Read more'}
-            </Link>
-          </Button>
+            </Button>
+          </Link>
         </CardFooter>
       )}
     </Card>

--- a/packages/ui/components/integrations/stackexchange/StackExchangeFeed.tsx
+++ b/packages/ui/components/integrations/stackexchange/StackExchangeFeed.tsx
@@ -41,12 +41,12 @@ export const StackExchangeFeed = ({ data, title, ...rest }: StackExchangeFeedPro
                 {question.tags.length && (
                   <Stack direction={{ base: 'column', sm: 'row' }} shouldWrapChildren maxWidth={'90%'}>
                     {question.tags.map((tag) => (
-                      <Button variant={'solid'} colorScheme="purple" size={{ base: 'xs', md: 'sm' }} borderRadius={0} key={tag}>
-                        <Link href={`https://sitecore.stackexchange.com/questions/tagged/${tag}`} target="_blank" rel="noopener noreferrer" color={useColorModeValue('white', 'black !important')}>
+                      <Link href={`https://sitecore.stackexchange.com/questions/tagged/${tag}`} target="_blank" rel="noopener noreferrer" color={useColorModeValue('white', 'black !important')}>
+                        <Button variant={'solid'} colorScheme="purple" size={{ base: 'xs', md: 'sm' }} borderRadius={0} key={tag}>
                           {tag}
                           <VisuallyHidden>Opens in a new tab</VisuallyHidden>
-                        </Link>
-                      </Button>
+                        </Button>
+                      </Link>
                     ))}
                   </Stack>
                 )}

--- a/packages/ui/components/promos/ctaCard/CTACard.tsx
+++ b/packages/ui/components/promos/ctaCard/CTACard.tsx
@@ -14,11 +14,11 @@ export const CTACard = ({ description, href, linkText, title, link2Text, link2hr
       <Text variant={'large'} mb={6}>
         {description}
       </Text>
-      <Button size={'lg'} variant={'solid'} rightIcon={<Icon path={mdiArrowRight} size={0.8} />}>
-        <Link href={href} as={NextLink} color={useColorModeValue('white', 'black !important')}>
+      <Link href={href} as={NextLink} color={useColorModeValue('white', 'black !important')}>
+        <Button size={'lg'} variant={'solid'} rightIcon={<Icon path={mdiArrowRight} size={0.8} />}>
           {linkText}
-        </Link>
-      </Button>
+        </Button>
+      </Link>
 
       {link2href && link2Text && <ButtonLink href={link2href} text={link2Text} size={'xl'} />}
     </CardBody>


### PR DESCRIPTION
## Description / Motivation

For some buttons, only the text was wrapped in the `Link` component not the entire button. Fixed `<Article>`, `<CTAcard>`, and stack exchange topic buttons. 

One case that still exists is with the `LinkItem` component. That uses a different `ButtonLink` component within it requiring a larger refactoring. I did not fix that case so behavior still exists 
![image](https://github.com/Sitecore/developer-portal/assets/24610108/2acdd255-45e0-4e3a-83ef-4ceba8869458)


## How Has This Been Tested?

Manual testing

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
