### PR TITLE
Fix links and align page formatting

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_AI_Automated_Personalization_Standard/10x/Sitecore_AI_Automated_Personalization_Standard_101/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_AI_Automated_Personalization_Standard/10x/Sitecore_AI_Automated_Personalization_Standard_101/index.md
@@ -6,17 +6,11 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_AI_Automated_Personalization
 
   <Alert variant='warning' mb={4}>
     <AlertIcon />
-    This release is deprecated, please use [Sitecore AI 3.0](/downloads/Sitecore_AI_Automated_Personalization_Standard/3x/) instead.
+    This release is deprecated, please use [Sitecore AI Automated Personalization Standard 3.0](/downloads/Sitecore_AI_Automated_Personalization_Standard/3x/Sitecore_AI_Automated_Personalization_Standard_300) instead.
   </Alert>
-  
 
-A module to enable Sitecore AI Auto-Personalization for Sitecore XP installation with traffic no greater than 12 million visits per year.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This release is compatible with Sitecore XP 10.1.
-  </Alert>
-  
+This module enables AI Auto-Personalization for Sitecore Experience Platform installations with traffic no greater than 12 million visits per year.\
+Sitecore AI Automated Personalization Standard 10.1.0 is compatible with Sitecore Experience Platform 10.1. 
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_AI_Automated_Personalization_Standard/2x/Sitecore_AI_Automated_Personalization_Standard_200/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_AI_Automated_Personalization_Standard/2x/Sitecore_AI_Automated_Personalization_Standard_200/index.md
@@ -4,13 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_AI_Automated_Personalization_Standard/2x/Sitecore_AI_Automated_Personalization_Standard_200.aspx
 ---
 
-A module to enable Sitecore AI Auto-Personalization for Sitecore XP installation with traffic no greater than 12 million visits per year.
+This module enables AI Auto-Personalization for Sitecore Experience Platform installations with traffic no greater than 12 million visits per year.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This release is compatible with Sitecore XP 10.0.
-  </Alert>
-  
+Sitecore AI Automated Personalization Standard 2.0.0 is compatible with Sitecore Experience Platform 10.0. 
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_AI_Automated_Personalization_Standard/3x/Sitecore_AI_Automated_Personalization_Standard_300/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_AI_Automated_Personalization_Standard/3x/Sitecore_AI_Automated_Personalization_Standard_300/index.md
@@ -4,13 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_AI_Automated_Personalization_Standard/3x/Sitecore_AI_Automated_Personalization_Standard_300.aspx
 ---
 
-A module to enable Sitecore AI Auto-Personalization for Sitecore XP installation with traffic no greater than 12 million visits per year.
+This module enables AI Auto-Personalization for Sitecore Experience Platform installations with traffic no greater than 12 million visits per year.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This release is compatible with Sitecore XP 10.1.
-  </Alert>
-  
+Sitecore AI Automated Personalization Standard 3.0.0 is compatible with Sitecore Experience Platform 10.1. 
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_AI_Automated_Personalization_Standard/4x/Sitecore_AI_Automated_Personalization_Standard_400/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_AI_Automated_Personalization_Standard/4x/Sitecore_AI_Automated_Personalization_Standard_400/index.md
@@ -4,13 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_AI_Automated_Personalization_Standard/4x/Sitecore_AI_Automated_Personalization_Standard_400.aspx
 ---
 
-A module to enable Sitecore AI Auto-Personalization for Sitecore XP installation with traffic no greater than 12 million visits per year.
+This module enables AI Auto-Personalization for Sitecore Experience Platform installations with traffic no greater than 12 million visits per year.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This release is compatible with Sitecore XP 10.2.
-  </Alert>
-  
+Sitecore AI Automated Personalization Standard 4.0.0 is compatible with Sitecore Experience Platform 10.2. 
+
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Embeddable_Forms/1x/Sitecore_Embeddable_Forms_100/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Embeddable_Forms/1x/Sitecore_Embeddable_Forms_100/index.md
@@ -6,11 +6,7 @@ origin: https://dev.sitecore.net/Downloads/Sitecore_Embeddable_Forms/1x/Sitecore
 
 Sitecore Embeddable Forms Framework (EFF) allow forms to be displayed on any website page, including websites that are not Sitecore applications. They are isolated and unobtrusive; hence they cannot hurt any other functionality or style of the page where they are embedded.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Embeddable Forms is compatible with Sitecore 10.3.
-  </Alert>
-  
+Sitecore Embeddable Forms 1.0.0 is compatible with Sitecore Experience Platform 10.3 and later.
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1000/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1000/index.md
@@ -4,18 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1000
 ---
 
-The Sitecore® Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.
+The Sitecore Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.\
+Sitecore Experience Accelerator 10.0.0 is compatible with Sitecore Experience Platform 10.0.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Experience Accelerator is compatible with Sitecore 10.0.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Accelerator).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Experience_Accelerator).
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1010/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1010/index.md
@@ -4,18 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1010
 ---
 
-The Sitecore® Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.
+The Sitecore Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.\
+Sitecore Experience Accelerator 10.1.0 is compatible with Sitecore Experience Platform 10.1.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Experience Accelerator is compatible with Sitecore 10.1.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Accelerator).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Experience_Accelerator).
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1020/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1020/index.md
@@ -4,18 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1020
 ---
 
-The Sitecore® Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.
+The Sitecore Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.\
+Sitecore Experience Accelerator 10.2.0 is compatible with Sitecore Experience Platform 10.2.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Experience Accelerator is compatible with Sitecore 10.2.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Accelerator).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Experience_Accelerator). 
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1030/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1030/index.md
@@ -3,19 +3,11 @@ title: "Sitecore Experience Accelerator 10.3.0"
 description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1030
 ---
+ 
+The Sitecore Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.\
+Sitecore Experience Accelerator 10.3.0 is compatible with Sitecore Experience Platform 10.3.
 
-The Sitecore® Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Experience Accelerator is compatible with Sitecore 10.3.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Accelerator).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Experience_Accelerator).
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1040/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Accelerator/10x/Sitecore_Experience_Accelerator_1040/index.md
@@ -3,8 +3,7 @@ title: "Sitecore Experience Accelerator 10.4.0"
 description: ""
 ---
 
-The Sitecore Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.
-
+The Sitecore Experience Accelerator provides reusable, templated UX layouts and components to help you get up and running quickly.\
 Sitecore Experience Accelerator 10.4.0 is compatible with Sitecore Experience Platform 10.4.
 
 See [all available versions here](/downloads/Sitecore_Experience_Accelerator).

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100/index.md
@@ -4,7 +4,7 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100.aspx
 ---
 
-Sitecore® Experience Platform™ 10.0 focuses on product updates and enhancements that provide more development and deployment options, increase usability and improve overall performance – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
+Sitecore Experience Platform 10.0 focuses on product updates and enhancements that provide more development and deployment options, increase usability and improve overall performance – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
 
 New delivery options including support for Docker, Kubernetes and new Sitecore-provided image repositories, helping delivery teams move to a continuous delivery model more easily with infrastructure-as-code deployments and more efficient solution and team onboarding. The addition of the ASP.NET Core SDK and headless rendering host architecture also provides developers with a new way of building their solutions allowing for faster development iterations.
 
@@ -21,30 +21,7 @@ Other highlights include:
 -   New marketing automation capabilities include capabilities to engage customers with automated birthday campaigns.
 -   Support for GDPR compliance journeys including features that make it easier to enforce and manage consent options as well as supporting the anonymization of personal information submitted via Sitecore Forms.
 
-This release is issued after extensive testing and feedback from customers, partners and developers, resulting in a new level of quality across the product and documentation. For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.0, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-  
-
-This page contains all the resources for **Sitecore Experience Platform 10.0**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -106,6 +83,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.0**.
  | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100/Secure/Quick_Installation_Guide_for_a_Developer_Workstation-10.0.0.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes. |
  | [Upgrade Guide (8.1.0-9.0.1 to 10.0.0)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100/Secure/Upgrade_Guide_Sitecore_10.0.0_from_8.1.0-9.0.1.pdf) | Explains how to directly upgrade from Sitecore versions 8.1.0 through 9.0.1 to 10.0.0. |
  | [Upgrade Guide (9.0.2 to 10.0.0)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100/Secure/Upgrade_Guide_Sitecore_10.0.0_from_9.0.2_or_later.pdf) | Explains how to directly upgrade from Sitecore 9.0.2 and later to 10.0.0. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100/Secure/Sitecore.Platform.Assemblies%2010.0.0%20rev.%20004346.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -153,3 +131,8 @@ This page contains all the resources for **Sitecore Experience Platform 10.0**.
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.0, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update1/index.md
@@ -4,47 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update1.aspx
 ---
 
