### PR TITLE
Fix broken links XC download pages

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/100/Sitecore_Experience_Commerce_100/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/100/Sitecore_Experience_Commerce_100/index.md
@@ -29,7 +29,7 @@ Continued performance enhancements
 Framework & 3rd party updates: OData, .NET Standard, .NET Core, Solr, Redis client  
 Corrective content based on feedback from our customers, partners, and developers  
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download Options for Sitecore Containers Deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/101/Sitecore_Experience_Commerce_101/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/101/Sitecore_Experience_Commerce_101/index.md
@@ -12,7 +12,7 @@ Sitecore XC 10.1 adds functional enhancements like data archiving of orders-rel
 
 Refer to the [Sitecore Experience Commerce Compatibility Table](https://kb.sitecore.net/articles/804595) for the software and version prerequisites. 
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download Options for Sitecore Container Deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/102/Sitecore_Experience_Commerce_102/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/102/Sitecore_Experience_Commerce_102/index.md
@@ -8,7 +8,7 @@ Sitecore Experience Commerce (XC) 10.2 is compatible with Sitecore Experience P
 
 Sitecore XC 10.2 adds deployment and upgrade enhancements including the "Items as Resources" and "Container Asset Images" features (described in the release notes below), business usability enhancements, performance enhancements, and bug fixes and improvements based on input from our customers and partners.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download Options for Sitecore Container Deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/103/Sitecore_Experience_Commerce_103/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/103/Sitecore_Experience_Commerce_103/index.md
@@ -8,7 +8,7 @@ Sitecore Experience Commerce (XC) 10.3 is compatible with Sitecore Experience P
 
 Sitecore XC 10.3 is a maintenance release comprising bug fixes and providing compatibility with Sitecore Experience Platform and dependent third parties.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download Options for Sitecore Container Deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Commerce_Server_112_Initial_Release/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Commerce_Server_112_Initial_Release/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/80/Commerce_Server_
 
 Stand-alone version of Commerce Server available for existing customers.  
 
-Looking for a different version? Return to [all available 11.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 11.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Commerce_Server_112_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Commerce_Server_112_Update1/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/80/Commerce_Server_
 
 Stand-alone version of Commerce Server available for existing customers.  
 
-Looking for a different version? Return to [all available 11.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 11.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_Connect/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_Connect/index.md
@@ -8,7 +8,7 @@ Connectivity module for integrating 3rd party commerce or ERP platforms with the
 
 This is the initial and only 8.0 release. There is no Update-1 release for Sitecore Commerce Connect 8.0. It is compatible with Sitecore Experience Platform 8.0 Initial Release through Update-7. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Commerce_Server_Initial_Release/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Commerce_Server_Initial_Release/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/80/Sitecore_Commerc
 
 Sitecore's powered by Commerce Server product, compatible with Sitecore Experience Platform 8.0 Initial Release through Update-3. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Commerce_Server_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Commerce_Server_Update1/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/80/Sitecore_Commerc
 
 Sitecore's powered by Commerce Server product, compatible with Sitecore Experience Platform 8.0 Update-4 through Update-7. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Microsoft_Dynamics_Initial_Release/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Microsoft_Dynamics_Initial_Release/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/80/Sitecore_Commerc
 
 Sitecore's powered by Microsoft Dynamics commerce product, compatible with Sitecore Experience Platform 8.0 Initial Release through Update-3. Includes connectivity modules for integration with Microsoft Dynamics Retail AX 2012 CU8. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Microsoft_Dynamics_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Microsoft_Dynamics_Update1/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/80/Sitecore_Commerc
 
 Sitecore's powered by Microsoft Dynamics commerce product, compatible with Sitecore Experience Platform 8.0 Update-4 through Update-7. Includes connectivity modules for integration with Microsoft Dynamics Retail AX 2012 R3 CU8. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_Connect/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_Connect/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/81/Sitecore_Commerc
 
 Connectivity module for integrating 3rd party commerce or ERP platforms with the Sitecore Experience Platform. Compatible with Sitecore Experience Platform 8.1 Update-1 through Update-3. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_powered_by_CS/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_powered_by_CS/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/81/Sitecore_Commerc
 
 Sitecore's powered by Commerce Server product, compatible with Sitecore Experience Platform 8.1 Update-1 through Update-3. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_powered_by_Microsoft_Dynamics_Initial_Release/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_powered_by_Microsoft_Dynamics_Initial_Release/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/81/Sitecore_Commerc
 
 Sitecore's powered by Microsoft Dynamics commerce product, compatible with Sitecore Experience Platform 8.1 Update-1 through Update-3. Includes connectivity modules for integration with Microsoft Dynamics Retail AX 2012 R3 CU9. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/81/Sitecore_Commerce_Server_113/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/81/Sitecore_Commerce_Server_113/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/81/Sitecore_Commerc
 
 Stand-alone version of Commerce Server available for existing customers.  
 
-Looking for a different version? Return to [all available 11.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 11.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/82/Commerce_Server_114/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/82/Commerce_Server_114/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/82/Commerce_Server_
 
 Stand-alone version of Commerce Server available for existing customers.
 
-Looking for a different version? Return to [all available 11.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 11.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_Connect/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_Connect/index.md
@@ -8,7 +8,7 @@ Connectivity module for integrating 3rd party commerce or ERP platforms with the
 
 Two package versions are available on this page, the initial release and the latest. Select the version that aligns with the version of the Sitecore Experience Platform you are deploying. For more information on alignment between releases of Sitecore Commerce and the Sitecore Experience Platform, see the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_powered_by_Commerce_Server/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_powered_by_Commerce_Server/index.md
@@ -8,7 +8,7 @@ Sitecore's powered by Commerce Server product, compatible with Sitecore Experien
 
 This page includes the latest available Commerce 8.2 downloads. Where specifically stated, downloads have been updated since the Initial Release to maintain compatibility with Sitecore XP. More information on alignment between Sitecore Commerce 8.2 and Sitecore XP 8.2 update releases is provided in the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_powered_by_Microsoft_Dynamics/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_powered_by_Microsoft_Dynamics/index.md
@@ -8,7 +8,7 @@ Sitecore's powered by Microsoft Dynamics commerce product, compatible with Sitec
 
 This page includes the latest available Commerce 8.2 downloads. Where specifically stated, downloads have been updated since the Initial Release to maintain compatibility with Sitecore XP. More information on alignment between Sitecore Commerce 8.2 and Sitecore XP 8.2 update releases is provided in the [Sitecore Commerce Compatibility Table](https://kb.sitecore.net/articles/316437)
 
-Looking for a different version? Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Looking for a different version? Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Core Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821/index.md
@@ -8,7 +8,7 @@ This is Sitecore's new Commerce product, simply named Sitecore Commerce. This is
 
 Sitecore Commerce Connect is no longer packaged as a separate product. To access it, download the full Sitecore Commerce release package and extract only the Sitecore Commerce Connect 10.0.174.zip file.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update1/index.md
@@ -8,7 +8,7 @@ This is Update-1 to Sitecore Commerce 8.2.1, compatible with Sitecore Experience
 
 Sitecore Commerce Connect is no longer packaged as a separate product. To access it, download the full Sitecore Commerce release package and extract only the Sitecore Commerce Connect 10.1.11.zip file.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update2/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update2/index.md
@@ -8,7 +8,7 @@ This is Update-2 to Sitecore Commerce 8.2.1, compatible with Sitecore Experience
 
 Sitecore Commerce Connect is no longer packaged as a separate product. To access it, download the full Sitecore Commerce release package and extract only the Sitecore Commerce Connect 10.2.12.zip file.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update3/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update3/index.md
@@ -8,7 +8,7 @@ This is Update-3 to Sitecore Commerce 8.2.1, compatible with Sitecore Experience
 
 Sitecore Commerce Connect is no longer packaged as a separate product. To access it, download the full Sitecore Commerce release package and extract only the Sitecore Commerce Connect 10.3.27.zip file. 
 
-Return to [all available 8.x versions](/Downloads/Sitecore_Commerce)
+Return to [all available 8.x versions](/downloads/Sitecore_Commerce)
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Initial_Release/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Initial_Release/index.md
@@ -10,7 +10,7 @@ Sitecore XC 9.0 Initial is compatible with Sitecore XP 9.0 Update-1. Refer to th
 
 Sitecore Commerce Connect is no longer packaged as a separate product. To access it, download the full Packages for On Premises and extract only the Sitecore Commerce Connect Core 11.0.192.zip file. Note that at this time, the product synchronization feature is not implemented as stated in Release Notes.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Update1/index.md
@@ -8,7 +8,7 @@ Update-1 to Sitecore Experience Commerce 9.0, compatible with Sitecore Experienc
 
 Sitecore Commerce Connect is no longer packaged as a separate product. To access it, download the full Packages for On Premises and extract only the Sitecore Commerce Connect Core 11.1.78.zip file. Note that at this time, the product synchronization feature is not implemented as stated in 9.0 Initial Release Notes.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)  
+Return to [all available versions](/downloads/Sitecore_Commerce)  
   
 
 ## Download options

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Update2/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Update2/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/90/Sitecore_Experie
 
 Update-2 to Sitecore Experience Commerce 9.0, compatible with Sitecore Experience Platform 9.0 Update-2. Refer to the [Sitecore Experience Commerce 9 Compatibility Table](https://kb.sitecore.net/articles/804595) for the software and version prerequisites.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Update3/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Update3/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/90/Sitecore_Experie
 
 Update-3 to Sitecore Experience Commerce 9.0, compatible with Sitecore Experience Platform 9.0 Update-2. Refer to the [Sitecore Experience Commerce 9 Compatibility Table](https://kb.sitecore.net/articles/804595) for the software and version prerequisites.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/91/Sitecore_Experience_Commerce_91_Initial_Release/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/91/Sitecore_Experience_Commerce_91_Initial_Release/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/91/Sitecore_Experie
 
 Initial launch of Sitecore Commerce 9.1, focusing on compatibility with Sitecore Experience Platform 9.1 Update-1, along with enhancements and corrective content. Refer to the [Sitecore Experience Commerce 9 Compatibility Table](https://kb.sitecore.net/articles/804595) for the software and version prerequisites.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/92/Sitecore_Experience_Commerce_92_Initial_Release/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/92/Sitecore_Experience_Commerce_92_Initial_Release/index.md
@@ -6,7 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/92/Sitecore_Experie
 
 Initial launch of Sitecore Experience Commerce 9.2, focusing on increased solution performance and ability to scale, along with functional enhancements and corrective content. Sitecore Commerce 9.2 is compatible with Sitecore Experience Platform 9.2 Initial Release. Refer to the [Sitecore Experience Commerce 9 Compatibility Table](https://kb.sitecore.net/articles/804595) for the software and version prerequisites.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/93/Sitecore_Experience_Commerce_93_Initial_Release/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Commerce/93/Sitecore_Experience_Commerce_93_Initial_Release/index.md
@@ -8,7 +8,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Commerce/93/Sitecore_Experie
 
 Initial launch of Sitecore Experience Commerce 9.3, focusing on increased solution performance and ability to scale, along with functional enhancements and corrective content. Sitecore Commerce 9.3 is compatible with Sitecore Experience Platform 9.3 Initial Release. Refer to the [Sitecore Experience Commerce 9 Compatibility Table](https://kb.sitecore.net/articles/804595) for the software and version prerequisites.
 
-Return to [all available versions](/Downloads/Sitecore_Commerce)
+Return to [all available versions](/downloads/Sitecore_Commerce)
 
 ## Download options
 


### PR DESCRIPTION
## Description / Motivation
Fixed broken link on all Experience Commerce download pages, carried over from dev.sitecore.net.

## How Has This Been Tested?
Copy/pasted broken and fixed links to a fresh browser.
Inspected PR line by line, compared against each XC download page.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
