### PR TITLE
Remove JSS trial references

### DIFF
--- a/apps/devportal/data/markdown/pages/content-management/headless.md
+++ b/apps/devportal/data/markdown/pages/content-management/headless.md
@@ -5,7 +5,6 @@ title: 'Sitecore Headless Development'
 description: 'Using Sitecore in a headless architecture'
 stackexchange: ['#jss']
 youtube: 'PL1jJVFm_lGnwZup4L4BjITS2sKr4rpMfI'
-
 ---
 
 ## Introduction
@@ -41,7 +40,6 @@ Sitecore JSS offers front-end developer of whole new way of working and interact
 
 ## Examples
 
-- [JSS Developer Trial](https://www.sitecore.com/knowledge-center/getting-started/developer-trial)
 - [JSS Developer Trial - Connected Demo guide](/trials/jss-connected-demo/getting-started/prerequisites)
 - [JSS Source Code](https://github.com/Sitecore/jss)
 - [JSS Sample Code](https://github.com/Sitecore/jss/tree/master/packages/create-sitecore-jss/src/templates)
@@ -53,7 +51,6 @@ Sitecore JSS offers front-end developer of whole new way of working and interact
 - [#SitecoreJSS Twitter](https://twitter.com/search?q=sitecorejss&src=typed_query&f=live)
 - [JSS Slack Channel](https://sitecorechat.slack.com/messages/jss)
 - [Github Repository](https://github.com/sitecore/jss)
-
 
 ## Headless Development
 
@@ -72,4 +69,3 @@ Sitecore Headless Development is based on a rendering host front end and a Sitec
 ## Downloads
 
 - [Download Sitecore Headless Rendering](https://dev.sitecore.net/Downloads/Sitecore_Headless_Rendering.aspx)
-

--- a/apps/devportal/data/markdown/pages/trials/index.md
+++ b/apps/devportal/data/markdown/pages/trials/index.md
@@ -16,18 +16,12 @@ Digital experience is a team sport. Modernize your content management architectu
 
 Fully API-driven, our architecture enables your team to build for any channel with the frameworks you already use, or use connectors to speed up system integration to your existing tech stack.
 
-<Row columns={3}>
-  <Article 
-    title="Sitecore front-end developer trial" 
-    description="Are you a front-end developer looking to level-up your career? The trial will teach you the basics of our javascript headless services, step by step. Additionally, you will get a taste of Sitecore's personalization capabilities, one of its most powerful features — it's what distinguishes it from other CMS." 
-    link="https://www.sitecore.com/trial" 
-    linktext="Sign up now!" />
-
+<Row columns={2}>
   <Article 
     title="Moosend" 
     description="Moosend provides all the necessary tools to get you started down your email marketing path. If you're well underway on your email marketing journey and you just traversed through other ESPs to our platform, you'll be happy to know that we give you state-of-the art features that will expand your toolbox and make your life easier." 
     link="https://identity.moosend.com/register/" 
-    linktext="Start by creating your own account!" />
+    linktext="Create your account!" />
 
   <Article 
     title="Sitecore OrderCloud" 

--- a/apps/devportal/data/markdown/pages/trials/jss-connected-demo/index.md
+++ b/apps/devportal/data/markdown/pages/trials/jss-connected-demo/index.md
@@ -2,6 +2,7 @@
 title: 'JSS Connected Demo'
 description: 'Unlock the full potential of Sitecore with JSS in a live demo environment.'
 ---
+
 ## Introduction
 
 The trial will teach you the basics of JSS, step by step. Additionally, you will get a taste of Sitecore's personalization capabilities, one of its most powerful features — it's what distinguishes it from other CMSs. The developer trial program offers a pre-configured Sitecore instance, access to guided learning materials, community portals for peer-to-peer support and advanced notice on developer events and giveaways
@@ -12,7 +13,7 @@ This trial is recommended for JavaScript developers who have at least a basic un
 
 ## How can I sign up?
 
-Please follow [this link](https://www.sitecore.com/knowledge-center/getting-started/developer-trial) to register for the trial. You will receive a confirmation email to get you started.
+Please follow [this link](https://developers.sitecore.com/trials) to register for any developer trials available from Sitecore. You will receive a confirmation email to get you started.
 
 ## What does the trial include?
 

--- a/apps/devportal/data/markdown/partials/solution/content-management/jss.md
+++ b/apps/devportal/data/markdown/partials/solution/content-management/jss.md
@@ -28,7 +28,6 @@ Sitecore JSS offers front-end developer of whole new way of working and interact
 
 ## Examples
 
-- [JSS Developer Trial](https://www.sitecore.com/knowledge-center/getting-started/developer-trial)
 - [JSS Developer Trial - Connected Demo guide](/trials/jss-connected-demo/getting-started/prerequisites)
 - [JSS Source Code](https://github.com/Sitecore/jss)
 - [JSS Sample Code](https://github.com/Sitecore/jss/tree/master/packages/create-sitecore-jss/src/templates)


### PR DESCRIPTION
## Description / Motivation
As part of decommissioning the old JSS Trial, this Pull Request removes all references to the links for the current trial. The forms are still live on sitecore.com at this moment, but we are slowly removing the paths to getting to the form in advance of removing the forms.

## How Has This Been Tested?
Tested locally. Small content changes only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
