### PR TITLE
Add new SIF 2.4.0 release, tidy previous SIF release notes

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_200/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_200/Release_Notes.md
@@ -6,38 +6,17 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Installation_Framework/2x/Si
 
 **November 2018 - released Sitecore Install Framework 2.0.0**
 
-# New Features/improvements
+## New Task
 
-## New Tasks
+`Invoke-RemoveXmlTask​` - deletes XML elements in XML files.
 
--   `Invoke-RemoveXmlTask​` - deletes XML elements in XML files. (222100)
+## New Features/improvements
 
-## New Features
-
--   You can now insert XML elements into XML files​. (222099)
--   We have removed the dependency on the Sitecore Fundamentals PowerShell module. (215452)
-    
-    This required migrating the following functions to the main SIF module:
-    
-    -   `Invoke-NewRootCertificateTask`
-    -   `Invoke-NewSignedCertificateTask`
-    -   `Invoke-AddWebFeatureSSLTask​`
--   ​SIF now supports Include/Partial of SIF templates in any other template​. (168494)
--   SIF now supports parameter validation. (159042)
--   Uninstallation support has been added for each topology. Uninstallation removes all the assets that are created during a standard installation including IIS sites, app pools, Windows Services, files, and databases. Uninstallation does ​​not remove client authentication certificates and SSL certificates. (230626)
-    
-    New PowerShell Cmdlet
-    
-    -   `Uninstall-SitecoreConfiguration`
-    
-    New Tasks
-    
-    -   `Invoke-RemoveAppPoolTask`
-    -   `Invoke-RemoveSqlDatabaseTask`
-    -   `​Invoke-RemoveWebsiteTask`
--   New Sitecore Install Framework templates and PowerShell tasks support the remote installation of Sitecore in a distributed environment. Remote deployment installs SIF remotely, copies the required assets; including the packages and license files to the target server, and installs Sitecore.​​​​ (230625)
-    
-    New Tasks
-    
-    -   `Invoke-InstallPSModuleTask`
-    -   `Invoke-InstallSitecoreConfigurationTask​`
+| Description | ADO no. |
+ | --- | --- |
+ | ​​​​​You can now insert XML elements into XML files​. ​​​​​| 222099 |
+ | ​​​​​We have removed the dependency on the Sitecore Fundamentals PowerShell module. This required migrating the following functions to the main SIF module: `Invoke-NewRootCertificateTask`, `Invoke-NewSignedCertificateTask`, `Invoke-AddWebFeatureSSLTask​` ​​​​​| 215452 |
+ | SIF now supports Include/Partial of SIF templates in any other template​. | 168494 |
+ | SIF now supports parameter validation. | 159042 |
+ | Uninstallation support has been added for each topology. Uninstallation removes all the assets that are created during a standard installation including IIS sites, app pools, Windows Services, files, and databases. Uninstallation does ​​not remove client authentication certificates and SSL certificates. New PowerShell Cmdlet: `Uninstall-SitecoreConfiguration`. New Tasks: `Invoke-RemoveAppPoolTask`, `Invoke-RemoveSqlDatabaseTask`, `​Invoke-RemoveWebsiteTask` | 230626 |
+ | New Sitecore Install Framework templates and PowerShell tasks support the remote installation of Sitecore in a distributed environment. Remote deployment installs SIF remotely, copies the required assets; including the packages and license files to the target server, and installs Sitecore.​​​​ New Tasks: `Invoke-InstallPSModuleTask`, `Invoke-InstallSitecoreConfigurationTask​` | 230625 |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_210/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_210/Release_Notes.md
@@ -6,17 +6,15 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Installation_Framework/2x/Si
 
 **April 2019 - released Sitecore Install Framework 2.1.0**
 
-# New Features/improvements
+## New Task
 
-## New Tasks
-
--   `Invoke-ManageKeyStorageTask` - This new task manages user key storage in the HKLM registry.​ Supports [​​Microsoft Data Protection key management](https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/default-settings?view=aspnetcore-2.1) in the registry. (293841)
+`Invoke-ManageKeyStorageTask` - This new task manages user key storage in the HKLM registry.​ Supports [​​Microsoft Data Protection key management](https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/default-settings?view=aspnetcore-2.1) in the registry.
 
 ## Resolved Issues
 
