### PR TITLE
Fix xDB to CDP migration tool docs link

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/xDB_to_CDP_Migration/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/xDB_to_CDP_Migration/index.md
@@ -18,7 +18,7 @@ Use the xDB to CDP Migration tool to facilitate seamless migration of visitor co
 
 - **Sitecore XP versions supported**: Data can be migrated from Sitecore XP versions 9.0 and later.
 
-- **More information**: See the xDB to CDP Migration Tool at [Sitecore Documentation](https://doc.sitecore.com/)
+- **More information**: See the xDB to CDP Migration Tool at [Sitecore Documentation](https://doc.sitecore.com/xp/en/developers/104/sitecore-experience-platform/the-xdb-to-cdp-migration-tool.html)
 
 ## Sitecore Connect Recipes
 

--- a/apps/devportal/data/markdown/pages/downloads/xDB_to_CDP_Migration/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/xDB_to_CDP_Migration/index.md
@@ -22,13 +22,13 @@ Use the xDB to CDP Migration tool to facilitate seamless migration of visitor co
 
 ## Sitecore Connect Recipes
 
- | Resource | Description |
- | --- | --- |
- | [xDB to CDP - USW](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20USW.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the United States West region. |
- | [xDB to CDP - USE](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20USE.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the United States East region. |
- | [xDB to CDP - EUW](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20EUW.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the Europe West region. |
- | [xDB to CDP - AUE](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20AUE.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the Australia region. |
- | [xDB to CDP - JPE](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20JPE.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the Japan region. |
+| Resource                                                                                                                                    | Description                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [xDB to CDP - USW](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20USW.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the United States West region. |
+| [xDB to CDP - USE](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20USE.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the United States East region. |
+| [xDB to CDP - EUW](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20EUW.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the Europe West region.        |
+| [xDB to CDP - AUE](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20AUE.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the Australia region.          |
+| [xDB to CDP - JPE](https://scdp.blob.core.windows.net/downloads/xDB_to_CDP_Migration/xDB_to_CDP_Migration_1.0/xDB%20to%20CDP%20-%20JPE.zip) | xDB to CDP Migration recipe for Sitecore Connect hosted in the Japan region.              |
 
 ## Other Resources
 


### PR DESCRIPTION
## Description / Motivation
The docs link was wrong and should go to: https://doc.sitecore.com/xp/en/developers/104/sitecore-experience-platform/the-xdb-to-cdp-migration-tool.html

## How Has This Been Tested?
Locally and on Vercel

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
