### PR TITLE
Remove exception throwing and replace with console warning

### DIFF
--- a/packages/changelog/src/lib/common/api.ts
+++ b/packages/changelog/src/lib/common/api.ts
@@ -15,7 +15,8 @@ export async function fetchAPI(credentials: ChangelogCredentials, query: string,
   }
 
   if (endpoint === undefined || token === undefined) {
-    throw new Error('Missing CH ONE endpoint or token');
+    console.warn('WARNING: Missing CH ONE endpoint or token');
+    return null;
   }
 
   return axios


### PR DESCRIPTION
## Description / Motivation

Allows for sites to run without a .env file or without the CH ONE configurations. This reverts to earlier behaviour where the Changelog is silently degraded.

## How Has This Been Tested?
Tested locally and on Vercel

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
