### PR TITLE
Update "Press" to "Click" for button instructions

### DIFF
--- a/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/datasources.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/datasources.md
@@ -117,15 +117,15 @@ These steps will create the Text Teaser template.
    Leave the Base template with the default value ([Standard template](https://doc.sitecore.com/xmc/en/developers/xm-cloud/the-standard-template.html)) for now. If you were creating a series of templates that inherited fields from each other, you might need to specify a base template to inherit from. The default Standard template will provide all the required fields your Text Teaser template will need so it is enough for the purpose of this tutorial.
    </Alert>
 
-1. Press the **Next** button to advance to the Location selection step.
-1. Press the **Next** button to keep the default selection for the location folder.
+1. Click the **Next** button to advance to the Location selection step.
+1. Click the **Next** button to keep the default selection for the location folder.
 
    <Alert status="info">
    <AlertIcon />
    The currently selected folder is set by default when this step shows. If the Basic Components folder wasn't already selected in the tree, you could choose it during this step instead.
    </Alert>
 
-1. Press the **Close** button to exit the wizard. The template has been created.
+1. Click the **Close** button to exit the wizard. The template has been created.
 
 ### Create the fields for the Text Teaser
 
@@ -179,9 +179,9 @@ With the Text Teaser component created, you now need a folder to hold the create
    </Alert>
 
 1. Write **"Text Teaser Folder"** in the **Name** field to name the template.
-1. Press the **Next** button to advance to the Location selection step.
-1. Press the **Next** button to keep the default selection for the location folder.
-1. Press the **Close** button to exit the wizard. The template has been created.
+1. Click the **Next** button to advance to the Location selection step.
+1. Click the **Next** button to keep the default selection for the location folder.
+1. Click the **Close** button to exit the wizard. The template has been created.
 
 ### Configure a template icon
 
@@ -228,7 +228,7 @@ When an author tries to create a new content item, they are presented with the t
 
    <Image title="Content Editor - Select Insert Options" src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/83ca1438aef7402491b87738e61dfb81?v=56fb9f4b" maxW="xl" />
 
-1. Press the **OK** button to save the changes.
+1. Click the **OK** button to save the changes.
 
    <Alert status="info">
    <AlertIcon />
@@ -479,6 +479,7 @@ In the previous tutorial, you added a Text Teaser component to the home page. Af
 </Alert>
 
 ### Related XM Cloud Documentation
+
 - [Data Templates](https://doc.sitecore.com/xmc/en/developers/xm-cloud/data-templates.html)
 - [Data definition and template overview](https://doc.sitecore.com/xmc/en/developers/xm-cloud/data-definition-and-template-overview.html)
 - [The Standard Template](https://doc.sitecore.com/xmc/en/developers/xm-cloud/the-standard-template.html)
@@ -488,7 +489,7 @@ In the previous tutorial, you added a Text Teaser component to the home page. Af
 - [Get your content from an XM data source](https://doc.sitecore.com/xmc/en/users/xm-cloud/get-your-content-from-an-xm-data-source.html)
 - [Map data from an XM data source to a component](https://doc.sitecore.com/xmc/en/users/xm-cloud/map-data-from-an-xm-data-source-to-a-component.html)
 
-
 ### Related XM Cloud Accelerate guidance for Sitecore Partners
+
 - [Project Solution Setup](/learn/accelerate/xm-cloud/pre-development/sprint-zero/project-solution-setup)
 - [Creating a Site](/learn/accelerate/xm-cloud/pre-development/sprint-zero/creating-a-site)

--- a/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/setup-xm-cloud.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/setup-xm-cloud.md
@@ -13,7 +13,7 @@ In this tutorial, we will go through the steps to learn the basics of XM Cloud a
 - How to access the XM Cloud Deploy application
 - How to create a new XM Cloud project using the XM Cloud Deploy application
 - How to create a new XM Cloud environment for a Project
-</Introduction>
+  </Introduction>
 
 ## Overview
 
@@ -55,7 +55,7 @@ Let’s get started!
    <Image title="Project Overview - Create new Project" src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/817fa236e3434742817279da7329eca6?v=d1261f63" maxW="xl" />
 1. From here you provide a Project Name e.g. `XM Cloud Tutorial Series` and click the Continue button
    <Image title="Create Project and Environment Step 1 - Provide Project Name" src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/57cf82679be64a498b9d43659c26e900?v=0bb6544a" maxW="xl" />
-1. Choose whether you want to connect to GitHub or to Azure DevOps. A starter solution will be copied to your connected source code repository as a starting point. For the sake of this tutorial you choose GitHub and press the Continue Button  
+1. Choose whether you want to connect to GitHub or to Azure DevOps. A starter solution will be copied to your connected source code repository as a starting point. For the sake of this tutorial you choose GitHub and click the Continue Button  
    <Image title="Create Project and Environment Step 2 - Choose Source Code Repository" src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/246d3a6f48d54765be0427179c3e9fd1?v=9240ac99" maxW="xl" />
 
    <Alert status="info">
@@ -77,8 +77,8 @@ Let’s get started!
    <Image title="Create Project and Environment Step 4 - Provide Environment details" src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/c891806b1758495c8af79c44088f07e3?v=c7f37143" maxW="xl" />
 1. In the **Production SaaS SLA** section you will specify if this new environment is a production environment or not. Select `No` to make this a non-production environment.
 1. Select whether you want to auto deploy on push to the repository. Select “Yes”. This enables the CI/CD pipeline from your main branch. This can be adjusted later.
-1. Press the Continue button.
-1. On the 5th step review your selections and press the “Start deployment” button
+1. Click the Continue button.
+1. On the 5th step review your selections and click the “Start deployment” button
    <Image title="Create Project and Environment Step 5 - Review your selections" src="https://sitecorecontenthub.stylelabs.cloud/api/public/content/d5cda1bf224c4f99b508fe612e527590?v=6c0f0076" maxW="xl" />
 
 The deployment starts, and provisioning and build run in parallel.  
@@ -125,6 +125,6 @@ Once the provisioning and build process are finished, the deployment starts. The
 - [Experience Edge architecture](https://doc.sitecore.com/xmc/en/developers/xm-cloud/the-architecture-of-sitecore-experience-edge-for-xm.html)
 - [Creating a source control connection with GitHub](https://doc.sitecore.com/xmc/en/developers/xm-cloud/manage-connections-for-source-control-and-hosting-providers.html#creating-a-source-control-connection-with-github)
 
-
 ### Related XM Cloud Accelerate guidance for Sitecore Partners
+
 - [Project Solution Setup](/learn/accelerate/xm-cloud/pre-development/sprint-zero/project-solution-setup)

--- a/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/setup-xm-cloud.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/setup-xm-cloud.md
@@ -13,7 +13,8 @@ In this tutorial, we will go through the steps to learn the basics of XM Cloud a
 - How to access the XM Cloud Deploy application
 - How to create a new XM Cloud project using the XM Cloud Deploy application
 - How to create a new XM Cloud environment for a Project
-  </Introduction>
+
+</Introduction>
 
 ## Overview
 


### PR DESCRIPTION
## Description / Motivation
Fixes #776 reported issue

## How Has This Been Tested?
Local and [on Vercel](https://developer-portal-git-776-upda-cd9918-sitecoretechnicalmarketing.vercel.app/learn/getting-started/xm-cloud/tutorials/setup-xm-cloud)

Ensured pages loaded and the word 'Press' was not in the tutorial.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
