### PR TITLE
Reload InPageNav after route change

### DIFF
--- a/apps/devportal/src/layouts/ArticlePage.tsx
+++ b/apps/devportal/src/layouts/ArticlePage.tsx
@@ -6,6 +6,7 @@ import SocialFeeds from '@src/components/common/SocialFeeds';
 import { MarkDownContent } from '@src/components/markdown/MarkdownContent';
 import InPageNav from '@src/components/navigation/InPageNav';
 import Layout from '@src/layouts/Layout';
+import { useRouter } from 'next/router';
 import GithubContributionNotice from '../components/common/contribute';
 import BreadcrumbNav from '../components/navigation/BreadcrumbNav';
 import SidebarNavigation from '../components/navigation/SidebarNavigation';
@@ -25,6 +26,7 @@ type ArticlePageProps = {
 };
 
 const ArticlePage = ({ pageInfo, partials, partialGroups, promoAfter, promoBefore, customNav, customNavPager, sidebarConfig }: ArticlePageProps) => {
+  const router = useRouter();
   if (!pageInfo) return <>No pageInfo found</>;
 
   // Check for headings in the content
@@ -33,7 +35,7 @@ const ArticlePage = ({ pageInfo, partials, partialGroups, promoAfter, promoBefor
 
   if (partials) sectionTitles.push(...partials.titles);
 
-  const Nav = pageInfo.hasInPageNav != false ? customNav ? customNav : sectionTitles != null ? <InPageNav titles={sectionTitles} /> : null : null;
+  const Nav = pageInfo.hasInPageNav != false ? customNav ? customNav : sectionTitles != null ? <InPageNav titles={sectionTitles} key={router.asPath} /> : null : null;
 
   return (
     <TrackPageView pageInfo={pageInfo}>

--- a/apps/devportal/src/layouts/DefaultContentPage.tsx
+++ b/apps/devportal/src/layouts/DefaultContentPage.tsx
@@ -1,16 +1,14 @@
 import { TrackPageView } from '@/src/components/engagetracker/TrackPageView';
 import { ContentHeading } from '@lib/interfaces/contentheading';
 import { ChildPageInfo, PageInfo, PagePartialGroup, PartialData } from '@lib/interfaces/page-info';
+import { ContentSection, Hero, PromoCardProps, PromoList } from '@scdp/ui/components';
+import ChangelogEntries from '@src/components/changelog/ChangelogEntries';
 import SocialFeeds from '@src/components/common/SocialFeeds';
 import { MarkDownContent } from '@src/components/markdown/MarkdownContent';
 import InPageNav from '@src/components/navigation/InPageNav';
 import Layout from '@src/layouts/Layout';
-import { Hero } from '@scdp/ui/components';
-import { ContentSection } from '@scdp/ui/components';
-import { PromoCardProps } from '@scdp/ui/components';
-import {PromoList} from '@scdp/ui/components';
+import { useRouter } from 'next/router';
 import { ThreeColumnLayout } from './ThreeColumnLayout';
-import ChangelogEntries from '@src/components/changelog/ChangelogEntries';
 
 type DefaultContentPageProps = {
   pageInfo: PageInfo;
@@ -25,6 +23,7 @@ type DefaultContentPageProps = {
 };
 
 const DefaultContentPage = ({ pageInfo, partials, partialGroups, promoAfter, promoBefore, customNav, customNavPager }: DefaultContentPageProps) => {
+  const router = useRouter();
   if (!pageInfo) return <>No pageInfo found</>;
 
   // Check for headings in the content
@@ -44,7 +43,7 @@ const DefaultContentPage = ({ pageInfo, partials, partialGroups, promoAfter, pro
           <PromoList data={promoBefore} />
           {/* Page structure */}
 
-          <ThreeColumnLayout sidebar={pageInfo.hasSubPageNav && Nav} inPageNav={sectionTitles.length > 0 && <InPageNav titles={sectionTitles} />} inPageLinks={sectionTitles}>
+          <ThreeColumnLayout sidebar={pageInfo.hasSubPageNav && Nav} inPageNav={sectionTitles.length > 0 && <InPageNav titles={sectionTitles} key={router.asPath} />} inPageLinks={sectionTitles}>
             <MarkDownContent content={pageInfo.parsedContent} partialGroups={partialGroups} partials={partials} />
 
             <ChangelogEntries entries={pageInfo.changelogEntries} title={`Latest product updates`} linkText="Full changelog" columns={2} />


### PR DESCRIPTION
## Description / Motivation
This PR fixes the issue that the InPageNav does not reload after route change

## How Has This Been Tested?
Local and Vercel

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
