### PR TITLE
Changelog meta info switch tag to badge

### DIFF
--- a/apps/devportal/src/components/changelog/ChangelogItemMeta.tsx
+++ b/apps/devportal/src/components/changelog/ChangelogItemMeta.tsx
@@ -30,7 +30,8 @@ export const ChangelogItemMeta = ({ item, ...rest }: ChangelogItemMetaProps) => 
 
       <time dateTime="2022-10-21T15:48:00.000Z">{item.releaseDate}</time>
 
-      {item.changeTypeName != null ? <Badge colorScheme={colorScheme(item.changeTypeName)}>{item.changeTypeName}</Badge> : <Badge>No changetype defined</Badge>}
+      {/* {item.changeTypeName != null ? <Badge colorScheme={colorScheme(item.changeTypeName)}>{item.changeTypeName}</Badge> : <Badge>No changetype defined</Badge>} */}
+      {item.changeType.length > 0 && item.changeType.map((changeTypeItem, key) => <Badge colorScheme={colorScheme(changeTypeItem.name)}>{changeTypeItem.name}</Badge>)}
       {item.breakingChange && <Badge colorScheme="danger">Breaking change</Badge>}
     </HStack>
   );

--- a/apps/devportal/src/components/changelog/ChangelogItemMeta.tsx
+++ b/apps/devportal/src/components/changelog/ChangelogItemMeta.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import { usePreview } from '@/src/context/PreviewContext';
-import { Alert, BoxProps, Button, HStack, Icon, Link, Tag, TagLabel, Tooltip } from '@chakra-ui/react';
+import { Alert, Badge, BoxProps, Button, HStack, Icon, Link, Tooltip } from '@chakra-ui/react';
 import { mdiSquareEditOutline } from '@mdi/js';
 import { ChangelogEntry } from 'sc-changelog/types/changeLogEntry';
 import { ProductIcon } from './ProductIcon';
@@ -30,13 +30,8 @@ export const ChangelogItemMeta = ({ item, ...rest }: ChangelogItemMetaProps) => 
 
       <time dateTime="2022-10-21T15:48:00.000Z">{item.releaseDate}</time>
 
-      {item.changeTypeName != null ? <Tag colorScheme={colorScheme(item.changeTypeName)}>{item.changeTypeName}</Tag> : <Tag>No changetype defined</Tag>}
-
-      {item.breakingChange && (
-        <Tag colorScheme="danger">
-          <TagLabel>Breaking change</TagLabel>
-        </Tag>
-      )}
+      {item.changeTypeName != null ? <Badge colorScheme={colorScheme(item.changeTypeName)}>{item.changeTypeName}</Badge> : <Badge>No changetype defined</Badge>}
+      {item.breakingChange && <Badge colorScheme="danger">Breaking change</Badge>}
     </HStack>
   );
 
@@ -47,17 +42,20 @@ export const ChangelogItemMeta = ({ item, ...rest }: ChangelogItemMetaProps) => 
       {MetaInfo}
       {isPreview && (
         <Tooltip label="Edit in Sitecore Content Hub ONE" aria-label="Edit in Sitecore Content Hub">
-        <Button variant={'ghost'} size="sm" leftIcon={
-            <Icon>
-              <path d={mdiSquareEditOutline} />
-            </Icon>
-          }
-        >
-          <Link href={`https://content.sitecorecloud.io/content/${item.id}?organization=${organizationId}&tenantName=${tenantId}`} target="_blank">
-            Edit
-          </Link>
+          <Button
+            variant={'ghost'}
+            size="sm"
+            leftIcon={
+              <Icon>
+                <path d={mdiSquareEditOutline} />
+              </Icon>
+            }
+          >
+            <Link href={`https://content.sitecorecloud.io/content/${item.id}?organization=${organizationId}&tenantName=${tenantId}`} target="_blank">
+              Edit
+            </Link>
           </Button>
-          </Tooltip>
+        </Tooltip>
       )}
     </HStack>
   );

--- a/apps/devportal/src/components/changelog/ChangelogItemMeta.tsx
+++ b/apps/devportal/src/components/changelog/ChangelogItemMeta.tsx
@@ -31,7 +31,12 @@ export const ChangelogItemMeta = ({ item, ...rest }: ChangelogItemMetaProps) => 
       <time dateTime="2022-10-21T15:48:00.000Z">{item.releaseDate}</time>
 
       {/* {item.changeTypeName != null ? <Badge colorScheme={colorScheme(item.changeTypeName)}>{item.changeTypeName}</Badge> : <Badge>No changetype defined</Badge>} */}
-      {item.changeType.length > 0 && item.changeType.map((changeTypeItem, key) => <Badge colorScheme={colorScheme(changeTypeItem.name)}>{changeTypeItem.name}</Badge>)}
+      {item.changeType.length > 0 &&
+        item.changeType.map((changeTypeItem, key) => (
+          <Badge colorScheme={colorScheme(changeTypeItem.name)} key={key}>
+            {changeTypeItem.name}
+          </Badge>
+        ))}
       {item.breakingChange && <Badge colorScheme="danger">Breaking change</Badge>}
     </HStack>
   );


### PR DESCRIPTION
## Description / Motivation
Small PR that changes the changetype display for Changelog entries from Tag to Badge and makes it consistent with other displays

## How Has This Been Tested?
Local

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
