### PR TITLE
Removing extra character in SSE link on StackExchangeFeed component

### DIFF
--- a/packages/ui/components/integrations/stackexchange/StackExchangeFeed.tsx
+++ b/packages/ui/components/integrations/stackexchange/StackExchangeFeed.tsx
@@ -19,7 +19,7 @@ export const StackExchangeFeed = ({ data, title, ...rest }: StackExchangeFeedPro
         <Heading as={'h3'} size={{ base: 'lg', md: 'xl' }}>
           {title ? title : `The Latest on Sitecore StackExchange`}
         </Heading>
-        <ButtonLink href={`https://sitecore.stackexchange.com/}`} text={'See all questions on StackExchange'} />
+        <ButtonLink href={`https://sitecore.stackexchange.com/`} text={'See all questions on StackExchange'} />
       </CardHeader>
       <CardBody px={0}>
         <SimpleGrid columns={{ base: 1, md: 2 }} spacing={{ base: 2, md: 8 }}>


### PR DESCRIPTION
## Description / Motivation
The link on the component is broken because of an extra } character in the markup. This PR removes that character. Fixes #687 

## How Has This Been Tested?
Tested locally and on Vercel preview site.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