- | Description | Customer ticket ID (or other) | TFS no. |
- | --- | --- | --- |
- | ​​The `Install-SitecoreConfiguration` cmdlet reports an incorrect progress percentage ​​for the root and child progress bars.​​ |  | 302858 |
- | The `Install-SitecoreConfiguration` cmdlet ​​parameter fails to merge multiple nested object types​​. |  | 288839 |
- | The `Invoke-RemoveSqlDatabaseTask` task reloads the SQL Server module and causes conflicts.​​​​ ​​ |  | 294281 |
- | The `Invoke-HostHeaderTask` task can fail to gain access to the hosts file during the uninstallation process.​ |  | 257822 |
+ | Description | ADO no. |
+ | --- | --- |
+ | ​​The `Install-SitecoreConfiguration` cmdlet reports an incorrect progress percentage ​​for the root and child progress bars.​​ | 302858 |
+ | The `Install-SitecoreConfiguration` cmdlet ​​parameter fails to merge multiple nested object types​​. | 288839 |
+ | The `Invoke-RemoveSqlDatabaseTask` task reloads the SQL Server module and causes conflicts.​​​​ ​| 294281 |
+ | The `Invoke-HostHeaderTask` task can fail to gain access to the hosts file during the uninstallation process.​ | 257822 |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_220/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_220/Release_Notes.md
@@ -6,16 +6,16 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Installation_Framework/2x/Si
 
 **November 2019 - released Sitecore Install Framework 2.2.0**
 
-# New Features/improvements
+## New Features/improvements
+
+ | Description | ADO no. |
+ | --- | --- |
+ | ​​​We have set the HTTP client to use TLS 1.2 for all requests. This is required for Solr 8.1.1 or later.​ | 336041 |
+ | ​To increase performance when downloading files, you can now disable the progress bar​. | 256446 |
 
 ## Resolved Issues
 
- | Description | Customer ticket ID (or other) | TFS no. |
- | --- | --- | --- |
- | ​​​We have set the HTTP client to use TLS 1.2 for all requests. This is required for Solr 8.1.1 or later.​ |  | 336041 |
- | ​To increase performance when downloading files, you can now disable the progress bar​. |  | 256446 |
-
- | Description | Customer ticket ID (or other) | TFS no. |
- | --- | --- | --- |
- | The `if` keyword in inline expressions executes both results of the condition regardless of the value​.​​ |  | 227261 |
- | The `Invoke-ManageAppPoolTask` cmdlet performs actions when the application pool is in a transitional state.​ |  | 328263 |
+ | Description | ADO no. |
+ | --- | --- |
+ | The `if` keyword in inline expressions executes both results of the condition regardless of the value​.​​ | 227261 |
+ | The `Invoke-ManageAppPoolTask` cmdlet performs actions when the application pool is in a transitional state.​ | 328263 |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_230/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_230/Release_Notes.md
@@ -6,15 +6,15 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Installation_Framework/2x/Si
 
 **August 2020 - released Sitecore Install Framework 2.3.0**
 
-# New Features/improvements
+## New Features/improvements
+
+ | Description | ADO no. |
+ | --- | --- |
+ | ​​​​​SIF now supports database removal on SQL Azure. ​​​​​| 355965 |
 
 ## Resolved Issues
 