-Sitecore® Experience Platform™ 10.0 focuses on product updates and enhancements that provide more development and deployment options, increase usability and improve overall performance – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
+Update-1 to Sitecore Experience Platform 10.0.
 
-New delivery options including support for Docker, Kubernetes and new Sitecore-provided image repositories, helping delivery teams move to a continuous delivery model more easily with infrastructure-as-code deployments and more efficient solution and team onboarding. The addition of the ASP.NET Core SDK and headless rendering host architecture also provides developers with a new way of building their solutions allowing for faster development iterations.
-
-Other highlights include:
-
--   Sitecore Containers support rapid deployment and more efficient solution and team onboarding with modern Docker and Kubernetes technology.
--   A new ASP.NET Core headless development option allows teams to build applications faster on the latest .NET technology.
--   Sitecore CLI and Sitecore for Visual Studio bring headless serialization by combining the best of TDS and Unicorn , making it easy for teams to script content changes and move them between different environments as part of deployment processes.
--   Audience analytics filters allow for deeper insights on audience engagement and segmentation to drive powerful personalization across all your channels.
--   Additional HTML Email Templates for EXM provide more options when crafting emails, which translates to the quicker creation and delivery of targeted emails to customer inboxes.
--   Horizon editing interface updates give marketers in-context insight across multilingual and multisite experiences.
--   Stronger CMP integration supports additional field types and allows for persistent taxonomy associations when importing into XP taxonomy repositories and connecting CMP to XP.
--   Salesforce Marketing Cloud (SFMC) connector updates provide new capabilities to immediately send xDB data and trigger Salesforce Marketing Cloud plans in Journey Builder.
--   New marketing automation capabilities include capabilities to engage customers with automated birthday campaigns.
--   Support for GDPR compliance journeys including features that make it easier to enforce and manage consent options as well as supporting the anonymization of personal information submitted via Sitecore Forms.
-
-This release is issued after extensive testing and feedback from customers, partners and developers, resulting in a new level of quality across the product and documentation. For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.0, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.0 Update-1**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -108,6 +70,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | [Upgrade Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update1/Secure/Sitecore_Upgrade_Container_Deployment_Guide-%20SC-10.0.1.pdf) | Explains how to use the Sitecore Container Deployment Package to upgrade the SQL Server databases of an existing Sitecore XP 9.3.0 installation to Sitecore XP 10.0.1. |
  | [Upgrade Guide (8.1.0-9.0.1 to 10.0.1)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update1/Secure/Upgrade_Guide_Sitecore_10.0.1_from%20_8.1.0-9.0.1.pdf) | Explains how to directly upgrade from Sitecore versions 8.1.0 through 9.0.1 to 10.0.1. |
  | [Upgrade Guide (9.0.2 to 10.0.1)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update1/Secure/Upgrade_Guide_Sitecore_10.0.1_from_9.0.2_or_later.pdf) | Explains how to directly upgrade from Sitecore 9.0.2 and later to 10.0.1. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update1/Secure/Sitecore.Platform.Assemblies%2010.0.1%20rev.%20004842.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -156,3 +119,9 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.0, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>
+  

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update2/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update2/index.md
@@ -4,47 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update2.aspx
 ---
 
-Sitecore® Experience Platform™ 10.0 focuses on product updates and enhancements that provide more development and deployment options, increase usability and improve overall performance – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
+Update-2 to Sitecore Experience Platform 10.0.
 
-New delivery options including support for Docker, Kubernetes and new Sitecore-provided image repositories, helping delivery teams move to a continuous delivery model more easily with infrastructure-as-code deployments and more efficient solution and team onboarding. The addition of the ASP.NET Core SDK and headless rendering host architecture also provides developers with a new way of building their solutions allowing for faster development iterations.
-
-Other highlights include:
-
--   Sitecore Containers support rapid deployment and more efficient solution and team onboarding with modern Docker and Kubernetes technology.
--   A new ASP.NET Core headless development option allows teams to build applications faster on the latest .NET technology.
--   Sitecore CLI and Sitecore for Visual Studio bring headless serialization by combining the best of TDS and Unicorn , making it easy for teams to script content changes and move them between different environments as part of deployment processes.
--   Audience analytics filters allow for deeper insights on audience engagement and segmentation to drive powerful personalization across all your channels.
--   Additional HTML Email Templates for EXM provide more options when crafting emails, which translates to the quicker creation and delivery of targeted emails to customer inboxes.
--   Horizon editing interface updates give marketers in-context insight across multilingual and multisite experiences.
--   Stronger CMP integration supports additional field types and allows for persistent taxonomy associations when importing into XP taxonomy repositories and connecting CMP to XP.
--   Salesforce Marketing Cloud (SFMC) connector updates provide new capabilities to immediately send xDB data and trigger Salesforce Marketing Cloud plans in Journey Builder.
--   New marketing automation capabilities include capabilities to engage customers with automated birthday campaigns.
--   Support for GDPR compliance journeys including features that make it easier to enforce and manage consent options as well as supporting the anonymization of personal information submitted via Sitecore Forms.
-
-This release is issued after extensive testing and feedback from customers, partners and developers, resulting in a new level of quality across the product and documentation. For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.0, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.0 Update-2**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -108,6 +70,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | [Upgrade Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update2/Secure/Sitecore_Upgrade_%20Container_Deployment_Guide-SC-10.0.2.pdf) | Explains how to use the Sitecore Container Deployment Package to upgrade the SQL Server databases of an existing Sitecore XP 9.3.0 installation to Sitecore XP 10.0.2. |
  | [Upgrade Guide (8.1.0-9.0.1 to 10.0.2)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update2/Secure/Upgrade_Guide_Sitecore_10.0.2_from%20_8.1.0-9.0.1.pdf) | Explains how to directly upgrade from Sitecore versions 8.1.0 through 9.0.1 to 10.0.2. |
  | [Upgrade Guide (9.0.2 to 10.0.2)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update2/Secure/Upgrade_Guide_Sitecore_10.0.2_from_9.0.2_or_later.pdf) | Explains how to directly upgrade from Sitecore 9.0.2 and later to 10.0.2. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update2/Secure/Sitecore.Platform.Assemblies%2010.0.2%20rev.%20006052.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -155,3 +118,9 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.0, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>
+  

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update3/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update3/index.md
@@ -4,47 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/100/Sitecore_Experience_Platform_100_Update3.aspx
 ---
 
-Sitecore® Experience Platform™ 10.0 focuses on product updates and enhancements that provide more development and deployment options, increase usability and improve overall performance – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
+Update-3 to Sitecore Experience Platform 10.0.
 
-New delivery options including support for Docker, Kubernetes and new Sitecore-provided image repositories, helping delivery teams move to a continuous delivery model more easily with infrastructure-as-code deployments and more efficient solution and team onboarding. The addition of the ASP.NET Core SDK and headless rendering host architecture also provides developers with a new way of building their solutions allowing for faster development iterations.
-
-Other highlights include:
-
--   Sitecore Containers support rapid deployment and more efficient solution and team onboarding with modern Docker and Kubernetes technology.
--   A new ASP.NET Core headless development option allows teams to build applications faster on the latest .NET technology.
--   Sitecore CLI and Sitecore for Visual Studio bring headless serialization by combining the best of TDS and Unicorn , making it easy for teams to script content changes and move them between different environments as part of deployment processes.
--   Audience analytics filters allow for deeper insights on audience engagement and segmentation to drive powerful personalization across all your channels.
--   Additional HTML Email Templates for EXM provide more options when crafting emails, which translates to the quicker creation and delivery of targeted emails to customer inboxes.
--   Horizon editing interface updates give marketers in-context insight across multilingual and multisite experiences.
--   Stronger CMP integration supports additional field types and allows for persistent taxonomy associations when importing into XP taxonomy repositories and connecting CMP to XP.
--   Salesforce Marketing Cloud (SFMC) connector updates provide new capabilities to immediately send xDB data and trigger Salesforce Marketing Cloud plans in Journey Builder.
--   New marketing automation capabilities include capabilities to engage customers with automated birthday campaigns.
--   Support for GDPR compliance journeys including features that make it easier to enforce and manage consent options as well as supporting the anonymization of personal information submitted via Sitecore Forms.
-
-This release is issued after extensive testing and feedback from customers, partners and developers, resulting in a new level of quality across the product and documentation. For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.0, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.0 Update-3**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -108,6 +70,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | [Upgrade Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update3/Secure/SC-XP-10.0.3-Upgrade-Container-Deployment-Guide-en.pdf) | Explains how to use the Sitecore Container Deployment Package to upgrade the SQL Server databases of an existing Sitecore XP 9.3.0 installation to Sitecore XP 10.0.2. |
  | [Upgrade Guide (8.1.0-9.0.1 to 10.0.3)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update3/Secure/SC-XP-10.0.3-Upgrade-Guide-from-SC-XP-%208.1.0-9.0.1-en.pdf) | Explains how to directly upgrade from Sitecore versions 8.1.0 through 9.0.1 to 10.0.3. |
  | [Upgrade Guide (9.0.2 to 10.0.3)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update3/Secure/SC-XP-10.0.3-Upgrade-Guide-from-SC-XP-9.0.2-or-later-en.pdf) | Explains how to directly upgrade from Sitecore 9.0.2 and later to 10.0.3. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/100/Sitecore%20Experience%20Platform%20100%20Update3/Secure/Sitecore.Platform.Assemblies%2010.0.3%20rev.%20006577.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -155,3 +118,9 @@ This page contains all the resources for **Sitecore Experience Platform 10.0 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.0, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>
