### PR TITLE
Promote SUGCON events on Community page

### DIFF
--- a/apps/devportal/data/markdown/pages/community.md
+++ b/apps/devportal/data/markdown/pages/community.md
@@ -11,8 +11,8 @@ sitecoreCommunityQuestionsSort: ['publish', 'view']
 
 <Promo
   title="Connect at events around the globe!"
-  description="The Sitecore User Group Conference (SUGCON) series of regional, community-run, events take place all around the world. Join together with Sitecore developers and users to gain knowledge, get inspired, and connect with the rest of the Sitecore community! "
+  description="The Sitecore User Group Conference (SUGCON) is a series of regional, community-run, events that take place all around the world. Join together with Sitecore developers and users to gain knowledge, get inspired, and connect with the rest of the Sitecore community! "
   imageSource="https://sugcon.events/img/SUGCON-Europe-2022.jpg"
-  linkText="Learn more about SUGCON"
+  linkText="Find out where the next SUGCON is happening!"
   linkHref="https://www.sugcon.events" isImageLeft={false}
 />

--- a/apps/devportal/data/markdown/pages/community.md
+++ b/apps/devportal/data/markdown/pages/community.md
@@ -11,7 +11,7 @@ sitecoreCommunityQuestionsSort: ['publish', 'view']
 
 <Promo
   title="Connect at events around the globe!"
-  description="SUGCThe Sitecore User Group Conference (SUGCON) a community-run event which brings the community together in different regions around the world. Gain knowledge, get inspired, and connect with the rest of the Sitecore community! "
+  description="The Sitecore User Group Conference (SUGCON) series of regional, community-run, events take place all around the world. Join together with Sitecore developers and users to gain knowledge, get inspired, and connect with the rest of the Sitecore community! "
   imageSource="https://sugcon.events/img/SUGCON-Europe-2022.jpg"
   linkText="Learn more about SUGCON"
   linkHref="https://www.sugcon.events" isImageLeft={false}

--- a/apps/devportal/data/markdown/pages/community.md
+++ b/apps/devportal/data/markdown/pages/community.md
@@ -13,6 +13,6 @@ sitecoreCommunityQuestionsSort: ['publish', 'view']
   title="Connect at events around the globe!"
   description="The Sitecore User Group Conference (SUGCON) is a series of regional, community-run, events that take place all around the world. Join together with Sitecore developers and users to gain knowledge, get inspired, and connect with the rest of the Sitecore community! "
   imageSource="https://sugcon.events/img/SUGCON-Europe-2022.jpg"
-  linkText="Find out where the next SUGCON is happening!"
+  linkText="Find a SUGCON near you!"
   linkHref="https://www.sugcon.events" isImageLeft={false}
 />

--- a/apps/devportal/data/markdown/pages/community.md
+++ b/apps/devportal/data/markdown/pages/community.md
@@ -10,9 +10,9 @@ sitecoreCommunityQuestionsSort: ['publish', 'view']
 ---
 
 <Promo
-  title="Recommended Practices"
-  description="Are you getting started with building on XM Cloud? Check out the new recommended tips for teams working on XM Cloud projects! "
-  imageSource="https://sitecorecontenthub.stylelabs.cloud/api/public/content/c612f3d1efbe4e0cb946ab96d0b4aea1?v=0cca3868"
-  linkText="Read now!"
-  linkHref="/learn/faq/xm-cloud-recommended-practices" isImageLeft={false}
+  title="Connect at events around the globe!"
+  description="SUGCThe Sitecore User Group Conference (SUGCON) a community-run event which brings the community together in different regions around the world. Gain knowledge, get inspired, and connect with the rest of the Sitecore community! "
+  imageSource="https://sugcon.events/img/SUGCON-Europe-2022.jpg"
+  linkText="Learn more about SUGCON"
+  linkHref="https://www.sugcon.events" isImageLeft={false}
 />


### PR DESCRIPTION
## Description / Motivation
Updated the promo at the top of the Community page to highlight the SUGCON events.

## How Has This Been Tested?
Tested on Vercel (local is currently broken)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