- | Description | Customer ticket ID (or other) | TFS no. |
- | --- | --- | --- |
- | ​​​​​SIF now supports database removal on SQL Azure. ​​​​​ |  | 355965 |
-
- | Description | Customer ticket ID (or other) | TFS no. |
- | --- | --- | --- |
- | Null/Empty values prevent configuration execution. ​​​​​​​ |  | 333659 |
- | The Identity Server certificate throws ​​a `SEC_ERROR_INADEQUATE_KEY_USAGE` error in Firefox​.​ |  | 313664 |
+ | Description | ADO no. |
+ | --- | --- |
+ | Null/Empty values prevent configuration execution. ​​​​​​​| 333659 |
+ | The Identity Server certificate throws ​​a `SEC_ERROR_INADEQUATE_KEY_USAGE` error in Firefox​.​ | 313664 |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_240/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_240/Release_Notes.md
@@ -1,0 +1,15 @@
+---
+title: "Release Notes"
+description: ""
+---
+
+**April 2024 - released Sitecore Install Framework 2.4.0**
+
+## New Features/improvements
+
+ | Description | ADO no. |
+ | --- | --- |
+ | ​​​​​​​​​​A new public UpdateBindingRedirectsTask task has been added. It is now possible to update or insert (if missing) binding redirects into the web.config file by scanning DLLs in the binaries folder. ​​​​| 599135 |
+ | ​​​​​​​​​​The Invoke-ManageAppPoolTask and Invoke-ManageWebsiteTask tasks have been updated to ensure they wait until the AppPool (or Website) is completely stopped for the stop action.​​​​​​​ ​​​​| 604453 |
+
+ 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_240/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_240/index.md
@@ -1,0 +1,35 @@
+---
+title: "Sitecore Installation Framework 2.4.0"
+description: ""
+origin: https://dev.sitecore.net/Downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_230
+---
+
+The Sitecore Install Framework (SIF) enables users to deploy and configure a Sitecore environment using a standard configuration design that can be extended through custom PowerShell functions.
+
+Please see the Sitecore product installation instructions for more information on how to install Sitecore using SIF.
+
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    We recommend installing the Sitecore Installation framework through the official Sitecore PowerShell gallery feed. [Read the FAQ for more information](https://doc.sitecore.com/xp/en/developers/100/sitecore-experience-manager/sitecore-powershell-public-nuget-feed-faq.html).
+  </Alert>
+  
+
+## Links
+
+ | Resource | Description |
+ | --- | --- |
+ | [Sitecore PowerShell Gallery](https://cloudsmith.io/~sitecore/repos/resources/packages/) | The official Sitecore PowerShell modules gallery hosts all releases of the Sitecore Installation Framework and related products. |
+ | [Sitecore PowerShell Gallery FAQ](https://doc.sitecore.com/xp/en/developers/100/sitecore-experience-manager/sitecore-powershell-public-nuget-feed-faq.html) | Please read the FAQ for the official Sitecore PowerShell modules gallery. |
+
+## Manual Downloads
+
+ | Resource | Description |
+ | --- | --- |
+ | [Sitecore Installation Framework](https://scdp.blob.core.windows.net/downloads/Sitecore%20Installation%20Framework/2x/Sitecore%20Installation%20Framework%20240/Secure/SitecoreInstallFramework%202.4.0%20rev.%20240301.zip) | Choose this link to download the Sitecore Installation Framework (SIF) PowerShell module. |
+
+## Release Information
+
+ | Resource | Description |
+ | --- | --- |
+ | [Release Notes](/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_240/Release_Notes) | A list of features, improvements, and fixes that have been implemented in this release. |
+ | [Sitecore Installation Framework Configuration Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Installation%20Framework/2x/Sitecore%20Installation%20Framework%20240/Secure/Sitecore_Installation_Framework_Configuration_Guide-2.4.0.pdf) | Configuration guide for Sitecore Installation Framework |

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Installation_Framework/index.md
@@ -9,6 +9,9 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Installation_Framework.aspx
 ## Sitecore Installation Framework 2.x
 </CardHeader>
 <CardBody>
+[Sitecore Installation Framework 2.4.0](/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_240)\
+The Sitecore Installation Framework is a Microsoft PowerShell module that supports local and remote installations of Sitecore, and it is fully extensible.
+
 [Sitecore Installation Framework 2.3.0](/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_230)\
 The Sitecore Installation Framework is a Microsoft PowerShell module that supports local and remote installations of Sitecore, and it is fully extensible.
 

--- a/apps/devportal/data/markdown/pages/downloads/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/index.md
@@ -97,10 +97,10 @@ Downloads relating to **Sitecore 7.5 and below** are available on the [Sitecore 
   link2href="/downloads/Sitecore_Universal_Tracker"
 />
 <Download 
-  title="Sitecore Installation Framework 2.3.0"
+  title="Sitecore Installation Framework 2.4.0"
   description="The Sitecore Installation Framework is a Microsoft PowerShell module that supports local and remote installations of Sitecore, and it is fully extensible."
   link1text="Get latest"
-  link1href="/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_230"
+  link1href="/downloads/Sitecore_Installation_Framework/2x/Sitecore_Installation_Framework_240"
   link2text="See all versions"
   link2href="/downloads/Sitecore_Installation_Framework"
 />


### PR DESCRIPTION
## Description / Motivation
- Added new release download SIF 2.4.0. Why: It was recently added to dev.sitecore.net. Is needed with forthcoming SXP 10.4 release. Needed to do a dry run release test, prior to the big SXP 10.4 release coming in late April!
- Minor tidying of release notes for previous SIF 2.x releases. Why: Some got messed up a little when porting from dev.sitecore.net. Some were already messy in dev.sitecore.net.

## How Has This Been Tested?
- Viewed documentation results in the Notepad++ markdown viewer panel.
- Did page by page comparisons between my new .md file and page in dev.sitecore.net

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