+  

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101/index.md
@@ -4,9 +4,7 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101.aspx
 ---
 
-Sitecore® Experience Platform™ 10.1 focuses on product updates and enhancements that improve time-to-market and increase usability and decrease infrastructure costs – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
-
-Sitecore AI Auto-Personalization Standard is available with this release, helps brands jumpstart personalization efforts, automatically identifying visitor trends, creating customer segments and modifying page elements to deliver personalized experiences and enabling users to drive more value out of their Sitecore implementations.
+Sitecore Experience Platform 10.1 focuses on product updates and enhancements that improve time-to-market and increase usability and decrease infrastructure costs – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
 
 Other highlights include:
 
@@ -21,30 +19,7 @@ Other highlights include:
 -   Reporting role consolidation enables further hosting cost reduction by consolidation the Reporting role with the CM role.
 -   New Next.js SDK and sample site are now available for the Sitecore JavaScript SDKs, providing a Jamstack rendering option that improves page performance and site scalability.
 
-For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.1, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.1**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -107,6 +82,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.1**.
  | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Quick_Installation_Guide_for_a_Developer_Workstation-10.1.0.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes. |
  | [Upgrade Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Sitecore_Container_Upgrade_Deployment_Guide-SC-10.1.0.pdf) | Explains how to use the Sitecore Container Deployment Package to upgrade the SQL Server databases of an existing Sitecore XP 10.0.X installation to Sitecore XP 10.1.0. |
  | [Upgrade Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Upgrade_Guide_Sitecore_XP-10.1.0.pdf) | Explains how to directly upgrade from Sitecore XP 8.1.0 or later to Sitecore XP 10.1.0. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Sitecore.Platform.Assemblies%2010.1.0%20rev.%20005207.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -136,10 +112,10 @@ This page contains all the resources for **Sitecore Experience Platform 10.1**.
 
  | Resource | Description |
  | --- | --- |
- | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Translations/Sitecore%2010.1.0%20rev.%20005207%20(da-DK).zip) | Danish language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Translations/Sitecore%2010.1.0%20rev.%20005207%20(de-DE).zip) | German language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Translations/Sitecore%2010.1.0%20rev.%20005207%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Translations/Sitecore%2010.1.0%20rev.%20005207%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
+ | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Translations/Sitecore%2010.1.0%20rev.%20005207%20(da-DK).zip) | Danish language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Translations/Sitecore%2010.1.0%20rev.%20005207%20(de-DE).zip) | German language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Translations/Sitecore%2010.1.0%20rev.%20005207%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101/Secure/Translations/Sitecore%2010.1.0%20rev.%20005207%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
  | [Chinese GeoIP Localization Pack](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/90/Sitecore%20Experience%20Platform%2090%20Initial%20Release/Secure/GeoIp%20Location%20China%20Localization%20Pack%201.0.0%20rev.%20180226.zip) | The pack provides enhanced region detection for China. The pack should be installed as a regular Sitecore module. |
 
 ## Usage policies
@@ -148,3 +124,9 @@ This page contains all the resources for **Sitecore Experience Platform 10.1**.
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.1, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>
+  

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/index.md
@@ -4,47 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1.aspx
 ---
 
-Sitecore® Experience Platform™ 10.1 focuses on product updates and enhancements that improve time-to-market and increase usability and decrease infrastructure costs – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
+Update-1 to Sitecore Experience Platform 10.1.
 
-Sitecore AI Auto-Personalization Standard is available with this release, helps brands jumpstart personalization efforts, automatically identifying visitor trends, creating customer segments and modifying page elements to deliver personalized experiences and enabling users to drive more value out of their Sitecore implementations.
-
-Other highlights include:
-
--   Horizon Enhancements providing new publishing and editing capabilities while reducing the need to switch UIs.
--   Global Search in Content and Pages enabling search within Horizon and making search more efficient.
--   Additional Field type support providing the ability to use Droplinks and Checklists within Horizon.
--   Rules-based content profiling improves marketer productivity with automatic behavioral-based profiling of content based on content tags and taxonomy.
--   Stronger SXA and Horizon integration exposing rendering parameters, components styles, and grid configuration out-of-the-box.
--   Simple Send Email action for sending emails without utilizing EXM and incorporating information from Forms fields.
--   Improved Upgrade Experience by storing default content items outside of the database, removing the need for applying Update packages.
--   Data Purge Tool for XDB provides more control of storage resources and can be used to reduce hosting costs.
--   Reporting role consolidation enables further hosting cost reduction by consolidation the Reporting role with the CM role.
--   New Next.js SDK and sample site are now available for the Sitecore JavaScript SDKs, providing a Jamstack rendering option that improves page performance and site scalability.
-
-For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.1, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.1 Update-1**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -106,6 +68,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
  | [Installation Guide for the XP Scaled topology](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Installation_Guide_for_the_XP_Scaled_topology-10.1.1.pdf) | Explains how to install the fully featured Sitecore Experience Platform Installation (XP1) topology. This topology can be configured to run separated server roles. |
  | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Quick_Installation_Guide_for_a_Developer_Workstation-10.1.1.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes. |
  | [Upgrade Guide for Updates](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Update_Guide-for_Sitecore-XP-10.1.X.pdf) | Explains how to update to the latest release in the Sitecore 10.1.X series. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Sitecore.Platform.Assemblies%2010.1.1%20rev.%20005862.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -135,10 +98,10 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Translations/Sitecore%2010.1.1%20rev.%20005862%20(da-DK).zip) | Danish language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Translations/Sitecore%2010.1.1%20rev.%20005862%20(de-DE).zip) | German language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Translations/Sitecore%2010.1.1%20rev.%20005862%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Translations/Sitecore%2010.1.1%20rev.%20005862%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
+ | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Translations/Sitecore%2010.1.1%20rev.%20005862%20(da-DK).zip) | Danish language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Translations/Sitecore%2010.1.1%20rev.%20005862%20(de-DE).zip) | German language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Translations/Sitecore%2010.1.1%20rev.%20005862%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update1/Secure/Translations/Sitecore%2010.1.1%20rev.%20005862%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
  | [Chinese GeoIP Localization Pack](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/90/Sitecore%20Experience%20Platform%2090%20Initial%20Release/Secure/GeoIp%20Location%20China%20Localization%20Pack%201.0.0%20rev.%20180226.zip) | The pack provides enhanced region detection for China. The pack should be installed as a regular Sitecore module. |
 
 ## Usage policies
@@ -147,3 +110,9 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.1, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>
+  

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/index.md
@@ -4,47 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2.aspx
 ---
 
-Sitecore® Experience Platform™ 10.1 focuses on product updates and enhancements that improve time-to-market and increase usability and decrease infrastructure costs – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
+Update-2 to Sitecore Experience Platform 10.1.
 
