### PR TITLE
Fixing URL to mentor article

### DIFF
--- a/apps/devportal/data/markdown/pages/newsletter/2024/02.md
+++ b/apps/devportal/data/markdown/pages/newsletter/2024/02.md
@@ -1,9 +1,9 @@
 ---
-title: "Sitecore Developers February 2024"
-description: "Find out the latest news and updates in the Sitecore community."
-pageType: "newsletter"
+title: 'Sitecore Developers February 2024'
+description: 'Find out the latest news and updates in the Sitecore community.'
+pageType: 'newsletter'
 ---
-  
+
 <NewsletterStory
   title="Secure Your Place at SUGCON EUROPE 2024"
   copy="Secure Your Place at SUGCON EUROPE 2024 Limited spots left. Join us for SUGCON Europe 2024 in Dublin on April 11-12 - Celebrating Our 10th anniversary edition. With a maximum capacity of 300 attendees, don't miss out on this milestone occasion. Explore a jam-packed agenda filled with certification exams, workshops, and sessions led by over 35 speakers covering a diverse range of topics. Connect with industry experts and product leaders, and be sure not to miss the opening keynote by Dave O'Flanagan. Secure your spot now for an unforgettable experience at SUGCON Europe 2024!"
@@ -35,7 +35,7 @@ pageType: "newsletter"
   title="The Sitecore Community Mentorship Program - A Mentor's Journey"
   copy="The Sitecore Community Mentor Program is a great way to get to know the Sitecore Community and start contributing as a mentee, but it is also great for mentors to learn more about our global community and gain new skills through the mentorship. Email us at mvp-program@sitecore.net to be a mentor or mentee today!"
   linkText="Read now"
-  linkHref="https://www.joshwcomeau.com/blog/the-end-of-frontend-development/"
+  linkHref="https://www.mastertoweb.com/blog/sitecore-mentor-program/"
 />
 <NewsletterStory
   title="Sitecore JSS Front-End Development Workflow with Storybook"


### PR DESCRIPTION
## Description / Motivation
Fixes #705 to provide correct URL for mentorship article: https://www.mastertoweb.com/blog/sitecore-mentor-program/

## How Has This Been Tested?
On [Vercel preview site](https://developer-portal-git-705-inco-5eef1d-sitecoretechnicalmarketing.vercel.app/newsletter/2024/02) and local

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
