### PR TITLE
Removing all content from XMC Recommended Practices and replacing with links to relevant Accelerate recipes

### DIFF
--- a/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/deployment.md
+++ b/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/deployment.md
@@ -5,43 +5,16 @@ hasInPageNav: true
 cdpTags: ['xm-cloud']
 ---
 
-<Alert status="info">
+<Alert status="warning">
   <AlertIcon />
-    The information in this article can be outdated. For the latest guidance on XM Cloud implementations visit the <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a> page
+    The current recommendations for XM Cloud have been moved to <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a>. 
 </Alert>
 
-What do developers need to keep in mind when **deploying their code** or **publishing sites**?
-
-## Tips
-
-Publishing to Edge can be an expensive operation, a good amount of the time is spent making the connection to Edge though. For this reason you should preference publishing larger batches on items, instead of lots of smaller item publishes as it will perform better.
-
-There can also be a short delay between the Publishing Dialog indicating that the publish has completed, and the content changes being returned from Edge as its caches are cleared. When this is combined with ISR timeouts when running in NextJs, this can lead to a delay before content changes are displayed on your end site.
-
-## Customization
-
-> ✅ DO utilize the XM Cloud deploy app rather than using your own CI/CD tool
-
-It’s better to use the OOTB GitOps functionality provided by XM Cloud where possible as it will save you development time setting up your own pipelines. Alongside that, as the GitOps functionality is improved, you’ll automatically get any new updates that are created.
-
-However, there are some scenarios where it might be preferable to roll your own CI/CD pipelines. Here you can utilize the CLI performing all of the interactions with your XM Cloud instance.Some examples of this are:
-
-- If you’re not using GitHub as your Source Control Provider, other providers aren’t currently supported, so you must use your own CI/CD in that instance.
-
-- If you have already made an investment in CI/CD setups for other parts of your system and want to leverage the same technologies, keeping all your deployment pipelines in one place.
-
-- If you have complexity in the types of sites you’re deploying, maybe you have a large number of sites run out of a single XM Cloud instance (multi-site setup), or you’re deploying to multiple cloud hosting providers for your different heads (multi-cloud setup).
-
-- If you have a large number of Non-Production & Production environments and you want to automate the flow of changes between these environments.
-
-You can find an example of a custom CI/CD configuration using the XM Cloud CLI here: [XM Cloud Introduction Repository](https://github.com/Sitecore/XM-Cloud-Introduction)
-
-## Git Workflow
-
-- Using git flow model is the old, obsolete way. In this old model, release branches are used. The build that happens on the dev branch and the build that happens on the release branch are different. Since the builds are not identical, it’s possible to see issues from a prod deployment that weren’t present in a dev build (which is where QA happened)
-
-- The recommended approach is to use continuous deployments, which means that every commit is instantly deployed out to the first environment, and every build, every commit I make, or every pull request I do has integration tests and things run against it.
-
-- With the ‘deploy once’ model, you can promote any single build to different environments via the XM Cloud deploy app.
-
-- Differences in configs across environment should be handled with environment variables (or like SXA handles it - configuration through Sitecore items)
+<Row columns={3}>
+  <Link title="Branching Strategy" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy" />
+  <Link title="DevOps" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/devops" />
+  <Link title="Setup Content Serialization" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/setup-content-serialization" />
+  <Link title="Development Workflow: GitHub Codespaces" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/dev-workflow-codespaces" />
+  <Link title="Running Next.js on Azure App Services" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/nextjs-azure-app-services" />
+  <Link title="Go-Live Checklist" link="/learn/accelerate/xm-cloud/final-steps/go-live-checklist" />
+</Row>

--- a/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/development.md
+++ b/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/development.md
@@ -6,121 +6,17 @@ cdpPersonaDefinition: { PagePattern: [{ 'ProfileKey': 'FrontendSkills', 'value':
 cdpTags: ['xm-cloud']
 ---
 
-
-<Alert status="info">
+<Alert status="warning">
   <AlertIcon />
-    The information in this article can be outdated. For the latest guidance on XM Cloud implementations visit the <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a> page
+    The current recommendations for XM Cloud have been moved to <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a>. 
 </Alert>
 
-## Dev Workflow
-
-[XM Cloud FAQ](https://developers.sitecore.com/learn/faq/xm-cloud/development) - Edge mode vs Fully local mode
-
-> ✅ DO utilize “Edge Mode” if you’re a front-end dev.
-
-> ✅ DO utilize “Fully Local Mode” if you’re a back-end dev.
-
-Recommended workflow:
-![Development Modes with XM Cloud](/images/learn/project-workflow.jpeg)
-
-1. **Analyze designs to identify page types and components**
-
-The Business Analyst or Product Owner analyze the website designs/wireframes and flush out authoring requirements. This information is discussed with the Sitecore architect or dev lead to identify the list of page types needed for the website and the list of components needed on each page type.
-
-This step gets the business side and the technical side of the project into alignment. Content Authors get to see the types of pages they will be able to create, the components they will be able to add to pages, and the fields that will be editable in those components. This information needs to be explicitly communicated with both, back-end and front-end devs. For front-end devs, going through this process promotes “component driven design”, which encourages separation of concerns and improves the maintainability and scalability of the codebase.
-
-2. **Back-end devs work from local containers**
-
-The Sitecore architect or back-end dev kicks off implementation by building out the information architecture in Sitecore. This work is done in a local Docker container, then serialized into source control.
-
-> ✅ DO use local Docker containers for **back-end Sitecore development**
-
-Trying to use an on-prem version of Sitecore XM for local development in order to avoid learning containers is not a good idea. The on-prem version is different from the cloud version, so whatever behavior you would see on your local machine could change once your code is deployed to the cloud version.
-
-> ✅ DO use local Docker containers for Sitecore **item serialization**
-
-Using a local container is best when serializing Sitecore items (ie when you want to save whatever has been done in Sitecore to source control). Trying to serialize against a cloud instance can lead to trouble because it’s a shared environment, so people can override each other’s work.
-
-There is an official template available to facilitate the original creation of the codebase - [GitHub - sitecorelabs/xmcloud-foundation-head](https://github.com/sitecorelabs/xmcloud-foundation-head). Using this template is recommended since it provides multisite capabilities, it comes with helpful scripts for managing local containers, and it is maintained and updated by Sitecore.
-
-3. **Initialize cloud instance and begin front-end work**
-
-Once the Sitecore templates have been serialized and added to source control, they can be deployed to the XM Cloud instance.
-
-> ✅ DO use the remote XM Cloud Sitecore instance for front-end development
-
-This enables front-end devs to begin work without having to set up any local Sitecore containers of their own - they can work against one of the cloud endpoints, ideally the CM GraphQL endpoint. The docker learning curve and setup can be heavy, so it’s not worth it if you’re only doing frontend work. Additionally, by using the real cloud endpoint (instead of a local endpoint tied to a local database), front-end devs are guaranteed to be hydrating their components with the same content data that will be used in the final product. So the “it works fine on my machine, but it looks weird in production” scenario can be avoided.
-
-Front-end devs still develop and run the front-end (JavaScript) part of the project on their local machines (on a Node server running locally - this is called the “rendering host”). As they build out components, if any changes are needed to the data incoming from the API, they communicate these needs to the back-end devs. So, back-end devs jump in occasionally to tweak the information architecture and front-end devs still don’t need to bother with local Sitecore containers. This is the favorite approach, according to all the teams we interview.
-
-Front-end devs like this workflow because they don’t have to learn containers, and Sitecore onboarding is minimal.
-
-4. **Components are built & tested locally, but authoring is tested in the cloud**
-
-Since front-end devs do not run Sitecore locally, they cannot test the authoring interface locally. This testing must be done in the cloud instance.
-
-Front-end devs work on components locally (using the cloud endpoint as a Headless CMS) and continuously deploy their changes to the cloud instance, where they regularly verify that their component work and look as expected in the authoring interface. The authoring interface is expected to behave in “desktop” mode, so this is also a good time to plan for responsive layout and consider extra fields that may need to be added to components to allow authors to edit all the different versions on a component.
-
-### Further reading
-
-[Headless Frontend Development with XM Cloud](https://thetombomb.com/posts/frontend-development-xm-cloud) - This article explains what XM Cloud is and provides two common workflows for frontend developers, one simple and one more advanced.
-
-## Code references
-
-In addition to the official starter template, there are a couple of other public repos available to use as a development reference.
-
-**Official starter foundation**
-
-[GitHub - sitecorelabs/xmcloud-foundation-head](https://github.com/sitecorelabs/xmcloud-foundation-head)
-
-- Best for new projects
-- Utilizes headless SXA
-- Has all SXA features (site management)
-- Maintained by dev team and will get all new features as they are released
-
-**MVP/SUGCON Sites**
-
-[GitHub - Sitecore/XM-Cloud-Introduction](https://github.com/Sitecore/XM-Cloud-Introduction)
-
-- Good reference for migration use case
-- Shows different rendering hosts (JS & .NET Core) coexisting
-- Custom build/deploy pipeline
-- Multisite
-
-**XM Cloud Play Summit**
-
-[GitHub - sitecorelabs/Sitecore.Demo.XmCloud.PlaySummit](https://github.com/sitecorelabs/Sitecore.Demo.XmCloud.PlaySummit)
-
-- Good reference for migration use case
-- Good for demos/trial
-- Multilingual
-- Examples of custom components & advanced use cases
-
-## Working with a shared cloud instance
-
-> ✅ DO add new items like components and templates to the cloud instance through code deployments rather than adding them directly in the interface.
-
-As devs work locally, they may be tempted to save time by testing out quick changes to the information architecture directly in the cloud instance, rather than going through the full process of committing the changes to source control and deploying them. This is risky since the cloud instance is a shared environment so any work done directly in the cloud instance (without going through source control) could interfere with other people’s work. For example, if you add a component that somebody else doesn't have the source to, that person will see errors on all pages that have this component.
-
-> ✅ DO use local containers for managing serialization
-
-It’s best to treat the shared environment as “read only” when it comes to data modeling and not do serialization off of an XM Cloud instance. Serialization in a shared environment can be a source of errors as devs risk wiping out each other’s work. Serialization in a local container environment is safe because the databases used in local containers are not shared.
-
-## Containers
-
-Based on our discussions with dev teams in the field, the most common source of local development challenges comes from working with Docker containers. Here is the advice and lessons learned that devs shared:
-
-> ✅ DO utilize the powershell scripts provided in the official project template to manage your container
-
-These scripts address common issues and handle error catching.
-
-- Use [up.ps1](https://github.com/sitecorelabs/xmcloud-foundation-head/blob/main/up.ps1) to start your container
-- Use [down.ps1](https://github.com/sitecorelabs/xmcloud-foundation-head/blob/main/down.ps1) to stop your container
-
-Most of the time, the up script and down script are all you need. These scripts manage your container without touching your local databases (ie they won’t change items in Sitecore). However, sometimes it is useful to reset your databases to whatever is serialized in source control (if you are getting unexpected errors or if you are switching between branches). This can be achieved with the clean.ps1 script.
-
-Tips for working with containers:
-
-- The up script pulls the latest versions of the base images. Pulling latest images is recommended. But if you need to hold off from pulling the latest version (as an exceptional case), you can pin your base image to a specific version in the docker-compose file.
-
-- If you’re seeing an error in XM Cloud that you cannot reproduce locally, you can use the CLI to inspect logs from the cloud environment (including logs from the editing rendering host). `dotnet sitecore cloud environment log list` and it will give you a list of all logs on your environment.
+<Row columns={3}>
+  <Link title="Project Solution Setup" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/project-solution-setup" />
+  <Link title="Branching Strategy" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy" />
+  <Link title="Development Workflow: GitHub Codespaces" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/dev-workflow-codespaces" />
+  <Link title="Setup Content Serialization" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/setup-content-serialization" />
+  <Link title="Head Application Security" link="/learn/accelerate/xm-cloud/pre-development/security/head-application-security" />
+  <Link title="Wildcard Pages" link="/learn/accelerate/xm-cloud/implementation/information-architecture/wildcard-pages" />
+  <Link title="Working with Experience Edge Rate Limits and Caching" link="/learn/accelerate/xm-cloud/pre-development/project-architecture/rate-limits-and-caching" />
+</Row>

--- a/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/getting-started.md
+++ b/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/getting-started.md
@@ -5,79 +5,20 @@ hasInPageNav: true
 cdpTags: ['xm-cloud']
 ---
 
-<Alert status="info">
+<Alert status="warning">
   <AlertIcon />
-    The information in this article can be outdated. For the latest guidance on XM Cloud implementations visit the <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a> page
+    The current recommendations for XM Cloud have been moved to <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a>. 
 </Alert>
 
-What do devs need to know **before they get started** on a Sitecore XM Cloud project?
-
-## Onboarding
-
-> ✅ DO focus on “**just the essentials**” during dev onboarding.
-
-Learn just a small subset of Sitecore technologies; don’t try to learn everything.
-
-Front-end devs who are new to Sitecore are saying that the quantity of Sitecore-specific terminology and product names (XM Cloud, Edge, JSS, SXA) can feel overwhelming. This is normal.
-
-First, it helps to recognize that all of these terms aren’t necessarily describing big new concepts that will require a lot of training in; in most cases they are simply Sitecore “codenames” for concepts that are common to the industry. For example, “Sitecore Edge” is a GraphQL endpoint, “JSS” (JavaScript SDK) is JavaScript middleware packages, and “SXA” (Sitecore Experience Accelerator) is a set of features that enables Content Authors to manage multisite environments through the UI rather than through code. These concepts are not unique to Sitecore, and as you get familiar with the language of Sitecore, you will realize that you already know it better than you thought.
-
-And second, it helps to start with just the essentials - **don’t try to learn everything all at once**. The Sitecore stack has evolved into what it is today over the course of 20 years; a lot of different technologies and expertise have gone into making Sitecore as feature rich as it is. This makes the Sitecore platform both, powerful and complex. [If you’re a front-end dev, start by focusing in on just Edge](https://youtu.be/Kig3kWZ8FuQ) (the GraphQL endpoint that serves data needed to render the page) and JSS (the JavaScript library that provides middleware for interfacing with this endpoint and transforming incoming JSON data into objects that are usable by React components). [If you’re a back-end dev, you’ll also need to learn about running Sitecore in Docker containers.](https://youtu.be/sVLM1g3Xi-U)
-
-**Recommended learning path for devs new to XM Cloud**: [XM Cloud Introduction](https://developers.sitecore.com/learn/getting-started/xm-cloud-introduction)
-
-## Content Management System (CMS) concepts
-
-> ✅ DO **master key Content Authoring concepts before starting work** in a Sitecore XM Cloud project
-
-Many devs coming to the Sitecore world are used to building components for webpages. But Sitecore is a CMS for marketers, so in Sitecore you are not building for webpages directly; you are building for the authoring interface, and this requires extra considerations.
-
-[Content authoring concepts for developers new to Sitecore](https://doc.sitecore.com/xmc/en/developers/xm-cloud/content-authoring-concepts-for-developers-new-to-sitecore.html) - It is critical to understand these key concepts before designing or building front-end components for a Sitecore XM Cloud backend.
-
-> ✅ DO acquire access to your XM Cloud instance and **try out the authoring workflow yourself** before building components.
-
-Don’t ignore the authoring interface and don’t hardcode the layout of the components. Many front-end devs are used to working with static websites, meaning that once the layout requirements are defined in the design, these requirements remain static. (For example, the number of columns). Even front-end devs who have experience working with other headless CMSs may be expecting that only the text or images change - the fact that Content Authors can edit the layout of the page and change how components are ordered or nested is a very significant and differentiating concept. Taking the time to learn the full extent of editing power that Content Authors have over pages (by trying it themselves) is the single best thing front-end devs can do to set themselves up for working on a Sitecore project.
-
-> ✅ DO regularly **test components and functionality in the authoring interface** during development.
-
-> ✅ DO keep Content Authors in control of page layout by **avoiding hardcoding layout** in code.
-
-Teams who are not used to building for a CMS and who did not take the time to master these concepts struggled when it was time to hand the system over to Content Authors because they ignored the authoring interface during development and pushed off the task of testing their components in the authoring interface to the end of the project. Remember that **it doesn’t matter how great your components are if Content Authors can’t add them to pages** - all components must work in the authoring interface, so they must be tested in the authoring interface. If front-end devs are following our recommended workflow of building against an XM Cloud endpoint instead of running local Sitecore containers, then they must plan for a little extra testing time since they will not be able to test all authoring interfaces (e.g. Pages) locally.
-
-## Sitecore’s JavaScript SDK (JSS)
-
-> ✅ DO **use functions provided by JSS** to fetch data from Sitecore’s GraphQL API rather than using the API directly.
-
-JSS is middleware for JavaScript components interfacing with the Sitecore API. Using JSS is not mandatory and it’s possible to work against the API directly, so front-end devs who are new to Sitecore wonder whether using JSS is worth it. Learning JSS takes time, and following the project structure that JSS dictates requires developers to give up control and work in a new way. However, even with this overhead in mind, it is still best to use JSS, as it provides many benefits and will save teams time in the long term. Building directly against the Sitecore API is not recommended, and teams who attempted to do this struggled.
-
-JSS helpers abstract away the specifics of the API. This means that you won’t have to change your components as much if you change Sitecore or JSS versions. When your front-end and back-end communicate through an interface, they are abstracted from each other’s changes.
-
-Additionally, using JSS helpers ensures that all content displayed in components is editable by Content Authors in the WYSIWYG authoring interface.
-
-> ❌ DON’T define the nesting structure of components through code. Instead, use the Placeholder component provided by JSS.
-
-> ❌ DON’T hardcode any text or images into components. Instead, use the Field components provided by JSS.
-
-## Sitecore’s Headless Experience Accelerator (Headless SXA)
-
-> ✅ DO **use features provided by Headless SXA** to deliver best authoring experiences but also save time on common reoccuring features.
-
-SXA used to be an add-on to Sitecore and is now part of XM Cloud. It provides multisite and multitenancy features, improved page layouting concepts using page designs, partial designs and page branches and the capability to build components easily and in a flexible way utilizing rendering variants (UI variations of components) and rendering parameters (configurable UI variations). Additionally it provides a list of features that can be easily utilized such as sitemaps, robots.txt. Following the XM Cloud starter template headless SXA out of the box components provide great implementation examples. SXA reduces the amount of code a lot makes configuration much more accessible.
-
-> ✅ Define Page- and Partial Designs using Headless SXA Components over creating static coded layouts.
-
-> ✅ DO use Headless SXA together with JSS to utilize the benefits of both worlds.
-
-**Recommended learning path for devs new to SXA**: [SXA Best Practices Guide](https://doc.sitecore.com/xmc/en/developers/xm-cloud/best-practices.html)
-
-## Other 3rd Party Tools & Integrations
-
-### GitHub
-
-> ✅ DO **chose GitHub** for your source control needs to take advantage of the built-in integrations with XM Cloud.
-
-Teams who use other source control tools say it’s not worth the effort.
-
-### Content search
-
-**Content search is not available on Edge**. Very complex search methodologies need to be reconsidered in a headless world / XM Cloud world.
+<Row columns={3}>
+  <Link title="Preparing for an XM Cloud Project" link="/learn/accelerate/xm-cloud/pre-development/project-planning/preparing-for-an-xm-cloud-project" />
+  <Link title="Project Solution Setup" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/project-solution-setup" />
+  <Link title="Branching Strategy" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy" />
+  <Link title="Development Workflow: GitHub Codespaces" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/dev-workflow-codespaces" />
+  <Link title="DevOps" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/devops" />
+  <Link title="Setup Content Serialization" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/setup-content-serialization" />
+  <Link title="Creating a Site" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/creating-a-site" />
+  <Link title="Component Design Best Practices" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/component-design-best-practices" />
+  <Link title="Creating New Components" link="/learn/accelerate/xm-cloud/implementation/developer-experience/creating-new-components" />
+  <Link title="Working with Experience Edge Rate Limits and Caching" link="/learn/accelerate/xm-cloud/pre-development/project-architecture/rate-limits-and-caching" />
+</Row>

--- a/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/index.md
+++ b/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/index.md
@@ -6,18 +6,7 @@ hasInPageNav: true
 cdpTags: ['xm-cloud']
 ---
 
-<Alert status="info">
+<Alert status="warning">
   <AlertIcon />
-    Please note that these best practices pre-date <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a> content which will replace these practices soon
+    The current recommendations for XM Cloud have been moved to <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a>. Any content remaining in this section is pending being moved over to Accelerate but will be removed once it has been ported to the new location.
 </Alert>
-
-
-# Who will this topic be interesting to?
-
-## Guides for business stakeholders
-
-Recommended practices for business stakeholders who are ramping up dev teams for Sitecore XM Cloud work.
-
-## Guides for developers
-
-Recommended practices for developers building sites powered by Sitecore XM Cloud.

--- a/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/preparing-for-project.md
+++ b/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/preparing-for-project.md
@@ -5,49 +5,12 @@ hasInPageNav: true
 cdpTags: ['xm-cloud']
 ---
 
-<Alert status="info">
+<Alert status="warning">
   <AlertIcon />
-    The information in this article can be outdated. For the latest guidance on XM Cloud implementations visit the <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a> page
+    The current recommendations for XM Cloud have been moved to <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a>.
 </Alert>
 
-> ## For Business Stakeholders
->
-> Recommended practices for business stakeholders who are ramping up dev teams for Sitecore XM Cloud work.
-
-### Team Structure
-
-> ✅ DO staff your dev teams with more front-end devs than back-end/Sitecore devs
-
-You’re probably unlikely to customize the CM much. Projects are seeing much less .NET code than past XM projects. This means that teams can consist mostly of front-end developers.
-
-### Project Workflow
-
-Conducting a planning phase where requirements are flushed out and documented is the best way to set up the dev team for success.
-
-Based on feedback from teams in the field, here is the approach that teams like:
-
-![Development Modes with XM Cloud](/images/learn/project-workflow.jpeg)
-
-1. Analyze designs and gather authoring requirements
-
-Before any development begins, the Business Analyst or Product Owner needs to analyze the website designs/wireframes and discuss authoring requirements with the people who are going to use the system to populate and maintain the website. Knowing **how often website content/assets need to be updated** and knowing **how much flexibility the authors need** over page layout and component structure is important information that needs to be communicated to the dev lead.
-
-2. Identify page types and components
-
-The Business Analyst or Product Owner needs to work together with the dev lead to identify the list of page types needed for the website and the list of components needed on each page type.
-
-Some tips that teams find helpful:
-
-- It helps to draw boxes around components and label them directly in the designs.
-
-- Include notes about any content that needs to be accounted for that is not included in the designs (for example, seasonal promos or extra fields for optional content).
-
-- Include notes about webpage behavior that may not be obvious in the designs (for example, do some components look or function differently on mobile? or if the user is logged in?)
-
-- It helps to come up with titles for all components at this stage. This makes it clear how many components there are total, and encourages teams to look for patterns and opportunities to reuse components across different pages. More components = more work for devs to build them and more work for Content Authors to learn them.
-
-This step gets the business side and the technical side of the project into alignment. Content Authors get to see the types of pages they will be able to create, the components they will be able to add to pages, and the fields that will be editable in those components.
-
-3. Implementation phase
-
-After the requirements are handed off to the dev team, the business stakeholder should jump in at regular intervals to review demos and provide feedback to the dev team.
+<Row columns={2}>
+  <Link title="Preparing for an XM Cloud Project" link="/learn/accelerate/xm-cloud/pre-development/project-planning/preparing-for-an-xm-cloud-project" />
+  <Link title="Project Estimation" link="/learn/accelerate/xm-cloud/pre-development/project-planning/project-estimation" />
+</Row>

--- a/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/project-structure.md
+++ b/apps/devportal/data/markdown/pages/learn/faq/xm-cloud-recommended-practices/project-structure.md
@@ -5,97 +5,16 @@ hasInPageNav: true
 cdpTags: ['xm-cloud']
 ---
 
-<Alert status="info">
+<Alert status="warning">
   <AlertIcon />
-    The information in this article can be outdated. For the latest guidance on XM Cloud implementations visit the <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a> page
+    The current recommendations for XM Cloud have been moved to <a href="/learn/accelerate/xm-cloud">Sitecore Accelerate for XM Cloud</a>.
 </Alert>
 
-Separate repos for frontend & backend? Separate repos for each head? Based on feedback from teams in the field, monorepos are good idea because
-
-- no need to worry about version compatibility, so it’s easier to scale over time.
-
-- monorepos more accurately represent the nature of an XM Cloud environment (Sitecore is not multi-tenant as far as the code base is concerned. There is no code or application isolation unless you have multiple instances.)
-
-Tips from devs:
-
-> Any time I have seen a project where they try to have multiple teams working in separate projects and all deploying to the same Sitecore instance, it goes horribly wrong. They should stick to a single code base and single deploy. Deploy often, use feature toggles to prevent code going live before it should and don't try to work in isolation.
-
-> If your solution requires multiple “heads” (front-ends) and the different heads are being worked on my different teams, you may want separate repos so that each team can work independently. With separate repos, each head could be deployed independently. While this would make the dev workflow for the teams easier, keep in mind that the Sitecore instance is still single tenant. So whenever each team deploys, their code has the potential to effect the other heads. This could be mitigated through QA processes.
-
-## Monorepo considerations
-
-A Sitecore XM Cloud solution is likely to consist of multiple projects (codebases) and dev teams wonder whether choosing a particular source control strategy (monorepo or broken up across multiple repositories) is important to the success of their team. Based on feedback from dev teams in the field, there is no single best approach for all cases. There are tradeoffs to both sides, and whether or not a particular XM Cloud solution should use a monorepo really varies from team to team. XM Cloud works the same for both approaches, and ultimately the answer to this question comes down to personal preference rather than technical requirement.
-
-### Managing dependencies
-
-In most cases, there is no special benefit to using a monorepo. The main case where monorepos shine is when there are multiple dependencies across projects (for example, if there is a project for shared components that is imported by more than one of the other projects).
-
-### Dev workflow
-
-Organizing projects into a monorepo does not limit how devs work - each dev is still free to use the tools that he or she is most comfortable with on their local machine.
-
-### Team structure
-
-The structure of the dev team needs to be considered. Unless the frontend and backend devs are part of a single, unified team (ie they work for the same company and all use the same communication processes, they all talk daily for updates, they are all involved in the same planning & scoping meetings), separate repos would likely be the more beneficial approach because it would provide the 2 sides with autonomy.
-
-Frontend devs prefer to work “disconnected” from Sitecore. A repo structure that does not force them to setup & manage containers is best.
-
-### CI/CD
-
-When projects are divided up into separate codebases, they can have separate publishing/deployment processes and schedules. This could be helpful if different teams are working on different projects, and they need independent processes.
-
-On the other hand, if one team is maintaining all of the projects, then the overhead of setting up multiple different CI/CD pipelines might not provide much value. We’ve also seen teams run into trouble with separate deployment processes when separate front-end projects were deploying to the same Sitecore cloud instance
-
-### Debugging
-
-Debugging across projects in easier in a monorepo. Similarly, testing bug fixes is easier when the entire dependency tree in container in the same codebase.
-
-### Serialization
-
-You need to consider that components need to be serialized. So if there are 2 projects, where will the serialized items go?
-
-### Migration vs “green field” project
-
-Customers migrating to XM Cloud from older versions (ex. .NET MVC solutions) could utilize a multirepo approach to do the migration gradually, over time (thereby avoiding having to do the entire migration work up front before being able to start using XM Cloud). In this approach, a new repo is created for front-end next.js work, and renderings are refactored to the new approach one by one. Since Sitecore supports having multiple rendering hosts, the new solution can process refactored renderings while the legacy solution can continue to be used for anything that has not been refactored yet.
-
-Dev Gotchya - doing a project from the starter template vs migrating to XM Cloud from a non-Cloud project (ie a JSS project that was created before XM Cloud existed). The older JSS project will be missing the multi-site features & configuration that was added with XM Cloud
-
-### Multisite projects
-
-Questions to consider: Do you wanna share content? Share templates? Share components?
-
-You need to consider that components need to be serialized. So if there are 2 projects, where will the serialized items go? That needs to be considered.
-
-Separate repos = heads can evolve separately from each other.
-
-### Further reading
-
-[Monorepos – Vercel](https://vercel.com/blog/monorepos) - Vercel likes monorepos
-
-[A 2021 guide about structuring your Next.js project in a flexible and efficient way](https://dev.to/vadorequest/a-2021-guide-about-structuring-your-next-js-project-in-a-flexible-and-efficient-way-472)
-
-## Helix
-
-“Helix” is a set of project structure and dependency management principles that was very helpful when Sitecore implementations were done entirely in back-end code. Helix is less useful in front-end projects built with JavaScript frameworks.
-
-> ❌ Don't try and force Helix into your front-end JavaScript application.
-
-If you know Helix and you love it and you wanna use it, that's fine. But if you don't know it, learning it is not critical for new XM Cloud projects. Front-end projects are better off following the project structure best practices published by the front-end framework authors.
-
-If your front-end project uses .NET Core, then Helix is still very useful (since most development is done in Visual Studio).
-
-## Component design
-
-> ✅ DO make sure that the appearance and functionality of components **does not depend on components being nested/structured any particular way**.
-
-Components need to be built in a way that keeps them independent, modular, and interchangeable, so that Content Authors remain free to move components around on a page however they want.
-
-> ✅ DO **align on component naming conventions** that parallel how components are structured in Sitecore
-
-If you know where a component is in Sitecore, it should be easy to find the source for that component in the code. For example, if in Sitecore there is a “Products” folder that houses component specific to the Product Details Page, then it would be helpful to use the same convention in code. The specific naming convention doesn't matter - having a naming convention and keeping it consistent is the critical piece.
-
-Having the JavaScript components match the Sitecore components makes it easier to onboard new devs to the project - they learn their way around the codebase faster. However, sometimes it makes sense to get more granular in the code in order to avoid code duplication.
-
-For example, there could be a “Promo” component and a “Modal” component in Sitecore, and both of these could have buttons. The front-end dev may wish to encapsulate the Button into it’s own component, even if that’s too granular for the authoring interface. This is possible - JavaScript components don’t have to map 1:1 to Content Author components. Front-end devs can make components as granular as they wish in the code, as long as the list of components that’s exported to the Component Factory matches what the Content Author expects to see.
-
-> ✅ Create as many JavaScript components in code as you wish, but only export the components that are intended to be used by Content Authors.
+<Row columns={3}>
+  <Link title="Preparing for an XM Cloud Project" link="/learn/accelerate/xm-cloud/pre-development/project-planning/preparing-for-an-xm-cloud-project" />
+  <Link title="Branching Strategy" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/branching-strategy" />
+  <Link title="Development Workflow: GitHub Codespaces" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/dev-workflow-codespaces" />
+  <Link title="Multisite Architecture" link="/learn/accelerate/xm-cloud/pre-development/project-architecture/multisite" />
+  <Link title="Setup Content Serialization" link="/learn/accelerate/xm-cloud/pre-development/sprint-zero/setup-content-serialization" />
+  <Link title="Component Design Best Practices" link="/learn/accelerate/xm-cloud/pre-development/developer-experience/component-design-best-practices" />
+</Row>


### PR DESCRIPTION
## Description / Motivation
The old recommended practices should not be available as they are causing confusion. As an intermediate step towards replacing with redirects, I have replaced all of the content on the pages with lists of links that are related to the type of content that was on the page previously.

This should also reduce the amount of traffic that reaches these pages via Search.

Fixes #754 

## How Has This Been Tested?
Tested locally.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