-Sitecore AI Auto-Personalization Standard is available with this release, helps brands jumpstart personalization efforts, automatically identifying visitor trends, creating customer segments and modifying page elements to deliver personalized experiences and enabling users to drive more value out of their Sitecore implementations.
-
-Other highlights include:
-
--   Horizon Enhancements providing new publishing and editing capabilities while reducing the need to switch UIs.
--   Global Search in Content and Pages enabling search within Horizon and making search more efficient.
--   Additional Field type support providing the ability to use Droplinks and Checklists within Horizon.
--   Rules-based content profiling improves marketer productivity with automatic behavioral-based profiling of content based on content tags and taxonomy.
--   Stronger SXA and Horizon integration exposing rendering parameters, components styles, and grid configuration out-of-the-box.
--   Simple Send Email action for sending emails without utilizing EXM and incorporating information from Forms fields.
--   Improved Upgrade Experience by storing default content items outside of the database, removing the need for applying Update packages.
--   Data Purge Tool for XDB provides more control of storage resources and can be used to reduce hosting costs.
--   Reporting role consolidation enables further hosting cost reduction by consolidation the Reporting role with the CM role.
--   New Next.js SDK and sample site are now available for the Sitecore JavaScript SDKs, providing a Jamstack rendering option that improves page performance and site scalability.
-
-For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.1, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.1 Update-2**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -107,6 +69,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
  | [Installation Guide for the XP Scaled topology](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/SC-XP-10.1.2-Installation-Guide-XP-Scaled-Topology-en.pdf) | Explains how to install the fully featured Sitecore Experience Platform Installation (XP1) topology. This topology can be configured to run separated server roles. |
  | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/SC-XP-10.1.2-Quick-Installation-Guide-Developer-Workstation-en.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes. |
  | [Update Installation Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/SC-XP-10.1.X-Update-Installation-Guide-en.pdf) | Explains how to update to the latest release in the Sitecore 10.1.X series. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Sitecore.Platform.Assemblies%2010.1.2%20rev.%20006578.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -136,10 +99,10 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Translations/Sitecore%2010.1.2%20rev.%20006578%20(da-DK).zip) | Danish language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Translations/Sitecore%2010.1.2%20rev.%20006578%20(de-DE).zip) | German language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Translations/Sitecore%2010.1.2%20rev.%20006578%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Translations/Sitecore%2010.1.2%20rev.%20006578%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
+ | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Translations/Sitecore%2010.1.2%20rev.%20006578%20(da-DK).zip) | Danish language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Translations/Sitecore%2010.1.2%20rev.%20006578%20(de-DE).zip) | German language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Translations/Sitecore%2010.1.2%20rev.%20006578%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update2/Secure/Translations/Sitecore%2010.1.2%20rev.%20006578%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
  | [Chinese GeoIP Localization Pack](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/90/Sitecore%20Experience%20Platform%2090%20Initial%20Release/Secure/GeoIp%20Location%20China%20Localization%20Pack%201.0.0%20rev.%20180226.zip) | The pack provides enhanced region detection for China. The pack should be installed as a regular Sitecore module. |
 
 ## Usage policies
@@ -148,3 +111,8 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.1, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/index.md
@@ -4,47 +4,9 @@ description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3.aspx
 ---
 
-Sitecore® Experience Platform™ 10.1 focuses on product updates and enhancements that improve time-to-market and increase usability and decrease infrastructure costs – all centered around enabling both Marketing and IT teams equally, thus making it easier and faster to launch and evolve digital customer experiences.
+Update-3 to Sitecore Experience Platform 10.1.
 
-Sitecore AI Auto-Personalization Standard is available with this release, helps brands jumpstart personalization efforts, automatically identifying visitor trends, creating customer segments and modifying page elements to deliver personalized experiences and enabling users to drive more value out of their Sitecore implementations.
-
-Other highlights include:
-
-- Horizon Enhancements providing new publishing and editing capabilities while reducing the need to switch UIs.
-- Global Search in Content and Pages enabling search within Horizon and making search more efficient.
-- Additional Field type support providing the ability to use Droplinks and Checklists within Horizon.
-- Rules-based content profiling improves marketer productivity with automatic behavioral-based profiling of content based on content tags and taxonomy.
-- Stronger SXA and Horizon integration exposing rendering parameters, components styles, and grid configuration out-of-the-box.
-- Simple Send Email action for sending emails without utilizing EXM and incorporating information from Forms fields.
-- Improved Upgrade Experience by storing default content items outside of the database, removing the need for applying Update packages.
-- Data Purge Tool for XDB provides more control of storage resources and can be used to reduce hosting costs.
-- Reporting role consolidation enables further hosting cost reduction by consolidation the Reporting role with the CM role.
-- New Next.js SDK and sample site are now available for the Sitecore JavaScript SDKs, providing a Jamstack rendering option that improves page performance and site scalability.
-
-For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.1, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-
-
-This page contains all the resources for **Sitecore Experience Platform 10.1 Update-3**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -107,6 +69,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
 | [Installation Guide for the XP Scaled topology](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/SC-XP-10.1.3-Installation_Guide_for_the_XP_Scaled_topology-pdf-en.pdf)               | Explains how to install the fully featured Sitecore Experience Platform Installation (XP1) topology. This topology can be configured to run separated server roles.                                                                     |
 | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/SC-XP-10.1.3-Quick_Installation_Guide_for_a_Developer_Workstation-pdf-en.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes.                                                                                                                             |
 | [Update Installation Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/SC-XP-10.1.3-Update_Installation_Guide_v2.pdf)                                                           | Explains how to update to the latest release in the Sitecore 10.1.X series.                                                                                                                                                             |
+| [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
 | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Sitecore.Platform.Assemblies%2010.1.3%20rev.%20009558.zip)                                                           | Complete list of assemblies shipped with this release.                                                                                                                                                                                  |
 
 ## Modules
@@ -136,10 +99,10 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
 
 | Resource                                                                                                                                                                                                                                                        | Description                                                                                                                                                                   |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Danish (da-DK)](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Translations/Sitecore%2010.1.3%20rev.%20009558%20(da-DK).zip>)                                      | Danish language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation.   |
-| [German (de-DE)](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Translations/Sitecore%2010.1.3%20rev.%20009558%20(de-DE).zip>)                                      | German language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation.   |
-| [Japanese (ja-JP)](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Translations/Sitecore%2010.1.3%20rev.%20009558%20(ja-JP).zip>)                                    | Japanese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
-| [Chinese (zh-CN)](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Translations/Sitecore%2010.1.3%20rev.%20009558%20(zh-CN).zip>)                                     | Chinese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/101/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation.  |
+| [Danish (da-DK)](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Translations/Sitecore%2010.1.3%20rev.%20009558%20(da-DK).zip>)                                      | Danish language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation.   |
+| [German (de-DE)](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Translations/Sitecore%2010.1.3%20rev.%20009558%20(de-DE).zip>)                                      | German language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation.   |
+| [Japanese (ja-JP)](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Translations/Sitecore%2010.1.3%20rev.%20009558%20(ja-JP).zip>)                                    | Japanese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+| [Chinese (zh-CN)](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/101/Sitecore%20Experience%20Platform%20101%20Update3/Secure/Translations/Sitecore%2010.1.3%20rev.%20009558%20(zh-CN).zip>)                                     | Chinese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation.  |
 | [Chinese GeoIP Localization Pack](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/90/Sitecore%20Experience%20Platform%2090%20Initial%20Release/Secure/GeoIp%20Location%20China%20Localization%20Pack%201.0.0%20rev.%20180226.zip) | The pack provides enhanced region detection for China. The pack should be installed as a regular Sitecore module.                                                             |
 
 ## Usage policies
@@ -148,3 +111,8 @@ This page contains all the resources for **Sitecore Experience Platform 10.1 Upd
 | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
 | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
 | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy)                       | This policy is applicable if you are using Sitecore IP Geolocations Service.  |
+
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.1, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/index.md
@@ -4,7 +4,7 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102.aspx
 ---
 
-Sitecore® Experience Platform™ 10.2 focuses on increasing performance and stability while helping to reduce costs so organizations can deliver unforgettable experiences faster than ever before. By providing the ability to incrementally convert to headless Sitecore architectures without a full rebuild, 10.2 also offers a bridge to our composable DXP for those who are interested in that path.
+Sitecore Experience Platform 10.2 focuses on increasing performance and stability while helping to reduce costs so organizations can deliver unforgettable experiences faster than ever before. By providing the ability to incrementally convert to headless Sitecore architectures without a full rebuild, 10.2 also offers a bridge to our composable DXP for those who are interested in that path.
 
 In addition, the developer experience is also vastly improved in 10.2 thanks to increases in agility and capabilities in SXA, publishing enhancements, headless rendering, and general upgrades and improvements.
 
@@ -20,30 +20,7 @@ Other highlights include:
 -   Headless Rendering 19.0: Includes enhancements and new documentation to facilitate the inclusion of Sitecore MVC components in the output of the Layout Service and Experience Edge, and conversion of existing Sitecore MVC sites to Jamstack architectures using Next.js.
 -   Sitecore CLI 4.0: Provides improved release velocity with Items as resource plugin and security role serialization.
 
-For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.2, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.2**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -106,6 +83,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.2**.
  | [Installation Guide for the XP Scaled topology](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/SC-XP-10.2.0-Install-Guide-XP-Scaled-Topology-en.pdf) | Explains how to install the fully featured Sitecore Experience Platform Installation (XP1) topology. This topology can be configured to run separated server roles. |
  | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/SC-XP-10.2.0-Quick-Install-Guide-Developer-Workstation-en.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes. |
  | [Upgrade Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/SC-XP-10.2.0-Upgrade-Guide-en.pdf) | Explains how to directly upgrade from Sitecore XP 8.1.0 or later to Sitecore XP 10.2.0. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Sitecore.Platform.Assemblies%2010.2.0%20rev.%20006766.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -136,10 +114,10 @@ This page contains all the resources for **Sitecore Experience Platform 10.2**.
 
  | Resource | Description |
  | --- | --- |
- | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Translations/Sitecore%2010.2.0%20rev.%20006766%20(da-DK).zip) | Danish language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Translations/Sitecore%2010.2.0%20rev.%20006766%20(de-DE).zip) | German language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Translations/Sitecore%2010.2.0%20rev.%20006766%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Translations/Sitecore%2010.2.0%20rev.%20006766%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
+ | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Translations/Sitecore%2010.2.0%20rev.%20006766%20(da-DK).zip) | Danish language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Translations/Sitecore%2010.2.0%20rev.%20006766%20(de-DE).zip) | German language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Translations/Sitecore%2010.2.0%20rev.%20006766%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102/Secure/Translations/Sitecore%2010.2.0%20rev.%20006766%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
  | [Chinese GeoIP Localization Pack](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/90/Sitecore%20Experience%20Platform%2090%20Initial%20Release/Secure/GeoIp%20Location%20China%20Localization%20Pack%201.0.0%20rev.%20180226.zip) | The pack provides enhanced region detection for China. The pack should be installed as a regular Sitecore module. |
 
 ## Usage policies
@@ -148,3 +126,8 @@ This page contains all the resources for **Sitecore Experience Platform 10.2**.
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+   <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.2, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/index.md
@@ -4,46 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1.aspx
 ---
 
-Sitecore® Experience Platform™ 10.2 focuses on increasing performance and stability while helping to reduce costs so organizations can deliver unforgettable experiences faster than ever before. By providing the ability to incrementally convert to headless Sitecore architectures without a full rebuild, 10.2 also offers a bridge to our composable DXP for those who are interested in that path.
+Update-1 to Sitecore Experience Platform 10.2.
 
-In addition, the developer experience is also vastly improved in 10.2 thanks to increases in agility and capabilities in SXA, publishing enhancements, headless rendering, and general upgrades and improvements.
-
-Other highlights include:
-
--   EXM DDS Container Support: Dedicated email dispatch servers (DDS) are supported in Kubernetes and Docker compose files allowing for quicker setup.
--   Introduction of GetTargetContact: Helps deliver efficient communication between tracker and xConnect to help increase overall performance.
--   UX Improvements in Experience Analytics: Gives marketers more control of and access to their data, providing better visualization and more actionable reporting for stakeholders.
--   Personalization Effect Reporting: Marketers can now see the impact of personalization on the conversions for individual goals which helps evaluate campaign effectiveness.
--   Data Purge on Interactions: The ability to purge interactions, based on date, channel or if they contain a certain event.
--   Streamlined Horizon editing: Further enhancemens of SXA on Horizon provides an a more integrated coherent platform and streamlined editing experiences.
--   Scriban Template Improvements: Now at full parity with the classic Rendering Variants, frontend developers have more flexibility to fully express the HTML without the need to log in to Sitecore.
--   Headless Rendering 19.0: Includes enhancements and new documentation to facilitate the inclusion of Sitecore MVC components in the output of the Layout Service and Experience Edge, and conversion of existing Sitecore MVC sites to Jamstack architectures using Next.js.
--   Sitecore CLI 4.0: Provides improved release velocity with Items as resource plugin and security role serialization.
-
-For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.2, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.2 Update-1**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -106,6 +69,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.2 Upd
  | [Installation Guide for the XP Scaled topology](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/SC-XP-10.2.1-Installation_Guide_for_the_XP_Scaled_topology-en.pdf) | Explains how to install the fully featured Sitecore Experience Platform Installation (XP1) topology. This topology can be configured to run separated server roles. |
  | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/SC-XP-10.2.1-Quick_Installation_Guide_for_a_Developer_Workstation-en.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes. |
  | [Update Installation Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/SC-XP-10.2.1-Update_Installation_Guide-en_v2.pdf) | Explains how to update to the latest release in the Sitecore 10.2.X series. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Sitecore.Platform.Assemblies%2010.2.1%20rev.%20009559.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -136,10 +100,10 @@ This page contains all the resources for **Sitecore Experience Platform 10.2 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Translations/Sitecore%2010.2.1%20rev.%20009559%20(da-DK).zip) | Danish language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Translations/Sitecore%2010.2.1%20rev.%20009559%20(de-DE).zip) | German language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Translations/Sitecore%2010.2.1%20rev.%20009559%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Translations/Sitecore%2010.2.1%20rev.%20009559%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/102/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
+ | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Translations/Sitecore%2010.2.1%20rev.%20009559%20(da-DK).zip) | Danish language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Translations/Sitecore%2010.2.1%20rev.%20009559%20(de-DE).zip) | German language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Translations/Sitecore%2010.2.1%20rev.%20009559%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/102/Sitecore%20Experience%20Platform%20102%20Update1/Secure/Translations/Sitecore%2010.2.1%20rev.%20009559%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
  | [Chinese GeoIP Localization Pack](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/90/Sitecore%20Experience%20Platform%2090%20Initial%20Release/Secure/GeoIp%20Location%20China%20Localization%20Pack%201.0.0%20rev.%20180226.zip) | The pack provides enhanced region detection for China. The pack should be installed as a regular Sitecore module. |
 
 ## Usage policies
@@ -148,3 +112,8 @@ This page contains all the resources for **Sitecore Experience Platform 10.2 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+  
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.2, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/index.md
@@ -4,7 +4,7 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103.aspx
 ---
 
-Sitecore® Experience Platform 10.3 delivers new capabilities and quality improvements that enable organizations to deliver unforgettable experiences with increased ease and convenience. 
+Sitecore Experience Platform 10.3 delivers new capabilities and quality improvements that enable organizations to deliver unforgettable experiences with increased ease and convenience. 
 
 Whether self-hosted, implemented in Sitecore Managed Cloud, or used as Experience Manager (XM) through Sitecore Experience Manager Cloud (XM Cloud), the 10.3 release improves how organizations extend and integrate the Sitecore Experience Platform (SXP) with other applications in their marketing tech stack. New management and administration APIs and webhooks enable developers to take an API-first and industry-standard approach to customization, reducing the reliance on in-process custom code. This separation of concerns makes it easier for developers to upgrade to new versions of the Experience Platform in the future.
 
@@ -22,34 +22,9 @@ Other highlights include:
      
 -   Sitecore CLI 5.0: Added Linux support, new telemetry, and XM Cloud support.  
      
--   System updates: Upgraded Identity Server and Publishing Service to support .NET 6, added support for Solr 8.11.2, and support for Windows Server 2022 coming in January.
+-   System updates: Upgraded Identity Server and Publishing Service to support .NET 6, added support for Solr 8.11.2, and Windows Server 2022.
 
-  
-
-For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.3, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.3**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -112,6 +87,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.3**.
  | [Installation Guide for the XP Scaled topology](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/SC-XP-10.3.0-Install-Guide-XP-Scaled-Topology-en.pdf) | Explains how to install the fully featured Sitecore Experience Platform Installation (XP1) topology. This topology can be configured to run separated server roles. |
  | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/SC-XP-10.3.0-Quick_Install_Guide_Developer_Workstation-en.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes. |
  | [Upgrade Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/SC-XP-10.3.0-Upgrade%20Guide-en.pdf) | Explains how to directly upgrade from Sitecore XP 8.1.0 or later to Sitecore XP 10.3.0. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Sitecore.Platform.Assemblies%2010.3.0%20rev.%20008463.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -141,10 +117,10 @@ This page contains all the resources for **Sitecore Experience Platform 10.3**.
 
  | Resource | Description |
  | --- | --- |
- | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Translations/Sitecore%2010.3.0%20rev.%20008463%20(da-DK).zip) | Danish language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/103/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Translations/Sitecore%2010.3.0%20rev.%20008463%20(de-DE).zip) | German language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/103/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Translations/Sitecore%2010.3.0%20rev.%20008463%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/103/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Translations/Sitecore%2010.3.0%20rev.%20008463%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/103/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
+ | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Translations/Sitecore%2010.3.0%20rev.%20008463%20(da-DK).zip) | Danish language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Translations/Sitecore%2010.3.0%20rev.%20008463%20(de-DE).zip) | German language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Translations/Sitecore%2010.3.0%20rev.%20008463%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103/Secure/Translations/Sitecore%2010.3.0%20rev.%20008463%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
  | [Chinese GeoIP Localization Pack](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/90/Sitecore%20Experience%20Platform%2090%20Initial%20Release/Secure/GeoIp%20Location%20China%20Localization%20Pack%201.0.0%20rev.%20180226.zip) | The pack provides enhanced region detection for China. The pack should be installed as a regular Sitecore module. |
 
 ## Usage policies
@@ -153,3 +129,8 @@ This page contains all the resources for **Sitecore Experience Platform 10.3**.
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.3, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/index.md
@@ -4,52 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1.aspx
 ---
 
-Sitecore® Experience Platform 10.3 delivers new capabilities and quality improvements that enable organizations to deliver unforgettable experiences with increased ease and convenience. 
+Update-1 to Sitecore Experience Platform 10.3.
 
-Whether self-hosted, implemented in Sitecore Managed Cloud, or used as Experience Manager (XM) through Sitecore Experience Manager Cloud (XM Cloud), the 10.3 release improves how organizations extend and integrate the Sitecore Experience Platform (SXP) with other applications in their marketing tech stack. New management and administration APIs and webhooks enable developers to take an API-first and industry-standard approach to customization, reducing the reliance on in-process custom code. This separation of concerns makes it easier for developers to upgrade to new versions of the Experience Platform in the future.
-
-Additionally, the introduction of Headless SXA, Headless Services 21.0, and enhancements to developer tools with 10.3 makes it easier for organizations to use SXP as a headless CMS, and to build engaging experiences using modern front-end frameworks. 
-
-Other highlights include:
-
--   Headless SXA: Benefit from site scaffolding and templating, and new Next.js components, when building applications with XM as a headless CMS.  
-     
--   EXM enhancements: Added OAuth support for custom SMTP deployments.  
-     
--   Headless Services 21.0: Includes the new starter framework to accelerate the creation of new projects, and support for Next.js 12.3.x and React 18.  
-     
--   Management Services 5.0: Enhanced Experience Edge publishing, resolved default publishing target, added support for single-item publishing.  
-     
--   Sitecore CLI 5.0: Added Linux support, new telemetry, and XM Cloud support.  
-     
--   System updates: Upgraded Identity Server and Publishing Service to support .NET 6, added support for Solr 8.11.2, and support for Windows Server 2022 coming in January.
-
-  
-
-For developer documentation please refer to documentation website.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Please note that as part of your system upgrade to Sitecore Version 10.3, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore Experience Platform 9.1 or later does not support the `Active Directory` module.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Experience_Platform).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore has moved its public feed from sitecore.myget.org to a different feed provider. [Learn more](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1002999).
-  </Alert>
-    
-
-This page contains all the resources for **Sitecore Experience Platform 10.3 Update-1**.
+See [all available versions here](/downloads/Sitecore_Experience_Platform).
 
 ## Download options for Sitecore Container deployments
 
@@ -112,6 +69,7 @@ This page contains all the resources for **Sitecore Experience Platform 10.3 Upd
  | [Installation Guide for the XP Scaled topology](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/SC-XP-10.3.1-Installation-Guide-XP-Scaled-Topology-en.pdf) | Explains how to install the fully featured Sitecore Experience Platform Installation (XP1) topology. This topology can be configured to run separated server roles. |
  | [Quick Installation Guide for a Developer Workstation](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/SC-XP-10.3.1-Quick_Install_Guide_Developer_Workstation-en.pdf) | Explains how to install the XP Single (XP0) topology on a workstation for development and testing purposes. |
  | [Update Installation Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/SC-XP-10.3.1-Update_Installation_Guide-en_v2.pdf) | Explains how to update to the latest release in the Sitecore 10.3.X series. |
+ | [Developer Documentation](https://doc.sitecore.com/xp/en/developers) | Link to Sitecore developer documentation. |
  | [Assembly list](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Sitecore.Platform.Assemblies%2010.3.1%20rev.%20009452.zip) | Complete list of assemblies shipped with this release. |
 
 ## Modules
@@ -141,10 +99,10 @@ This page contains all the resources for **Sitecore Experience Platform 10.3 Upd
 
  | Resource | Description |
  | --- | --- |
- | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Translations/Sitecore%2010.3.1%20rev.%20009452%20(da-DK).zip) | Danish language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/103/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Translations/Sitecore%2010.3.1%20rev.%20009452%20(de-DE).zip) | German language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/103/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Translations/Sitecore%2010.3.1%20rev.%20009452%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/103/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
- | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Translations/Sitecore%2010.3.1%20rev.%20009452%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](https://doc.sitecore.com/xp/en/users/103/sitecore-experience-platform/add-a-new-language-to-system-settings.html) how to import a new language into the Sitecore installation. |
+ | [Danish (da-DK)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Translations/Sitecore%2010.3.1%20rev.%20009452%20(da-DK).zip) | Danish language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [German (de-DE)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Translations/Sitecore%2010.3.1%20rev.%20009452%20(de-DE).zip) | German language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Japanese (ja-JP)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Translations/Sitecore%2010.3.1%20rev.%20009452%20(ja-JP).zip) | Japanese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
+ | [Chinese (zh-CN)](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/103/Sitecore%20Experience%20Platform%20103%20Update1/Secure/Translations/Sitecore%2010.3.1%20rev.%20009452%20(zh-CN).zip) | Chinese language client translation file. Read [instructions](/downloads/Sitecore_Experience_Platform/Client_Translations_Manual) how to import a new language into the Sitecore installation. |
  | [Chinese GeoIP Localization Pack](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/90/Sitecore%20Experience%20Platform%2090%20Initial%20Release/Secure/GeoIp%20Location%20China%20Localization%20Pack%201.0.0%20rev.%20180226.zip) | The pack provides enhanced region detection for China. The pack should be installed as a regular Sitecore module. |
 
 ## Usage policies
@@ -153,3 +111,8 @@ This page contains all the resources for **Sitecore Experience Platform 10.3 Upd
  | --- | --- |
  | [Sitecore Device Detection Services usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_Device_Detection_Services_Usage_Policy) | This policy is applicable if you are using Sitecore Device Detection Service. |
  | [Sitecore IP Geolocation usage policy](/downloads/Sitecore_Experience_Platform/Sitecore_IP_Geolocation_Usage_Policy) | This policy is applicable if you are using Sitecore IP Geolocations Service. |
+ 
+  <Alert variant='warning' mb={4}>
+    <AlertIcon />
+    Please note that as part of your system upgrade to Sitecore Version 10.3, Sitecore may collect additional information such as product version, number of site visits, generic hardware and software information, and recovery actions. This information will be used to help us to optimize your experience. All data will be processed in accordance with Sitecore’s privacy policy [here](https://www.sitecore.com/trust/privacy-policy). Should you have any queries or wish to discuss this, [please refer to our FAQ](https://kb.sitecore.net/articles/424335), or contact your Sitecore Account Manager.
+  </Alert>

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/20x/Sitecore_Headless_Rendering_2000/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/20x/Sitecore_Headless_Rendering_2000/index.md
@@ -4,23 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Headless_Rendering/20x/Sitecore_Headless_Rendering_2000.aspx
 ---
 
-The Sitecore Headless Services module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Headless Rendering is compatible with Sitecore 10.2.
-  </Alert>
+The Sitecore Headless Rendering module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).\
+Sitecore Headless Rendering 20.0.0 is compatible with Sitecore Experience Platform 10.2.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Headless_Rendering).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Headless_Rendering).\
+For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/20x/Sitecore_Headless_Rendering_2002/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/20x/Sitecore_Headless_Rendering_2002/index.md
@@ -4,23 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Headless_Rendering/20x/Sitecore_Headless_Rendering_2002
 ---
 
