### PR TITLE
Add filter to downloads sidebar

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/manifest.json
+++ b/apps/devportal/data/markdown/pages/downloads/manifest.json
@@ -4,6 +4,7 @@
   "path": "/downloads",
   "showRootAsSections": true,
   "enableSearch": true,
+  "enableBreadcrumb": false,
   "routes": [
     {
       "title": "Composable DXP",

--- a/apps/devportal/data/markdown/pages/downloads/manifest.json
+++ b/apps/devportal/data/markdown/pages/downloads/manifest.json
@@ -3,6 +3,7 @@
   "description": "Sitecore Downloads",
   "path": "/downloads",
   "showRootAsSections": true,
+  "enableSearch": true,
   "routes": [
     {
       "title": "Composable DXP",

--- a/apps/devportal/src/components/navigation/BreadcrumbNav.tsx
+++ b/apps/devportal/src/components/navigation/BreadcrumbNav.tsx
@@ -1,0 +1,60 @@
+import { PageInfo, SidebarNavigationConfig, SidebarNavigationItem } from '@/src/lib/interfaces/page-info';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '@chakra-ui/react';
+import NextLink from 'next/link';
+import { useRouter } from 'next/router';
+import { appendPathToBasePath } from '../../../../../packages/ui/src/lib/utils/stringUtil';
+
+export interface BreadcrumbNavProps {
+  enabled?: boolean;
+  currentPage: PageInfo;
+  config: SidebarNavigationConfig;
+}
+
+const findRoute = (routes: SidebarNavigationItem[], path: string): SidebarNavigationItem | null => {
+  for (let route of routes) {
+    if (route.path === path) return route;
+    if (route.children) {
+      const foundRoute: SidebarNavigationItem | null = findRoute(route.children, path);
+      if (foundRoute) return foundRoute;
+    }
+  }
+  return null;
+};
+
+const BreadcrumbNav = ({ config, currentPage, enabled = false }: BreadcrumbNavProps) => {
+  const router = useRouter();
+
+  if (!enabled || router.asPath == config.path) return null;
+
+  const urlSegments: string[] = router.asPath != config.path ? router.asPath.replace(config.path + '/', '').split('/') : [];
+  return (
+    <Breadcrumb>
+      <BreadcrumbItem>
+        <BreadcrumbLink href={config.path}>Downloads</BreadcrumbLink>
+      </BreadcrumbItem>
+
+      {urlSegments.length > 1 &&
+        urlSegments
+          .map((segment, index) => {
+            const matchingRoute = findRoute(config.routes, segment);
+
+            if (matchingRoute) {
+              return (
+                <BreadcrumbItem key={index}>
+                  <BreadcrumbLink as={NextLink} href={appendPathToBasePath(config.path, matchingRoute.path)}>
+                    {matchingRoute.title}
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+              );
+            }
+          })
+          .filter(Boolean)}
+
+      <BreadcrumbItem isCurrentPage>
+        <BreadcrumbLink href="#">{currentPage.title}</BreadcrumbLink>
+      </BreadcrumbItem>
+    </Breadcrumb>
+  );
+};
+
+export default BreadcrumbNav;

--- a/apps/devportal/src/components/navigation/SidebarNavigation.tsx
+++ b/apps/devportal/src/components/navigation/SidebarNavigation.tsx
@@ -4,10 +4,12 @@ import { mdiChevronDown, mdiChevronRight, mdiMinus, mdiPlus } from '@mdi/js';
 import { appendPathToBasePath } from '@scdp/ui/lib';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useState } from 'react';
+import SidebarSearch from './SidebarSearch';
 
 export interface SidebarNavigationProps {
   title?: string;
+  showSearch?: boolean;
   config: SidebarNavigationConfig;
 }
 
@@ -16,20 +18,23 @@ let showRootAsSections: boolean | undefined;
 
 const SidebarNavigation = ({ config }: SidebarNavigationProps) => {
   const router = useRouter();
+  const [searchActive, setSearchActive] = useState<boolean>(false);
 
   showRootAsSections = config.showRootAsSections;
   basePath = config.path;
 
   return (
     <React.Fragment>
-      {config.heading && (
+      {config.enableSearch && <SidebarSearch config={config} onFocus={() => setSearchActive(true)} onBlur={() => setSearchActive(false)} />}
+
+      {config.heading && !searchActive && (
         <Heading as={NextLink} variant={'section'} my={4} hideBelow={'md'} href={config.path} px={2}>
           {config.title}
         </Heading>
       )}
 
       {/* Desktop */}
-      <Wrap direction="column" hideBelow={'md'}>
+      <Wrap direction="column" hideBelow={'md'} hidden={searchActive}>
         {showRootAsSections && config.routes.map((link, i) => <SidebarGroupItem {...link} key={i} />)}
 
         {!showRootAsSections && (

--- a/apps/devportal/src/components/navigation/SidebarNavigation.tsx
+++ b/apps/devportal/src/components/navigation/SidebarNavigation.tsx
@@ -1,5 +1,5 @@
 import { SidebarNavigationConfig, SidebarNavigationItem } from '@/src/lib/interfaces/page-info';
-import { Box, Button, ButtonGroup, Collapse, HStack, Heading, Icon, IconButton, Text, Wrap, useDisclosure } from '@chakra-ui/react';
+import { Box, Button, ButtonGroup, Collapse, HStack, Heading, Hide, Icon, IconButton, Text, Wrap, useDisclosure } from '@chakra-ui/react';
 import { mdiChevronDown, mdiChevronRight, mdiMinus, mdiPlus } from '@mdi/js';
 import { appendPathToBasePath } from '@scdp/ui/lib';
 import NextLink from 'next/link';
@@ -25,7 +25,11 @@ const SidebarNavigation = ({ config }: SidebarNavigationProps) => {
 
   return (
     <React.Fragment>
-      {config.enableSearch && <SidebarSearch config={config} onFocus={() => setSearchActive(true)} onBlur={() => setSearchActive(false)} />}
+      {config.enableSearch && (
+        <Hide below="md">
+          <SidebarSearch config={config} onFocus={() => setSearchActive(true)} onBlur={() => setSearchActive(false)} />
+        </Hide>
+      )}
 
       {config.heading && !searchActive && (
         <Heading as={NextLink} variant={'section'} my={4} hideBelow={'md'} href={config.path} px={2}>
@@ -182,7 +186,6 @@ const DropDownMenu = ({ config, ...rest }: SidebarNavigationProps) => {
       >
         {config.title}
       </Button>
-
       <Collapse in={isOpen}>
         <Box position={'relative'}>
           <ButtonGroup variant="navigation" orientation="vertical" width={'full'} spacing="1" mt={2} as="ul">

--- a/apps/devportal/src/components/navigation/SidebarSearch.tsx
+++ b/apps/devportal/src/components/navigation/SidebarSearch.tsx
@@ -77,11 +77,13 @@ const SidebarSearch = ({ config, onFocus, onBlur }: SidebarNavigationProps) => {
           <Box key={i} hidden={filteredRoutes.length == 0 || searchTerm == ''} mt={6}>
             {filteredRoutes.length == 0 && <Heading variant="section">No results found</Heading>}
 
-            <Heading variant="section">{link.title}</Heading>
+            <Heading variant="section" mb="4">
+              {link.title}
+            </Heading>
             {link.children.map((child, j) => (
               <Box key={j}>
                 <ButtonGroup variant="navigation" orientation="vertical" spacing="1" width={'full'} key={i}>
-                  <Button as={NextLink} colorScheme="neutral" href={appendPathToBasePath(config.path, child.path)} px={2} width={'full'}>
+                  <Button as={NextLink} colorScheme="neutral" href={appendPathToBasePath(config.path, child.path)} px={2} width={'full'} display={'inline-block'} alignContent={'center'}>
                     <Highlight styles={{ px: '0', py: '0.5', bg: 'orange.100' }} query={searchTerm}>
                       {child.title}
                     </Highlight>

--- a/apps/devportal/src/components/navigation/SidebarSearch.tsx
+++ b/apps/devportal/src/components/navigation/SidebarSearch.tsx
@@ -1,0 +1,99 @@
+import { Box, Button, ButtonGroup, Heading, Highlight, Icon, IconButton, Input, InputGroup, InputLeftElement, InputRightElement } from '@chakra-ui/react';
+import { mdiClose, mdiMagnify } from '@mdi/js';
+import NextLink from 'next/link';
+import React from 'react';
+import { appendPathToBasePath } from '../../../../../packages/ui/src/lib/utils/stringUtil';
+import { SidebarNavigationConfig } from '../../lib/interfaces/page-info';
+
+export interface SidebarNavigationProps {
+  title?: string;
+  config: SidebarNavigationConfig;
+  onFocus: () => void;
+  onBlur: () => void;
+}
+
+const SidebarSearch = ({ config, onFocus, onBlur }: SidebarNavigationProps) => {
+  const [searchTerm, setSearchTerm] = React.useState('');
+
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.value === '') return reset();
+
+    setSearchTerm(event.target.value);
+    onFocus();
+  };
+
+  const reset = () => {
+    setSearchTerm('');
+    onBlur();
+  };
+
+  const searchRoutes = (searchTerm: string) => {
+    return config.routes
+      .map((route) => ({
+        ...route,
+        children: route.children.filter((child) => child.title.toLowerCase().includes(searchTerm.toLowerCase())),
+      }))
+      .filter((route) => route.title.toLowerCase().includes(searchTerm.toLowerCase()) || route.children.length > 0);
+  };
+
+  const filteredRoutes = searchRoutes(searchTerm);
+
+  return (
+    <>
+      <Box>
+        <InputGroup maxW="full">
+          <InputLeftElement
+            pointerEvents="none"
+            children={
+              <Icon>
+                <path d={mdiMagnify} />
+              </Icon>
+            }
+          />
+          <Input placeholder="Search" onChange={handleSearch} value={searchTerm} />
+          <InputRightElement>
+            <IconButton
+              onClick={reset}
+              variant="ghost"
+              icon={
+                <Icon>
+                  <path d={mdiClose} />
+                </Icon>
+              }
+              size="sm"
+              aria-label={'Close'}
+            />
+          </InputRightElement>
+        </InputGroup>
+      </Box>
+      <Box>
+        {filteredRoutes.length == 0 && (
+          <Heading variant="section" p="2">
+            No results found
+          </Heading>
+        )}
+
+        {filteredRoutes.map((link, i) => (
+          <Box key={i} hidden={filteredRoutes.length == 0 || searchTerm == ''} mt={6}>
+            {filteredRoutes.length == 0 && <Heading variant="section">No results found</Heading>}
+
+            <Heading variant="section">{link.title}</Heading>
+            {link.children.map((child, j) => (
+              <Box key={j}>
+                <ButtonGroup variant="navigation" orientation="vertical" spacing="1" width={'full'} key={i}>
+                  <Button as={NextLink} colorScheme="neutral" href={appendPathToBasePath(config.path, child.path)} px={2} width={'full'}>
+                    <Highlight styles={{ px: '0', py: '0.5', bg: 'orange.100' }} query={searchTerm}>
+                      {child.title}
+                    </Highlight>
+                  </Button>
+                </ButtonGroup>
+              </Box>
+            ))}
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
+};
+
+export default SidebarSearch;

--- a/apps/devportal/src/components/navigation/SidebarSearch.tsx
+++ b/apps/devportal/src/components/navigation/SidebarSearch.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, ButtonGroup, Heading, Highlight, Icon, IconButton, Input, InputGroup, InputLeftElement, InputRightElement } from '@chakra-ui/react';
-import { mdiClose, mdiMagnify } from '@mdi/js';
+import { mdiClose, mdiFilterVariant } from '@mdi/js';
 import NextLink from 'next/link';
 import React from 'react';
 import { appendPathToBasePath } from '../../../../../packages/ui/src/lib/utils/stringUtil';
@@ -46,11 +46,11 @@ const SidebarSearch = ({ config, onFocus, onBlur }: SidebarNavigationProps) => {
             pointerEvents="none"
             children={
               <Icon>
-                <path d={mdiMagnify} />
+                <path d={mdiFilterVariant} />
               </Icon>
             }
           />
-          <Input placeholder="Search" onChange={handleSearch} value={searchTerm} />
+          <Input placeholder="Filter" onChange={handleSearch} value={searchTerm} />
           <InputRightElement>
             <IconButton
               onClick={reset}

--- a/apps/devportal/src/layouts/ArticlePage.tsx
+++ b/apps/devportal/src/layouts/ArticlePage.tsx
@@ -1,12 +1,13 @@
 import { TrackPageView } from '@/src/components/engagetracker/TrackPageView';
 import { ContentHeading } from '@lib/interfaces/contentheading';
 import { ChildPageInfo, PageInfo, PagePartialGroup, PartialData, SidebarNavigationConfig } from '@lib/interfaces/page-info';
+import { Hero, PromoCardProps, PromoList } from '@scdp/ui/components';
 import SocialFeeds from '@src/components/common/SocialFeeds';
 import { MarkDownContent } from '@src/components/markdown/MarkdownContent';
 import InPageNav from '@src/components/navigation/InPageNav';
 import Layout from '@src/layouts/Layout';
-import { Hero, PromoCardProps, PromoList } from '@scdp/ui/components';
 import GithubContributionNotice from '../components/common/contribute';
+import BreadcrumbNav from '../components/navigation/BreadcrumbNav';
 import SidebarNavigation from '../components/navigation/SidebarNavigation';
 import { ThreeColumnLayout } from './ThreeColumnLayout';
 
@@ -40,13 +41,12 @@ const ArticlePage = ({ pageInfo, partials, partialGroups, promoAfter, promoBefor
         <Hero title={pageInfo.title} description={pageInfo.description} image={pageInfo.heroImage} productLogo={pageInfo.productLogo} />
 
         <ThreeColumnLayout sidebar={pageInfo.hasSubPageNav && <SidebarNavigation config={sidebarConfig} />} inPageLinks={sectionTitles} inPageNav={sectionTitles.length > 0 && Nav}>
-          <PromoList data={promoBefore} />
+          <BreadcrumbNav enabled={sidebarConfig.enableBreadcrumb} currentPage={pageInfo} config={sidebarConfig} />
 
+          <PromoList data={promoBefore} />
           <MarkDownContent content={pageInfo.parsedContent} partialGroups={partialGroups} partials={partials} />
           <GithubContributionNotice pageInfo={pageInfo} />
-
           {customNavPager}
-
           <PromoList data={promoAfter} />
           <SocialFeeds pageInfo={pageInfo} />
         </ThreeColumnLayout>

--- a/apps/devportal/src/lib/interfaces/page-info.ts
+++ b/apps/devportal/src/lib/interfaces/page-info.ts
@@ -78,6 +78,7 @@ export type SidebarNavigationConfig = {
   heading: boolean;
   path: string;
   showRootAsSections?: boolean;
+  enableSearch?: boolean;
   routes: SidebarNavigationItem[];
 };
 

--- a/apps/devportal/src/lib/interfaces/page-info.ts
+++ b/apps/devportal/src/lib/interfaces/page-info.ts
@@ -79,6 +79,7 @@ export type SidebarNavigationConfig = {
   path: string;
   showRootAsSections?: boolean;
   enableSearch?: boolean;
+  enableBreadcrumb?: boolean;
   routes: SidebarNavigationItem[];
 };
 


### PR DESCRIPTION
## Description / Motivation
This PR adds a filter to the sidebar on the [download pages](https://developer-portal-1057hpalq-sitecoretechnicalmarketing.vercel.app/downloads).

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-1057hpalq-sitecoretechnicalmarketing.vercel.app/downloads)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
