### PR TITLE
Updated Monorepo listing to include restriction on node version differences

### DIFF
--- a/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy.md
+++ b/apps/devportal/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy.md
@@ -70,6 +70,8 @@ Go with a monorepo strategy and focus on trunk-based deployments rather than git
 
 Deploy often, use feature toggles to prevent code from going live before it should and don't try to work in isolation.
 
+A final thing to note about the Monorepo approach is that currently in XM Cloud it is required for all heads contained within the Monorepo to be running the same version of Node if you want to use the inbuilt Editing Host functionality. If you want to use different Node versions for each head, then you will need to host your Editing Hosts externally by following this approach detailed in our Documentation Site: [Walkthrough: Configuring external editing hosts for XM Cloud instances](https://doc.sitecore.com/xmc/en/developers/xm-cloud/walkthrough--configuring-external-editing-hosts-for-xm-cloud-instances.html)
+
 ### Branching vs Continuous Integration
 
 Picking the right branching strategy can be a sensitive subject, many developers have very strong views on how branching should be done. In this recipe, we will offer a recommendation that will scale from small to large teams. If your client enforces a different branching strategy, the principles outlined here can still help your team streamline the process.


### PR DESCRIPTION
## Description / Motivation

Update Accelerate document covering Monorepos, to include the requirement all of the heads running in the Monorepo to all be on the same version of Node.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