-The Sitecore Headless Services module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Headless Rendering is compatible with Sitecore 10.2.
-  </Alert>
+The Sitecore Headless Rendering module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).\
+Sitecore Headless Rendering 20.0.2 is compatible with Sitecore Experience Platform 10.2.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Headless_Rendering).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Headless_Rendering).\
+For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/21x/Sitecore_Headless_Rendering_2100/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/21x/Sitecore_Headless_Rendering_2100/index.md
@@ -4,23 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Headless_Rendering/21x/Sitecore_Headless_Rendering_2100
 ---
 
-The Sitecore Headless Services module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Headless Rendering is compatible with Sitecore 10.3.
-  </Alert>
+The Sitecore Headless Rendering module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).\
+Sitecore Headless Rendering 21.0.0 is compatible with Sitecore Experience Platform 10.3.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Headless_Rendering).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Headless_Rendering).\
+For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/21x/Sitecore_Headless_Rendering_2101/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/21x/Sitecore_Headless_Rendering_2101/index.md
@@ -4,23 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Headless_Rendering/21x/Sitecore_Headless_Rendering_2101.aspx
 ---
 
-The Sitecore Headless Services module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Headless Rendering is compatible with Sitecore 10.3.
-  </Alert>
+The Sitecore Headless Rendering module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).\
+Sitecore Headless Rendering 21.0.1 is compatible with Sitecore Experience Platform 10.3.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Headless_Rendering).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Headless_Rendering).\
+For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/22x/Sitecore_Headless_Rendering_2200/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Headless_Rendering/22x/Sitecore_Headless_Rendering_2200/index.md
@@ -4,23 +4,11 @@ description: ""
 origin: 
 ---
 
-The Sitecore Headless Services module (formerly known as the Sitecore JavaScript Services Server module) provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Headless Rendering is compatible with Sitecore 10.4.
-  </Alert>
+The Sitecore Headless Rendering module provides the server-side APIs and components which are required for the ASP.NET Core Rendering SDK and JavaScript Rendering SDKs (JSS).\
+Sitecore Headless Rendering 22.0.0 is compatible with Sitecore Experience Platform 10.4.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Headless_Rendering).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Headless_Rendering).\
+For use of Sitecore JSS with versions of Sitecore prior to 10.1, see [Sitecore JavaScript Services downloads](/downloads/Sitecore_JavaScript_Services).
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1000/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1000/index.md
@@ -3,21 +3,11 @@ title: "Sitecore Horizon 10.0.0"
 description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Horizon/100/Sitecore_Horizon_1000
 ---
-
-Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform™.
-
-This release is focused on enhancing Horizon pages and content editing functionality and enabling integration with Sitecore DAM.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Horizon is compatible with Sitecore 10.0.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Horizon).
-  </Alert>
-  
+ 
+Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform.\
+Sitecore Horizon 10.0.0 is compatible with Sitecore Experience Platform 10.0.
+ 
+See [all available versions here](/downloads/Sitecore_Horizon).  
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1001/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1001/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Horizon/100/Sitecore_Horizon_1001
 ---
 
-Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform™.
-
-This release is focused on enhancing Horizon pages and content editing functionality and enabling integration with Sitecore DAM.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Horizon is compatible with Sitecore 10.0.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Horizon).
-  </Alert>
-  
+Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform.\
+Sitecore Horizon 10.0.1 is compatible with Sitecore Experience Platform 10.0.
+ 
+See [all available versions here](/downloads/Sitecore_Horizon).  
 
 ## Download options
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1010/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1010/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Horizon/100/Sitecore_Horizon_1010
 ---
 
-Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform™.
-
-This release is focused on enhancing Horizon pages and content editing functionality and enabling integration with Sitecore DAM.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Horizon is compatible with Sitecore 10.1.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Horizon).
-  </Alert>
-  
+Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform.\
+Sitecore Horizon 10.1.0 is compatible with Sitecore Experience Platform 10.1.
+ 
+See [all available versions here](/downloads/Sitecore_Horizon).  
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1011/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1011/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Horizon/100/Sitecore_Horizon_1011
 ---
 
-Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform™.
-
-This release is focused on enhancing Horizon pages and content editing functionality and enabling integration with Sitecore DAM.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Horizon is compatible with Sitecore XP 10.1.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Horizon).
-  </Alert>
-  
+Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform.\
+Sitecore Horizon 10.1.1 is compatible with Sitecore Experience Platform 10.1.
+ 
+See [all available versions here](/downloads/Sitecore_Horizon).  
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1020/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Horizon/100/Sitecore_Horizon_1020/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Horizon/100/Sitecore_Horizon_1020
 ---
 
-Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform™.
-
-This release is focused on enhancing Horizon pages and content editing functionality and enabling integration with Sitecore DAM.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Horizon is compatible with Sitecore XP 10.2.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Horizon).
-  </Alert>
-  
+Sitecore Horizon is the next generation Experience Management product for the Sitecore Experience Platform.\
+Sitecore Horizon 10.2.0 is compatible with Sitecore Experience Platform 10.2.
+ 
+See [all available versions here](/downloads/Sitecore_Horizon).  
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/5x/Sitecore_Identity_500/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/5x/Sitecore_Identity_500/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/5x/Sitecore_Identity_500
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For security reasons we strongly recommend using [Sitecore Identity 6.0](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).    
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/5x/Sitecore_Identity_501/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/5x/Sitecore_Identity_501/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/5x/Sitecore_Identity_501
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For security reasons we strongly recommend using [Sitecore Identity 6.0](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).    
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/5x/Sitecore_Identity_510/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/5x/Sitecore_Identity_510/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/5x/Sitecore_Identity_510
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For security reasons we strongly recommend using [Sitecore Identity 6.0](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).      
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/5x/Sitecore_Identity_511/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/5x/Sitecore_Identity_511/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/5x/Sitecore_Identity_511
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    For security reasons we strongly recommend using [Sitecore Identity 6.0](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).    
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/6x/Sitecore_Identity_600/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/6x/Sitecore_Identity_600/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/6x/Sitecore_Identity_600
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).  
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_70325/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_70325/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/7x/Sitecore_Identity_70325
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).  
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_70326/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_70326/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/7x/Sitecore_Identity_70326.aspx
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).  
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_70327/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_70327/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/7x/Sitecore_Identity_70327.aspx
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).  
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_70328/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_70328/index.md
@@ -4,20 +4,10 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Identity/7x/Sitecore_Identity_70328.aspx
 ---
 
-Sitecore Identity is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
+Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
-Sitecore Identity is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Identity).
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Identity was introduced with Sitecore Experience Platform 9.1 (Initial version). Any Sitecore releases prior to this do not support Sitecore Identity.
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Identity).  
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_7111/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Identity/7x/Sitecore_Identity_7111/index.md
@@ -3,7 +3,7 @@ title: "Sitecore Identity Server 7.1.11"
 description: ""
 ---
 
-Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.\
+Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform, Sitecore Experience Commerce and other Sitecore instances that require authentication.
 Sitecore Identity Server is compatible with Sitecore Membership user storage but may be be extended with other identity providers to integrate with customers AIM systems.
 
 See [all available versions here](/downloads/Sitecore_Identity).  

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/41/Sitecore_Publishing_Service_410/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/41/Sitecore_Publishing_Service_410/index.md
@@ -4,15 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service/41/Sitecore_Publishing_Service_410.aspx
 ---
 
-Sitecore Publishing Service is an opt-in module providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk.
+The Sitecore Publishing Service is an opt-in service providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk. It uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Publishing Service uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
-  </Alert>
-  
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
-Here you will find [all available versions](/downloads/Sitecore_Publishing_Service_Module) of Sitecore Publishing Service Modules.
+Integration of this service into Sitecore Experience Platform also requires the Sitecore Publishing Services Module. See [all available Module versions here](/downloads/Sitecore_Publishing_Service_Module).
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/42/Sitecore_Publishing_Service_420/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/42/Sitecore_Publishing_Service_420/index.md
@@ -4,15 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service/42/Sitecore_Publishing_Service_420.aspx
 ---
 
-Sitecore Publishing Service is an opt-in module providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk.
+The Sitecore Publishing Service is an opt-in service providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk. It uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Publishing Service uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
-  </Alert>
-  
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
-Here you will find [all available versions](/downloads/Sitecore_Publishing_Service_Module) of Sitecore Publishing Service Modules.
+Integration of this service into Sitecore Experience Platform also requires the Sitecore Publishing Services Module. See [all available Module versions here](/downloads/Sitecore_Publishing_Service_Module).
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/43/Sitecore_Publishing_Service_430/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/43/Sitecore_Publishing_Service_430/index.md
@@ -4,20 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service/43/Sitecore_Publishing_Service_430.aspx
 ---
 
