### PR TITLE
Add frontmatter menuOrder to create component and datasource tutorial

### DIFF
--- a/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/create-a-component.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/create-a-component.md
@@ -3,6 +3,7 @@ title: 'Tutorial: Create your first XM Cloud no-code component'
 description: 'In this tutorial, we will go through the steps to create a Text Teaser component with a no-code approach using XM Cloud Components builder'
 openGraphImage: 'https://sitecorecontenthub.stylelabs.cloud/api/public/content/21dabc30da2c475a8549640a04885a46?v=18b721db'
 pageType: 'tutorial'
+menuOrder: 3
 ---
 
 <Introduction title="What You are Going to Learn">

--- a/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/datasources.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/xm-cloud/tutorials/datasources.md
@@ -3,6 +3,7 @@ title: 'Tutorial: How to Create Component Data Sources in XM Cloud'
 description: 'Learn about defining and creating new content items that can be used by authors as data sources in the XM Cloud Component builder.'
 openGraphImage: 'https://sitecorecontenthub.stylelabs.cloud/api/public/content/21dabc30da2c475a8549640a04885a46?v=18b721db'
 pageType: 'tutorial'
+menuOrder: 4
 ---
 
 <Introduction title="What You are Going to Learn">


### PR DESCRIPTION
## Description / Motivation
This PR adds the right menuOrder to the frontmatter of the article. Fixes the wrong order in the overview page.

## How Has This Been Tested?
Local and [Vercel](https://developer-portal-git-content-b1f8ef-sitecoretechnicalmarketing.vercel.app/learn/getting-started/xm-cloud/tutorials)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X ] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
