### PR TITLE
Use full version of syntax highlight

### DIFF
--- a/apps/devportal/src/components/markdown/MarkdownContent.tsx
+++ b/apps/devportal/src/components/markdown/MarkdownContent.tsx
@@ -5,13 +5,13 @@ import { mdiSquareEditOutline } from '@mdi/js';
 import { Icon } from '@mdi/react';
 import { Prose } from '@nikolovlazar/chakra-ui-prose';
 import { MDXRemote } from 'next-mdx-remote';
-import { Light as SyntaxHighlight } from 'react-syntax-highlighter';
 import { Article, LinkItem, Repository } from 'ui/components/cards';
 import { Row } from 'ui/components/helpers/Row';
 import { ButtonLink } from 'ui/components/links/ButtonLink';
 import { Promo, VideoPromo } from 'ui/components/promos';
 import YouTube from 'ui/components/video/YouTube';
 
+import SyntaxHighlighter from 'react-syntax-highlighter';
 import { Download } from 'ui/components/cards/Download';
 import { Group } from 'ui/components/cards/Group';
 import styles from './MarkdownContent.module.css'; /* eslint-disable react/no-unknown-property */
@@ -47,9 +47,9 @@ export const DecoratedMarkdown = ({ children }: DecoratedMarkdownProps): JSX.Ele
             const match = /language-(\w+)/.exec(className || '');
             const lang = match ? match[1] : '';
             return match ? (
-              <SyntaxHighlight style={a11yDark} language={lang} className="no-prose" PreTag={'div'} customStyle={{ background: 'inherit', display: 'inline-grid', width: '100%' }} wrapLongLines wrapLines>
+              <SyntaxHighlighter style={a11yDark} language={lang} className="no-prose" PreTag={'div'} customStyle={{ background: 'inherit', display: 'inline-grid', width: '100%' }} wrapLongLines wrapLines>
                 {String(children).replace(/\n$/, '')}
-              </SyntaxHighlight>
+              </SyntaxHighlighter>
             ) : (
               <code className={className}>{children}</code>
             );


### PR DESCRIPTION
## Description / Motivation
Fixes #604 - Use full version of syntax highlighter to resolve [bug](https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/263)

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-git-issue-60-37a375-sitecoretechnicalmarketing.vercel.app/contribute/components)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