-Sitecore Publishing Service is an opt-in module providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk.
+The Sitecore Publishing Service is an opt-in service providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk. It uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Publishing Service uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Publishing_Service).
-  </Alert>
-  
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
-Please go here to find [all available versions](/downloads/Sitecore_Publishing_Service_Module) of Sitecore Publishing Service Modules.
+Integration of this service into Sitecore Experience Platform also requires the Sitecore Publishing Services Module. See [all available Module versions here](/downloads/Sitecore_Publishing_Service_Module).
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/5x/Sitecore_Publishing_Service_500/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/5x/Sitecore_Publishing_Service_500/index.md
@@ -4,20 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service/5x/Sitecore_Publishing_Service_500.aspx
 ---
 
-Sitecore Publishing Service is an opt-in module providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk.
+The Sitecore Publishing Service is an opt-in service providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk. It uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.\
+This page contains Sitecore Publishing Service 5.0.0.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Publishing Service uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Publishing_Service).
-  </Alert>
-  
-
-Please go here to find [all available versions](/downloads/Sitecore_Publishing_Service_Module) of Sitecore Publishing Service Modules.
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).\
+Integration of this service into Sitecore Experience Platform also requires the Sitecore Publishing Services Module. See [all available Module versions here](/downloads/Sitecore_Publishing_Service_Module).
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/6x/Sitecore_Publishing_Service_600/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/6x/Sitecore_Publishing_Service_600/index.md
@@ -4,20 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service/6x/Sitecore_Publishing_Service_600.aspx
 ---
 
-Sitecore Publishing Service is an opt-in module providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk.
+The Sitecore Publishing Service is an opt-in service providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk. It uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.\
+This page contains Sitecore Publishing Service 6.0.0.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Publishing Service uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Publishing_Service).
-  </Alert>
-  
-
-Please go here to find [all available versions](/downloads/Sitecore_Publishing_Service_Module) of Sitecore Publishing Service Modules.
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).\
+Integration of this service into Sitecore Experience Platform also requires the Sitecore Publishing Services Module. See [all available Module versions here](/downloads/Sitecore_Publishing_Service_Module).
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/7x/Sitecore_Publishing_Service_7020/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service/7x/Sitecore_Publishing_Service_7020/index.md
@@ -4,20 +4,11 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service/7x/Sitecore_Publishing_Service_7020.aspx
 ---
 
-Sitecore Publishing Service is an opt-in module providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk.
+The Sitecore Publishing Service is an opt-in service providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk. It uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.\
+This page contains Sitecore Publishing Service 7.0.0.
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Note: Sitecore Publishing Service uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
-  </Alert>
-  
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Publishing_Service).
-  </Alert>
-  
-
-Please go here to find [all available versions](/downloads/Sitecore_Publishing_Service_Module) of Sitecore Publishing Service Modules.
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).\
+Integration of this service into Sitecore Experience Platform also requires the Sitecore Publishing Services Module. See [all available Module versions here](/downloads/Sitecore_Publishing_Service_Module).
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1000/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1000/index.md
@@ -4,20 +4,13 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1000
 ---
 
-The Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
-
-Here you will find [all available versions](/downloads/Sitecore_Publishing_Service) of Sitecore Publishing Services.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Publishing Service Module is compatible with Sitecore 10.0.
-  </Alert>
+The Sitecore Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
+ 
+Sitecore Publishing Service Module 10.0.0 is compatible with Sitecore Experience Platform 10.0.\
+Sitecore Publishing Service Module 10.0.0 is compatible with Sitecore Publishing Service 3.x.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Publishing_Service_Module).
-  </Alert>
-  
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/index.md
@@ -4,20 +4,13 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010
 ---
 
-The Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
-
-Here you will find [all available versions](/downloads/Sitecore_Publishing_Service) of Sitecore Publishing Services.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Publishing Service Module is compatible with Sitecore 10.1.
-  </Alert>
+The Sitecore Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
+ 
+Sitecore Publishing Service Module 10.1.0 is compatible with Sitecore Experience Platform 10.1.\
+Sitecore Publishing Service Module 10.1.0 is compatible with Sitecore Publishing Service 4.x.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Publishing_Service_Module).
-  </Alert>
-  
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/index.md
@@ -4,20 +4,13 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020
 ---
 
-The Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
-
-Here you will find [all available versions](/downloads/Sitecore_Publishing_Service) of Sitecore Publishing Services.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Publishing Service Module is compatible with Sitecore 10.2.
-  </Alert>
+The Sitecore Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
+ 
+Sitecore Publishing Service Module 10.2.0 is compatible with Sitecore Experience Platform 10.2.\
+Sitecore Publishing Service Module 10.2.0 is compatible with Sitecore Publishing Service 5.0.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Publishing_Service_Module).
-  </Alert>
-  
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/index.md
@@ -4,20 +4,13 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030
 ---
 
-The Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
+The Sitecore Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
 
-Here you will find [all available versions](/downloads/Sitecore_Publishing_Service) of Sitecore Publishing Services.
-
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of Sitecore Publishing Service Module is compatible with Sitecore 10.3.
-  </Alert>
+Sitecore Publishing Service Module 10.3.0 is compatible with Sitecore Experience Platform 10.3.\
+Sitecore Publishing Service Module 10.3.0 is compatible with Sitecore Publishing Service 6.0.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Publishing_Service_Module).
-  </Alert>
-  
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service). 
 
 ## Download options for Sitecore Container deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040/index.md
@@ -3,13 +3,13 @@ title: "Sitecore Publishing Service Module 10.4.0"
 description: ""
 ---
 
-The Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
+The Sitecore Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
  
 Sitecore Publishing Service Module 10.4.0 is compatible with Sitecore Experience Platform 10.4.\
 Sitecore Publishing Service Module 10.4.0 is compatible with Sitecore Publishing Service 7.0.
   
-See [all available Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
-See [all available Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
 ## Download for On Premises deployments
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Universal_Tracker/4x/Sitecore_Universal_Tracker_400/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Universal_Tracker/4x/Sitecore_Universal_Tracker_400/index.md
@@ -4,16 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Universal_Tracker/4x/Sitecore_Universal_Tracker_400.aspx
 ---
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of the Universal Tracker is compatible with Sitecore 10.0.
-  </Alert>
+Universal Tracker 4.0.0 is compatible with Sitecore Experience Platform 10.0.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Universal_Tracker).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Universal_Tracker).   
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Universal_Tracker/5x/Sitecore_Universal_Tracker_500/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Universal_Tracker/5x/Sitecore_Universal_Tracker_500/index.md
@@ -4,16 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Universal_Tracker/5x/Sitecore_Universal_Tracker_500.aspx
 ---
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of the Universal Tracker is compatible with Sitecore 10.1.
-  </Alert>
+Universal Tracker 5.0.0 is compatible with Sitecore Experience Platform 10.1.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Universal_Tracker).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Universal_Tracker).   
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Universal_Tracker/6x/Sitecore_Universal_Tracker_600/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Universal_Tracker/6x/Sitecore_Universal_Tracker_600/index.md
@@ -4,16 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Universal_Tracker/6x/Sitecore_Universal_Tracker_600.aspx
 ---
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of the Universal Tracker is compatible with Sitecore 10.2.
-  </Alert>
+Universal Tracker 6.0.0 is compatible with Sitecore Experience Platform 10.2.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Universal_Tracker).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Universal_Tracker). 
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Universal_Tracker/7x/Sitecore_Universal_Tracker_700/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Universal_Tracker/7x/Sitecore_Universal_Tracker_700/index.md
@@ -4,16 +4,9 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Universal_Tracker/7x/Sitecore_Universal_Tracker_700.aspx
 ---
 
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    This version of the Universal Tracker is compatible with Sitecore 10.3.
-  </Alert>
+Universal Tracker 7.0.0 is compatible with Sitecore Experience Platform 10.3.
   
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    Sitecore encourages customers to always install latest update of a given version to ensure latest fixes are included in their solution. See [all available versions here](/downloads/Sitecore_Universal_Tracker).
-  </Alert>
-  
+See [all available versions here](/downloads/Sitecore_Universal_Tracker).
 
 ## Downloads
 


### PR DESCRIPTION
## Description / Motivation
- Changed links in SXP pages to translation instructions. Newer instructions apply for all 10.1 and later releases.
- Updated SXP 10.x pages' formatting to align with 10.4.
- Updated all modules (10.x equivalent) pages' formatting to align with latest.
Deferred to a future PR: Tools and Connectors pages.

## How Has This Been Tested?
- Tested on localhost:3000

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
