### PR TITLE
Tidy SXP policy references

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100/index.md
@@ -153,4 +153,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.0**.
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update1/index.md
@@ -156,4 +156,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update2/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update2/index.md
@@ -155,4 +155,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update3/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update3/index.md
@@ -155,4 +155,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101/index.md
@@ -148,4 +148,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.1**.
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/index.md
@@ -147,4 +147,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/index.md
@@ -148,4 +148,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/index.md
@@ -148,4 +148,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/index.md
@@ -148,4 +148,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.2**.
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/index.md
@@ -148,4 +148,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.2 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/index.md
@@ -153,4 +153,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.3**.
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/index.md
@@ -153,4 +153,3 @@ This page contains all the resources for **Sitecore Experience Platform 10.3 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
- | [Sitecore xDB Cloud usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy) | This policy is applicable if you are using Sitecore xDB Cloud. |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy.md
@@ -4,26 +4,24 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy
 ---
 
-**`(last updated 20 October 2015)`**
-
-1.  As a Customer (“You” or “I”), who am I?
+**A. As a Customer (“You” or “I”), who am I?**
     
-    You hereby acknowledge and represent that you are a real person and/or an entity legally organized in any country not subject to U.S. sanction laws.
+1.  You hereby acknowledge and represent that you are a real person and/or an entity legally organized in any country not subject to U.S. sanction laws.
     
-2.  **As a Customer, what am I prohibited from doing?**
+**B. As a Customer, what am I prohibited from doing?**
     
 
 1.  Except as authorized by applicable law or by Sitecore expressly in a signed written agreement:
     
-    1.  Reverse engineering, disassembling, decompiling or otherwise attempting to discover the source code, object code or underlying structure, ideas or algorithms of any part or all of the Services;
+    a.  Reverse engineering, disassembling, decompiling or otherwise attempting to discover the source code, object code or underlying structure, ideas or algorithms of any part or all of the Services;
         
-    2.  Publishing or distributing code of the Services;
+    b.  Publishing or distributing code of the Services;
         
-    3.  Modifying, selling, renting, leasing, lending, distributing, selling, assigning, licensing, or otherwise transferring or reselling for profit its right to access and use the Services;
+    c.  Modifying, selling, renting, leasing, lending, distributing, selling, assigning, licensing, or otherwise transferring or reselling for profit its right to access and use the Services;
         
-    4.  Creating derivative works based on the Services, in whole or in part; or
+    d.  Creating derivative works based on the Services, in whole or in part; or
         
-    5.  Copying any portion of the Services except as reasonably required for using the Services as permitted by the Agreement.
+    e.  Copying any portion of the Services except as reasonably required for using the Services as permitted by the Agreement.
         
 2.  Allowing any third parties to use the Sitecore Tools or access the Services except as is necessary to assist Customer in its Permitted Usage of the Services, and further provided that such use is within the scope of the activities Customer is itself authorized to perform under the Agreement, where Customer is fully liable to the extent allowed by law for any unauthorized use of the Sitecore Tools and/or the Services by third parties caused by any acts or omissions of Customer.
     
@@ -34,7 +32,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/Sitecore
 5.  Attempting to, or gaining unauthorized access to, the Services, or using, copying or otherwise accessing any portion of the Services for which Customer has not made a payment to Sitecore (if for any reason, you access such Services, these terms and conditions apply to your use of the Services and you agree to pay all applicable charges).
     
 
-5.  **As a Customer, what must I do?**
+**C. As a Customer, what must I do?**
     
 
 1.  In the event you become aware of any known or suspected violation by User(s) of this Sitecore Usage Policy, you shall immediately: (a) notify Sitecore in writing of the violation, (b) suspend such User’s access to any aspect of the Services, and (c) cooperate with Sitecore in any investigation of such known or suspected violation by User(s).

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy.md
@@ -4,8 +4,6 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy
 ---
 
-**`(last updated 20 April 2015)`**
-
 **A. As a Customer, what am I prohibited from doing?**
 
 1.  Except as authorized by applicable law or by Sitecore expressly in a signed written agreement, Customer will not: (i) reverse engineer, disassemble, decompile or otherwise attempt to discover the source code, object code or underlying structure, ideas or algorithms of any part or all of the Services; (ii) rent, lease, lend, distribute, sell, assign, license, or otherwise transfer its right to access and use the Services; (iii) create derivative works based on the Services; or (iv) copy any portion of the Services except as reasonably required for using the Services as permitted by the Agreement;

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy.md
@@ -4,8 +4,6 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/Sitecore_xDB_Cloud_Usage_Policy
 ---
 
-**`(last updated 28 August 2015)`**
-
 **A. As a Customer (“You” or “I”), who am I?**
 
 1.  You hereby acknowledge and represent that you are a real person and/or an entity legally organized in any country not subject to U.S. sanction laws.


### PR DESCRIPTION
## Description / Motivation
Changes:
- Tidied doc formatting that got messed up after porting over from dev.sitecore.net
- Removed the 2015 document creation date, because it adds no value, and looks bad on Sitecore.
- Removed links from SXP release download pages to one policy that no longer applies (due to being a discontinued offering).
Why:
- Tidying prior to releasing SXP 10.4, where we want the download page to appear accurate and updated.
- Also cleaning up some former releases, which was easy to do within this same PR.
- These trivial updates all contribute to the credibility of our Platform DXP program.

## How Has This Been Tested?
- First confirmed that these old policy docs are not actively owned or managed by anyone, so its up to us to keep them relevant.
- Observed the doc edits in a markdown viewer panel of Notepad++.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
