### PR TITLE
Replaced Devops and devops with DevOps

### DIFF
--- a/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/manifest.json
+++ b/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/manifest.json
@@ -62,7 +62,7 @@
               "path": "setup-content-serialization"
             },
             {
-              "title": "Devops",
+              "title": "DevOps",
               "path": "devops"
             }
           ]

--- a/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy.md
+++ b/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy.md
@@ -76,7 +76,7 @@ Picking the right branching strategy can be a sensitive subject, many developers
 
 Ultimately, rather than talking about branching, we need to focus on the why - what do we use branching for? The end game is to control change within our application. A lot of common branching strategies (like GitFlow etc...) promote the use of long lived branches, this can cause problems when making changes because as a developer you are isolating your change away from everyone else's change and you don't have a picture of everything happening to the application. We need to _Embrace Change, don't Hide Change_.
 
-The opposite of a feature branch heavy strategy is trunk based development, where every change happens directly on the `main` or `trunk` branch. This method clearly embraces change, but without very strong testing and devops practices, it can be very easy to introduce breaking changes that block other development activities.
+The opposite of a feature branch heavy strategy is trunk based development, where every change happens directly on the `main` or `trunk` branch. This method clearly embraces change, but without very strong testing and DevOps practices, it can be very easy to introduce breaking changes that block other development activities.
 
 Because of this, we recommend a hybrid approach, based on the [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow) or [Gitlab Flow](https://about.gitlab.com/topics/version-control/what-is-gitlab-flow/) models.
 

--- a/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/sprint-zero/devops.md
+++ b/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/sprint-zero/devops.md
@@ -6,6 +6,6 @@ hasSubPageNav: true
 hasInPageNav: false
 ---
 
-### Devops
+### DevOps
 
 - 🚀 This Sitecore Accelerate Recipe is coming soon...

--- a/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/sprint-zero/project-solution-setup.md
+++ b/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/sprint-zero/project-solution-setup.md
@@ -181,7 +181,7 @@ Site Folders organize sites. They are optional as well and help in case you have
 
 <Row columns={2}>
   <Link title="Branching Strategy | Sitecore Accelerate" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy" />
-  <Link title="Devops| Sitecore Accelerate" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/devops" />
+  <Link title="DevOps| Sitecore Accelerate" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/devops" />
   <Link title="Setting Up Serialization" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/setup-content-serialization" />
 </Row>
 

--- a/apps/devportal/data/markdown/pages/learn/getting-started/managed-cloud-with-containers/index.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/managed-cloud-with-containers/index.md
@@ -9,7 +9,7 @@ The purpose of this guide will be to provide a list of existing documentation an
 
 ## Assumptions
 
-There is an assumption that this is for an existing Sitecore solution (however most steps may apply to a new solution as well), that is ran from an existing Source Control Management (SCM) system such as Github, GitLabs, or a separate repository in Azure Devops. This guide provices a general overview of a Sitecore XP transition to Sitecore MCC that does not consist of Containerization.
+There is an assumption that this is for an existing Sitecore solution (however most steps may apply to a new solution as well), that is ran from an existing Source Control Management (SCM) system such as Github, GitLabs, or a separate repository in Azure DevOps. This guide provices a general overview of a Sitecore XP transition to Sitecore MCC that does not consist of Containerization.
 
 ## Prerequisites
 
@@ -19,8 +19,8 @@ There is an assumption that this is for an existing Sitecore solution (however m
 - Users should have a working MCC environment:
   - [Access Details](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/getting-started-with-managed-cloud.html)
   - [Architecture](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/the-managed-cloud-architecture.html)
-- Users should have correct permissions to the MCC Azure Devops project:
-  - Users should see the "Repository" tab in Azure Devops, if not, your account may need to have a valid Visual Studio Subscription.
+- Users should have correct permissions to the MCC Azure DevOps project:
+  - Users should see the "Repository" tab in Azure DevOps, if not, your account may need to have a valid Visual Studio Subscription.
   - Details about Permissions:
     - [Managed Security Overview](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/managed-cloud-security-overview.html)
     - [Managed Security Roles](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/the-managed-cloud-security-roles.html)
@@ -101,22 +101,22 @@ The overall process involves building your images with the CI tool of your choic
 1. You'll need to first create the process to build your images, likely in a different topology than what you ran locally, on strategy to do this, is to create a new docker-compose.yml file for these builds. This new compose file only needs instructions related to the build of the images, since Kubernetes definitions will handle how those images run (including volumes, memory usage, etc.).
    - [An example of a docker-compose.build.yml File](https://github.com/Sitecore/Sitecore.Demo.Platform/blob/main/docker-compose-xp1.build.yml)
 2. You'll need to create the build definition files (Dockerfile) for the images that you plan to build that are not in your original docker-compose.yml file. Example, if you originally setup an XP0 and are now building XP1 images, you'll have several new images depending on your configuration, such as CD, PRC, as well as several xConnect roles.
-3. (Optional) if you are using a CI system like Azure Devops or another system that uses Yaml to configure the the build process, you should create this file and specify the steps in the build. Your process should be setup to build the images in this custom docker-compose.yml file and then push those images into the MCC ACR.
+3. (Optional) if you are using a CI system like Azure DevOps or another system that uses Yaml to configure the the build process, you should create this file and specify the steps in the build. Your process should be setup to build the images in this custom docker-compose.yml file and then push those images into the MCC ACR.
    - [Example of Azure Pipeline Yaml](https://github.com/Sitecore/MVP-Site/blob/main/azure-pipelines.yml)
 4. You will need to authenticate with the MCC ACR using the Admin account (which is turned on by MCC by default) for completing pushes to the ACR during the build process.
    - [Admin Account Overview](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
-   - If you are using Azure Devops to configure your CI pipeline, you'll need to complete the following steps:
+   - If you are using Azure DevOps to configure your CI pipeline, you'll need to complete the following steps:
      - You'll need to create a new Service Connection for your ACR, but specify this registry as a standard docker registry, instead of using an Azure Container Registry. Refer to the image below:
-       ![Service Connection Details for Azure Container Registry Authentication in Azure Devops](https://mss-p-006-delivery.stylelabs.cloud/api/public/content/05753795f5974b15bca0d6dfe7c80de2?v=bced5b2d)
+       ![Service Connection Details for Azure Container Registry Authentication in Azure DevOps](https://mss-p-006-delivery.stylelabs.cloud/api/public/content/05753795f5974b15bca0d6dfe7c80de2?v=bced5b2d)
      - In your Build Pipeline you'll need to use the following parameters for the use of this service principle.
-5. (Optional) There are several strategies to replace the environment variables in these files, and it may vary upon CI system used, but if you are using Azure Devops, you can define a Variable Group and if you match them to the variables in your file (ie. `${REGISTRY}` with a key of REGISTRY, and a value), they should automatically get picked up in your file, if you assign the variable group to your build pipeline.
+5. (Optional) There are several strategies to replace the environment variables in these files, and it may vary upon CI system used, but if you are using Azure DevOps, you can define a Variable Group and if you match them to the variables in your file (ie. `${REGISTRY}` with a key of REGISTRY, and a value), they should automatically get picked up in your file, if you assign the variable group to your build pipeline.
 6. Once you've completed the build and push of your images, you can now move on to the next section, where you'll configured the CD of your release process. You'll need to know your Build Id and Build branch for use with tagging.
 
 ## Adjustments to CD Pipeline
 
 The Continous Delivery (CD) pipeline is hosted in the `Application` repository in MCC and utilizes Ansible to pull the images and release those images to AKS. Once you have successfully pushed your images into your Azure Container Registry (ACR), you'll need to update your `./config/docker-images/docker-images.json`.
 
-The `Application` and `Infrastructure` repositories in the Managed Cloud with Containers (MCC) Azure Devops environment are both configured to trigger deployments when a change is made to the `main` branch either directly or via a pull request (however you can also trigger the deployment manually). The best practice would be to create a new feature branch for your latest deployment and in that branch, you'll need to update the configuration to include references to your new custom images in the ACR. This is where you'll need to know the latest build number and branch (or tag version of the latest image in your ACR).
+The `Application` and `Infrastructure` repositories in the Managed Cloud with Containers (MCC) Azure DevOps environment are both configured to trigger deployments when a change is made to the `main` branch either directly or via a pull request (however you can also trigger the deployment manually). The best practice would be to create a new feature branch for your latest deployment and in that branch, you'll need to update the configuration to include references to your new custom images in the ACR. This is where you'll need to know the latest build number and branch (or tag version of the latest image in your ACR).
 
 - [Define Custom Images](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/configure-managed-cloud.html#add-a-custom-image_body)
 


### PR DESCRIPTION
Fix for casing should be brought into Accelerate branch as well to correct issues in the in-progress recipes.

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Any text that used incorrect casing for DevOps ('devops' or 'Devops') was updated. This impacted Accelerate recipes and Managed Cloud guides.

## How Has This Been Tested?
Reviewed on preview environment in Vercel

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
