### PR TITLE
Replace InPageNav sidebar with icon on smaller screens

### DIFF
--- a/apps/devportal/src/components/navigation/InPageNav.tsx
+++ b/apps/devportal/src/components/navigation/InPageNav.tsx
@@ -17,7 +17,7 @@ const InPageNav = ({ titles }: InPageNavProps): JSX.Element => {
   }));
 
   return (
-    <Wrap as={'nav'} direction="column" mt={{ base: 0, md: 10 }} mr={4} p={{ base: 2, md: 0 }}>
+    <Wrap as={'nav'} direction="column" mt={{ base: 0, md: 10 }} mr={4} p={{ base: 2, md: 0 }} width={'3xs'} hideBelow={'xl'}>
       {title && (
         <Heading variant={'section'} size={'sm'} mb={{ base: 0, md: 2 }}>
           Table of contents

--- a/apps/devportal/src/layouts/ThreeColumnLayout.tsx
+++ b/apps/devportal/src/layouts/ThreeColumnLayout.tsx
@@ -17,12 +17,12 @@ export const ThreeColumnLayout = ({ sidebar, inPageNav, inPageLinks, children, .
     <Flex flexGrow={0} justify={'space-between'} width={'full'} gap={0} direction={{ base: 'column', md: 'row' }} {...rest} flexFlow={'column'}>
       <Sidebar showBackground>{sidebar}</Sidebar>
 
-      <Box maxW={'7xl'} as="main" paddingX={{ base: 4, md: 'inherit' }} width={'full'}>
+      <Box maxW={'6xl'} as="main" paddingX={{ base: 4, md: 'inherit' }}>
         {inPageLinks && <InPageNavSmall hideFrom={'xl'} titles={inPageLinks} />}
         <CenteredContent>{children}</CenteredContent>
       </Box>
 
-      <Sidebar hideBelow={'xl'}>{inPageNav}</Sidebar>
+      <Sidebar>{inPageNav}</Sidebar>
     </Flex>
   );
 };


### PR DESCRIPTION
## Description / Motivation
This PR replaces the inpage sidebar on smaller screens with a icon

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-git-inpagenav-width-sitecoretechnicalmarketing.vercel.app/learn/accelerate/xm-cloud)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
