### PR TITLE
Update links from SXP download pages to their corresponding container packages

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/index.md
@@ -50,7 +50,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.1.0.005207.309) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.1.1.005862.645) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
  | [Installation Guide for Developer Workstation with Containers](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Sitecore_XP_10_1_1_Developer_Workstation_Deployment_With_Docker-en.pdf) | This guide describes how to use Sitecore Containers with Docker Compose to deploy a developer workstation. |
  | [Installation Guide for Production Environment with Kubernetes](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Sitecore_XP_10_1_1_Production_Deployment_With_Kubernetes-en.pdf) | This guide describes how to use Sitecore Containers with Kubernetes to deploy containers to the Azure Kubernetes Service. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/index.md
@@ -50,7 +50,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.1.2.006578.651) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.1.2.006578.1247) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
  | [Installation Guide for Developer Workstation with Containers](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Sitecore_XP_10_1_2_Developer_Workstation_Deployment_With_Docker-en.pdf) | This guide describes how to use Sitecore Containers with Docker Compose to deploy a developer workstation. |
  | [Installation Guide for Production Environment with Kubernetes](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Sitecore_XP_10_1_2_Production_Deployment_With_Kubernetes-en.pdf) | This guide describes how to use Sitecore Containers with Kubernetes to deploy containers to the Azure Kubernetes Service. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/index.md
@@ -50,7 +50,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.1.3.009558.1487) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/10.1.3.009558.1562) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
  | [Installation Guide for Developer Workstation with Containers](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/SC-XP-10.1.3-Developer_Workstation_Deployment_With_Docker-pdf-en.pdf) | This guide describes how to use Sitecore Containers with Docker Compose to deploy a developer workstation. |
  | [Installation Guide for Production Environment with Kubernetes](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/SC-XP-10.1.3-Production_Deployment_With_Kubernetes-pdf-en.pdf) | This guide describes how to use Sitecore Containers with Kubernetes to deploy containers to the Azure Kubernetes Service. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/index.md
@@ -49,7 +49,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.2**.
 
  | Resource | Description |
  | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.2.0.006766.683) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.2.0.006766.1227) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
  | [Installation Guide for Developer Workstation with Containers](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Sitecore_XP_10_2_0_Developer_Workstation_Deployment_With_Docker-en.pdf) | This guide describes how to use Sitecore Containers with Docker Compose to deploy a developer workstation. |
  | [Installation Guide for Production Environment with Kubernetes](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Sitecore_XP_10_2_0_Production_Deployment_With_Kubernetes-en.pdf) | This guide describes how to use Sitecore Containers with Kubernetes to deploy containers to the Azure Kubernetes Service. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/index.md
@@ -49,7 +49,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.2 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.2.1.009559.1460) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/10.2.1.009559.1564) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
  | [Installation Guide for Developer Workstation with Containers](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/SC-XP-10.2.1-Developer_Workstation_Deployment_With_Docker-en.pdf) | This guide describes how to use Sitecore Containers with Docker Compose to deploy a developer workstation. |
  | [Installation Guide for Production Environment with Kubernetes](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/SC-XP-10.2.1-Production_Deployment_With_Kubernetes-en.pdf) | This guide describes how to use Sitecore Containers with Kubernetes to deploy containers to the Azure Kubernetes Service. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/index.md
@@ -55,7 +55,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.3**.
 
  | Resource | Description |
  | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.3.0.008463.1135) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.3.0.008463.1229) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
  | [Installation Guide for Developer Workstation with Containers](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Sitecore_XP_10_3_0_Developer_Workstation_Deployment_With_Docker-en.pdf) | This guide describes how to use Sitecore Containers with Docker Compose to deploy a developer workstation. |
  | [Installation Guide for Production Environment with Kubernetes](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/SC-XP-10.3.0-Production_Deployment_With_Kubernetes-en.pdf) | This guide describes how to use Sitecore Containers with Kubernetes to deploy containers to the Azure Kubernetes Service. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/index.md
@@ -55,7 +55,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.3 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/sxp%2F10.3.1.009452.1448) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/10.3.1.009452.1563) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
  | [Installation Guide for Developer Workstation with Containers](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Sitecore_XP_10_3_1_Developer_Workstation_Deployment_With_Docker.pdf) | This guide describes how to use Sitecore Containers with Docker Compose to deploy a developer workstation. |
  | [Installation Guide for Production Environment with Kubernetes](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Sitecore_XP_10_3_1_Production_Deployment_With_Kubernetes.pdf) | This guide describes how to use Sitecore Containers with Kubernetes to deploy containers to the Azure Kubernetes Service. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |


### PR DESCRIPTION
## Description / Motivation
On each applicable Sitecore XP download page, updated the link to its latest Container Package, for the given SXP 10.x.y patch release.
Customer satisfaction. To avoid confusion where some links were old, some newer, some jumped to a new SXP patch release, some did not.
Based on feedback from Sitecore Prof. Services, on dev.sitecore.net.

## How Has This Been Tested?
Copy/pasted every new link to a browser. Visually inspected that intended link was reached.
For those links that included a change in link format, confirmed new links worked.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
