### PR TITLE
UI updates for the Accelerate content

### DIFF
--- a/apps/devportal/src/components/common/contribute.tsx
+++ b/apps/devportal/src/components/common/contribute.tsx
@@ -1,30 +1,28 @@
 import { PageInfo } from '@/src/lib/interfaces/page-info';
-import { Card, CardBody, Heading, Link, Text } from '@chakra-ui/react';
+import { Alert, AlertDescription, AlertIcon, AlertTitle, Button, Link, Stack } from '@chakra-ui/react';
 
 type GithubContributionNoticeProps = {
   pageInfo: PageInfo;
 };
 
 const GithubContributionNotice = ({ pageInfo }: GithubContributionNoticeProps) => {
-  // Only show this notice on pages that are in the Accelerate area  
-  if (pageInfo?.area?.findIndex(a => a.toLocaleLowerCase() === 'accelerate')) {
+  // Only show this notice on pages that are in the Accelerate area
+  if (!pageInfo?.area?.includes('accelerate')) {
     return null;
   }
 
   return (
-    <Card>
-      <CardBody>
-        <Heading as="h2"  mb="4" size='md'>Have a recipe suggestion?</Heading>
-        <Text>
-          If you have a recipe suggestion to share, please create a pull request on the Github repository. If you have a question or feedback, please submit an issue.<br /><br />
-          <Link href="/contribute">
-            Click here for instructions on how to contribute.
-          </Link>
-        </Text>
-      </CardBody>
-    </Card>
+    <Alert>
+      <AlertIcon />
+      <Stack align={'flex-start'}>
+        <AlertTitle>Have a recipe suggestion?</AlertTitle>
+        <AlertDescription>If you have a recipe suggestion to share, please create a pull request on the Github repository. If you have a question or feedback, please submit an issue.</AlertDescription>
+        <Button variant="link">
+          <Link href="/contribute">Click here for instructions on how to contribute.</Link>
+        </Button>
+      </Stack>
+    </Alert>
   );
-
 };
 
 export default GithubContributionNotice;

--- a/apps/devportal/src/components/navigation/ChildNavigation.tsx
+++ b/apps/devportal/src/components/navigation/ChildNavigation.tsx
@@ -99,7 +99,13 @@ function renderMenuGroup(child: SubPageNavigationItem, basePath: string, index?:
 
   return (
     <React.Fragment key={index}>
-      <Button rightIcon={currentRouteIncludesChild ? undefined : <Icon onClick={onToggle}>{isOpen ? <path d={mdiChevronDown} /> : <path d={mdiChevronRight} />}</Icon>} justifyContent={'space-between'} width={'full'} transition={'ease-in-out'}>
+      <Button
+        rightIcon={currentRouteIncludesChild ? undefined : <Icon onClick={onToggle}>{isOpen ? <path d={mdiChevronDown} /> : <path d={mdiChevronRight} />}</Icon>}
+        justifyContent={'space-between'}
+        width={'full'}
+        transition={'ease-in-out'}
+        onClick={child.ignoreLink ? onToggle : undefined}
+      >
         {child.ignoreLink ? (
           <Text px={2}>{child.title}</Text>
         ) : (

--- a/apps/devportal/src/lib/theme/proseTheme.ts
+++ b/apps/devportal/src/lib/theme/proseTheme.ts
@@ -91,18 +91,28 @@ export const proseBaseStyle: SystemStyleFunction = () => ({
     },
 
     code: {
-      fontWeight: 'semibold',
+      fontWeight: 'medium',
       fontFamily: 'ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace',
       '&::before, &::after': {
         content: '""',
       },
+      fontSize: 'inherit',
+      backgroundColor: 'transparent',
+      _dark: {
+        backgroundColor: 'transparent',
+      },
     },
   },
   code: {
-    fontWeight: 'semibold',
+    fontWeight: 'medium',
     fontFamily: 'ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace',
     '&::before, &::after': {
       content: '""',
+    },
+    fontSize: 'inherit',
+    backgroundColor: 'gray.100',
+    _dark: {
+      backgroundColor: 'gray.700',
     },
   },
 


### PR DESCRIPTION
## Description / Motivation
This PR adds;
- Menu item clickable to expand subitems
- Styling improvements to `<code />` element
- Have the recipe contribution component use the Alert component instead of card

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-ki66w0292-sitecoretechnicalmarketing.vercel.app/learn/accelerate/xm-cloud/implementation/information-architecture/wildcard-pages)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
