### PR TITLE
Fix link references to Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ NEXT_PUBLIC_SITECORE_CDP_POS=
 
 We are very grateful to the community for contributing bug fixes and improvements. We welcome all efforts to evolve and improve the Sitecore Developer Portal; read below to learn how to participate in those efforts.
 
-### [Code of Conduct](https://github.com/Sitecore/developer-portal/blob/main/apps/devportal/CODE_OF_CONDUCT.md)
+### [Code of Conduct](https://github.com/Sitecore/developer-portal/blob/main/CODE_OF_CONDUCT.md)
 
-Sitecore has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://github.com/Sitecore/developer-portal/blob/main/apps/devportal/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+Sitecore has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://github.com/Sitecore/developer-portal/blob/main/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ### Contributing Guide
 

--- a/apps/devportal/data/markdown/pages/contribute/index.md
+++ b/apps/devportal/data/markdown/pages/contribute/index.md
@@ -53,7 +53,7 @@ We are very grateful to the community for contributing bug fixes and improvement
 
 ### Code of Conduct
 
-Sitecore has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://github.com/Sitecore/developer-portal/blob/main/apps/devportal/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+Sitecore has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://github.com/Sitecore/developer-portal/blob/main/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ### Feedback, ideas or found issues?
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current links to the Code of Conduct file in GitHub are broken and show a 404.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
