### PR TITLE
Add social media sharing buttons and popover to Changelog

### DIFF
--- a/packages/ui/components/social/SocialShare.tsx
+++ b/packages/ui/components/social/SocialShare.tsx
@@ -1,8 +1,6 @@
-import { HStack, Icon, IconButton, Tooltip, useClipboard, useToast, Button } from '@chakra-ui/react';
-import { mdiCheck, mdiContentCopy } from '@mdi/js';
+import { HStack, Icon, IconButton, Popover, PopoverArrow, PopoverBody, PopoverContent, PopoverTrigger, Tooltip, useClipboard, useToast } from '@chakra-ui/react';
+import { mdiCheck, mdiChevronUp, mdiContentCopy } from '@mdi/js';
 import { EmailIcon, EmailShareButton, LinkedinIcon, LinkedinShareButton, RedditIcon, RedditShareButton, TelegramIcon, TelegramShareButton, TwitterIcon, TwitterShareButton, WhatsappIcon, WhatsappShareButton } from 'next-share';
-import { ChevronUpIcon } from '@chakra-ui/icons'
-import { Popover, PopoverTrigger, PopoverContent, PopoverArrow, PopoverBody } from '@chakra-ui/react';
 
 type SocialShareProps = {
   url: string;
@@ -11,40 +9,69 @@ type SocialShareProps = {
 
 const SocialShare = ({ title, url }: SocialShareProps): JSX.Element => {
   const { onCopy, hasCopied } = useClipboard(url);
+
   const toast = useToast();
 
   return (
-    <HStack>
-      <Popover placement='top'>
-          <PopoverTrigger>
-            <Button variant={'ghost'} mr={-2}><ChevronUpIcon /></Button>
-          </PopoverTrigger>
-        <PopoverContent style={{ maxWidth: 'unset', width: 'unset' }}>
+    <HStack gap={1}>
+      <Popover placement="top" closeOnBlur closeOnEsc>
+        <PopoverTrigger>
+          <IconButton
+            variant="ghost"
+            aria-label="More sharing methods"
+            icon={
+              <Icon boxSize={5}>
+                <path d={mdiChevronUp} />
+              </Icon>
+            }
+            boxSize={8}
+            minWidth={4}
+            mx={1}
+          />
+        </PopoverTrigger>
+
+        <PopoverContent style={{ maxWidth: 'unset', width: 'unset' }} shadow={'lg'}>
           <PopoverArrow />
-          <PopoverBody>
-            <HStack>
-              <Tooltip label="Share link by Whatsapp" aria-label="Share link by Whatsapp">
-                <IconButton as={WhatsappShareButton} url={url} title={title} aria-label="Share by Whatsapp" icon={<WhatsappIcon size={32} round />} />
-              </Tooltip>
-              <Tooltip label="Share link by Telegram" aria-label="Share link by Telegram">
-                <IconButton as={TelegramShareButton} url={url} title={title} aria-label="Share by Telegram" icon={<TelegramIcon size={32} round />} />
-              </Tooltip>
-              <Tooltip label="Share link by Reddit" aria-label="Share link by Reddit">
-                <IconButton as={RedditShareButton} url={url} title={title} aria-label="Share by Reddit" icon={<RedditIcon size={32} round />} />
-              </Tooltip>
+          <PopoverBody p={4}>
+            <HStack gap={4}>
+              <WhatsappShareButton url={url} title={title}>
+                <Tooltip label="Share link by Whatsapp" aria-label="Share link by Whatsapp">
+                  <IconButton variant="ghost" aria-label="Share by Whatsapp" icon={<WhatsappIcon size={32} round />} />
+                </Tooltip>
+              </WhatsappShareButton>
+              <TelegramShareButton url={url} title={title}>
+                <Tooltip label="Share link by Telegram" aria-label="Share link by Telegram">
+                  <IconButton variant="ghost" aria-label="Share by Telegram" icon={<TelegramIcon size={32} round />} />
+                </Tooltip>
+              </TelegramShareButton>
+              <RedditShareButton url={url} title={title}>
+                <Tooltip label="Share link by Reddit" aria-label="Share link by Reddit">
+                  <IconButton variant="ghost" aria-label="Share by Reddit" icon={<RedditIcon size={32} round />} />
+                </Tooltip>
+              </RedditShareButton>
             </HStack>
           </PopoverBody>
         </PopoverContent>
       </Popover>
-      <Tooltip label="Share link by email" aria-label="Share link by email">
-        <IconButton as={EmailShareButton} url={url} title={title} aria-label="Share by email" icon={<EmailIcon size={32} round />} />
-      </Tooltip>
-      <Tooltip label="Share link on LinkedIn" aria-label="Share link on LinkedIn">
-        <IconButton as={LinkedinShareButton} url={url} title={title} aria-label="Share by email" icon={<LinkedinIcon size={32} round />} />
-      </Tooltip>
-      <Tooltip label="Share link on Twitter" aria-label="Share link on Twitter">
-        <IconButton as={TwitterShareButton} url={url} title={title} aria-label="Share on Twitter" icon={<TwitterIcon size={32} round />} />
-      </Tooltip>
+
+      <EmailShareButton url={url} title={title}>
+        <Tooltip label="Share link by email" aria-label="Share link by email">
+          <IconButton variant={'ghost'} aria-label="Share by email" icon={<EmailIcon size={32} round />} />
+        </Tooltip>
+      </EmailShareButton>
+
+      <LinkedinShareButton url={url} title={title}>
+        <Tooltip label="Share link on LinkedIn" aria-label="Share link on LinkedIn">
+          <IconButton variant={'ghost'} aria-label="Share by email" icon={<LinkedinIcon size={32} round />} />
+        </Tooltip>
+      </LinkedinShareButton>
+
+      <TwitterShareButton url={url} title={title}>
+        <Tooltip label="Share link on Twitter" aria-label="Share link on Twitter">
+          <IconButton variant={'ghost'} aria-label="Share on Twitter" icon={<TwitterIcon size={32} round />} />
+        </Tooltip>
+      </TwitterShareButton>
+
       <Tooltip label="Copy link to clipboard" aria-label="Copy link to clipboard">
         <IconButton
           onClick={() => {
@@ -63,6 +90,7 @@ const SocialShare = ({ title, url }: SocialShareProps): JSX.Element => {
             )
           }
           size={'sm'}
+          mx={1}
         >
           {hasCopied ? 'Copied!' : 'Copy'}
         </IconButton>

--- a/packages/ui/components/social/SocialShare.tsx
+++ b/packages/ui/components/social/SocialShare.tsx
@@ -1,6 +1,8 @@
-import { HStack, Icon, IconButton, Tooltip, useClipboard, useToast } from '@chakra-ui/react';
+import { HStack, Icon, IconButton, Tooltip, useClipboard, useToast, Button } from '@chakra-ui/react';
 import { mdiCheck, mdiContentCopy } from '@mdi/js';
-import { EmailIcon, EmailShareButton, LinkedinIcon, LinkedinShareButton, TwitterIcon, TwitterShareButton } from 'next-share';
+import { EmailIcon, EmailShareButton, LinkedinIcon, LinkedinShareButton, RedditIcon, RedditShareButton, TelegramIcon, TelegramShareButton, TwitterIcon, TwitterShareButton, WhatsappIcon, WhatsappShareButton } from 'next-share';
+import { ChevronUpIcon } from '@chakra-ui/icons'
+import { Popover, PopoverTrigger, PopoverContent, PopoverArrow, PopoverBody } from '@chakra-ui/react';
 
 type SocialShareProps = {
   url: string;
@@ -13,6 +15,27 @@ const SocialShare = ({ title, url }: SocialShareProps): JSX.Element => {
 
   return (
     <HStack>
+      <Popover placement='top'>
+          <PopoverTrigger>
+            <Button variant={'ghost'} mr={-2}><ChevronUpIcon /></Button>
+          </PopoverTrigger>
+        <PopoverContent style={{ maxWidth: 'unset', width: 'unset' }}>
+          <PopoverArrow />
+          <PopoverBody>
+            <HStack>
+              <Tooltip label="Share link by Whatsapp" aria-label="Share link by Whatsapp">
+                <IconButton as={WhatsappShareButton} url={url} title={title} aria-label="Share by Whatsapp" icon={<WhatsappIcon size={32} round />} />
+              </Tooltip>
+              <Tooltip label="Share link by Telegram" aria-label="Share link by Telegram">
+                <IconButton as={TelegramShareButton} url={url} title={title} aria-label="Share by Telegram" icon={<TelegramIcon size={32} round />} />
+              </Tooltip>
+              <Tooltip label="Share link by Reddit" aria-label="Share link by Reddit">
+                <IconButton as={RedditShareButton} url={url} title={title} aria-label="Share by Reddit" icon={<RedditIcon size={32} round />} />
+              </Tooltip>
+            </HStack>
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
       <Tooltip label="Share link by email" aria-label="Share link by email">
         <IconButton as={EmailShareButton} url={url} title={title} aria-label="Share by email" icon={<EmailIcon size={32} round />} />
       </Tooltip>


### PR DESCRIPTION
Add additional social share buttons to the Changelog to match the social icons that will be available in the Migration Advisor. 
![image](https://github.com/Sitecore/developer-portal/assets/24610108/f564685f-c828-4e17-b7a1-4dcf7468b7d7)

Viewable: https://developer-portal-git-social-s-2c454a-sitecoretechnicalmarketing.vercel.app/changelog


## How Has This Been Tested?

Manually tested

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
