### PR TITLE
Add downloads page

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/index.md
@@ -1,0 +1,5 @@
+---
+pageType: 'childoverview'
+title: 'Downloads'
+description: 'Download Sitecore software, tools and resources'
+---

--- a/apps/devportal/src/components/navigation/Footer.tsx
+++ b/apps/devportal/src/components/navigation/Footer.tsx
@@ -4,7 +4,7 @@ import { FaFacebook, FaInstagram, FaLinkedin, FaTwitter, FaYoutube } from 'react
 import { SocialButton } from 'ui/components/links/SocialButton';
 
 export const Footer = () => (
-  <Box bg={'chakra-subtle-bg'} borderTop={'1px'} borderColor={'chakra-border-color'}>
+  <Box bg={'chakra-subtle-bg'} borderTop={'1px'} borderColor={'chakra-border-color'} position={'absolute'} bottom={0} left={0} width={'full'}>
     <Container as={Stack} maxW={'6xl'} py={4} px={2} direction={{ base: 'column', md: 'column' }} spacing={4}>
       <Stack direction={'row'} spacing={6}>
         <SocialButton label={'Twitter'} href={'https://twitter.com/WeAreSitecore'} aria-label="Twitter">

--- a/apps/devportal/src/layouts/ChildOverviewPage.tsx
+++ b/apps/devportal/src/layouts/ChildOverviewPage.tsx
@@ -1,7 +1,6 @@
 import { Button, Card, CardBody, CardFooter, CardHeader, Grid, GridItem, Link, SimpleGrid, Text } from '@chakra-ui/react';
 
 import { ChildPageInfo, PageInfo, PagePartialGroup, PartialData, SubPageNavigation } from '@lib/interfaces/page-info';
-import SocialFeeds from '@src/components/common/SocialFeeds';
 import { RenderContent } from '@src/components/markdown/MarkdownContent';
 import Layout from '@src/layouts/Layout';
 import Hero from 'ui/components/common/Hero';
@@ -53,7 +52,7 @@ const ChildOverviewPage = ({ pageInfo, promoAfter, promoBefore, childPageInfo, s
           <CenteredContent>
             <SimpleGrid columns={{ base: 1, md: 2 }} spacing={10}>
               {childPageInfo.map((childPage, i) => (
-                <Card variant={'elevated'} size="md" key={i}>
+                <Card variant={'outlineRaised'} size="md" layerStyle={'interactive.raise'} key={i}>
                   <CardHeader>
                     <TextLink isHeading as={'h3'} text={childPage.title} aria-label={childPage.title} href={childPage.link} />
                   </CardHeader>
@@ -70,12 +69,15 @@ const ChildOverviewPage = ({ pageInfo, promoAfter, promoBefore, childPageInfo, s
             </SimpleGrid>
           </CenteredContent>
         </VerticalGroup>
-        <VerticalGroup>
+        {/* <VerticalGroup>
           <CenteredContent>
             <PromoList data={promoAfter} />
-            <SocialFeeds pageInfo={pageInfo} />
+            <YouTubeFeed data={pageInfo.youtube} title={pageInfo.youtubeTitle} playlistTitle={pageInfo.youtubePlaylistTitle} />
+            <SitecoreCommunityQuestions data={pageInfo.sitecoreCommunity.questions} sortKeys={pageInfo.sitecoreCommunityQuestionsSort} forumKeys={pageInfo.sitecoreCommunityQuestionsCategory} />
+            <StackExchangeFeed data={pageInfo.stackexchange} />
+            <SitecoreCommunityBlog entries={pageInfo.sitecoreCommunity.blog} sortKeys={pageInfo.sitecoreCommunityBlogSort} />
           </CenteredContent>
-        </VerticalGroup>
+        </VerticalGroup> */}
       </ThreeColumnLayout>
     </Layout>
   );

--- a/apps/devportal/src/layouts/Layout.tsx
+++ b/apps/devportal/src/layouts/Layout.tsx
@@ -43,7 +43,7 @@ const Layout = ({ title, description = '', openGraphImage, children, ...rest }: 
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
 
-      <Box as="main" style={{ minHeight: 'calc(100vh - 50px)' }} {...rest}>
+      <Box as="main" {...rest}>
         <VisuallyHidden>
           <a href="#main-content">Skip to main content</a>
         </VisuallyHidden>

--- a/apps/devportal/src/layouts/ThreeColumnLayout.tsx
+++ b/apps/devportal/src/layouts/ThreeColumnLayout.tsx
@@ -6,11 +6,12 @@ type ThreeColumnLayoutProps = {
   sidebar: React.ReactNode;
   inPageNav: React.ReactNode;
   children: React.ReactNode;
+  background?: string;
 };
 
-export const ThreeColumnLayout = ({ sidebar, inPageNav, children }: ThreeColumnLayoutProps) => {
+export const ThreeColumnLayout = ({ sidebar, inPageNav, children, ...rest }: ThreeColumnLayoutProps) => {
   return (
-    <Flex flexGrow={0} justify={'space-between'} width={'full'} gap={0} direction={{ base: 'column', md: 'row' }}>
+    <Flex flexGrow={0} justify={'space-between'} width={'full'} gap={0} direction={{ base: 'column', md: 'row' }} {...rest} flexFlow={'column'}>
       <Sidebar showBackground>{sidebar}</Sidebar>
 
       <Box maxW={'7xl'} as="main" paddingX={{ base: 4, md: 'inherit' }}>

--- a/apps/devportal/src/pages/_app.tsx
+++ b/apps/devportal/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { ChakraProvider } from '@chakra-ui/react';
+import { Box, ChakraProvider } from '@chakra-ui/react';
 import { IsSearchEnabled, SEARCH_CONFIG } from '@lib/search';
 import { scdpTheme } from '@lib/theme/theme';
 import { PageController, WidgetsProvider, trackEntityPageViewEvent } from '@sitecore-search/react';
@@ -95,9 +95,9 @@ function MyApp({ Component, pageProps }: AppProps) {
           <Navbar>
             <SearchInputSwitcher />
           </Navbar>
-          <div ref={contentInnerRef}>
+          <Box ref={contentInnerRef} paddingBottom={{ base: 32, md: 20 }}>
             <Component {...pageProps} />
-          </div>
+          </Box>
           <Footer />
         </PreviewProvider>
       </ChakraProvider>

--- a/apps/devportal/src/pages/_document.tsx
+++ b/apps/devportal/src/pages/_document.tsx
@@ -11,7 +11,7 @@ export class MyDocument<P = {}> extends Component<DocumentProps & P> {
 
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" style={{ height: '100%' }}>
         <Head />
         <body style={{ scrollMarginTop: '9em' }}>
           <Main />


### PR DESCRIPTION
## Description / Motivation
Fixes #575 

Adding a (temporary) downloads page that lists sub items. Will be replaced with proper page once dev migration is completed. PR also includes a fix to make the footer stick to bottom.

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-git-issue-57-cecb24-sitecoretechnicalmarketing.vercel.app/downloads)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
