### PR TITLE
Patched SAT Resources download package to replace incomplete Application Insights configuration

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/104/Sitecore_Experience_Platform_104/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/104/Sitecore_Experience_Platform_104/Release_Notes.md
@@ -6,8 +6,11 @@ title: 'Release Notes'
 
   <Alert variant='warning' mb={4}>
     <AlertIcon />
-    **May 27, 2024 - Patched and republished the four Azure App Service download package options to add missing Application Insights artifacts. Package version numbers were not changed, to avoid re-spinning the entire release. To confirm you have the correct package version, ensure the following file is included in your zip download:**\
-	`Sitecore 10.4.0 rev. 010422 (xx) (Cloud)_xxx.scwdp.zip\Content\Website\ApplicationInsights.config`
+    **May 28, 2024 - Patched and republished the four Azure App Service download package options and the SAT Resources package to add missing Application Insights configuration. Package version numbers were not changed, to avoid re-spinning the entire release.**\
+	**To confirm you have the correct Azure App Service package version, ensure the following file is included in your zip download:**\
+	`Sitecore 10.4.0 rev. 010422 (xx) (Cloud)_xxx.scwdp.zip\Content\Website\ApplicationInsights.config`\
+	**To confirm you have the correct Sitecore Azure Toolkit Resources 10.4.0 rev. 010422.zip package, ensure the following file is included in your zip download:**\
+	`CargoPayloads\Sitecore.Cloud.ApplicationInsights.sccpl\CopyToWebsite\ApplicationInsights.config` 
   </Alert>
   <Alert variant='warning' mb={4}>
     <AlertIcon />

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/104/Sitecore_Experience_Platform_104/index.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/104/Sitecore_Experience_Platform_104/index.md
@@ -4,7 +4,7 @@ title: "Sitecore Experience Platform 10.4"
 
   <Alert variant='warning' mb={4}>
     <AlertIcon />
-    **Packages for Azure App Service were republished on May 27, 2024 to add missing Application Insights artifacts. See Release Notes for more info.**
+    **Packages for Azure App Service were republished on May 28, 2024 to add missing Application Insights configuration. See Release Notes for more info.**
   </Alert>
   <Alert variant='warning' mb={4}>
     <AlertIcon />
@@ -17,11 +17,11 @@ See [all available versions here](/downloads/Sitecore_Experience_Platform).
 ## Download options for Azure App Service deployments
  | Resource | Description |
  | --- | --- |
- | [Packages for XM Single](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%2010.4.0%20rev.%20010422%20(WDP%20XMSingle%20packages).zip) | **May 27, 2024 - patched and republished this package to add missing Application Insights artifacts.** Packages for the Sitecore XM Single (XM0) instance topology. |
- | [Packages for XM Scaled](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%2010.4.0%20rev.%20010422%20(WDP%20XMScaled%20packages).zip) | **May 27, 2024 - patched and republished this package to add missing Application Insights artifacts.** Packages for each role of the Sitecore XM Scaled (XM1) topology. |
- | [Packages for XP Single](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%2010.4.0%20rev.%20010422%20(WDP%20XPSingle%20packages).zip) | **May 27, 2024 - patched and republished this package to add missing Application Insights artifacts.** Packages for the Sitecore XP Single (XP0) instance topology. |
- | [Packages for XP Scaled](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%2010.4.0%20rev.%20010422%20(WDP%20XPScaled%20packages).zip) | **May 27, 2024 - patched and republished this package to add missing Application Insights artifacts.** Packages for each role of the Sitecore XP Scaled (XP1) topology. |
- | [Sitecore Azure Toolkit Resources](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%20Azure%20Toolkit%20Resources%2010.4.0%20rev.%20010422.zip) | SXP release-specific resources for use with the Sitecore Azure Toolkit. The Sitecore Azure Toolkit is [here](/downloads/Sitecore_Azure_Toolkit/3x/Sitecore_Azure_Toolkit_300). |
+ | [Packages for XM Single](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%2010.4.0%20rev.%20010422%20(WDP%20XMSingle%20packages).zip) | **May 28, 2024 - republished package to add missing Application Insights configuration.** Packages for the Sitecore XM Single (XM0) instance topology. |
+ | [Packages for XM Scaled](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%2010.4.0%20rev.%20010422%20(WDP%20XMScaled%20packages).zip) | **May 28, 2024 - republished package to add missing Application Insights configuration.** Packages for each role of the Sitecore XM Scaled (XM1) topology. |
+ | [Packages for XP Single](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%2010.4.0%20rev.%20010422%20(WDP%20XPSingle%20packages).zip) | **May 28, 2024 - republished package to add missing Application Insights configuration.** Packages for the Sitecore XP Single (XP0) instance topology. |
+ | [Packages for XP Scaled](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%2010.4.0%20rev.%20010422%20(WDP%20XPScaled%20packages).zip) | **May 28, 2024 - republished package to add missing Application Insights configuration.** Packages for each role of the Sitecore XP Scaled (XP1) topology. |
+ | [Sitecore Azure Toolkit Resources](https://scdp.blob.core.windows.net/downloads/Sitecore%20Experience%20Platform/104/Sitecore%20Experience%20Platform%20104/Sitecore%20Azure%20Toolkit%20Resources%2010.4.0%20rev.%20010422.zip) | **May 28, 2024 - republished package to add missing Application Insights configuration.** SXP release-specific resources for use with the Sitecore Azure Toolkit. The Sitecore Azure Toolkit is [here](/downloads/Sitecore_Azure_Toolkit/3x/Sitecore_Azure_Toolkit_300). |
  
 ## Download options for On Premises deployments
  | Resource | Description |


### PR DESCRIPTION
## Description / Motivation
- Updated description of the *Sitecore Azure Toolkit Resources* package on the SXP 10.4 download page, to identify that it has been patched and republished.
- Updated this on both the SXP 10.4 download page, and its Release Notes page.
- This accompanies a PR committed to Main just yesterday, which addressed accompanying Azure App Service packages. 

## How Has This Been Tested?
- tested on localhost:3000

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM