### PR TITLE
Add release build number to SXP release notes

### DIFF
--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101/Release_Notes.md
@@ -4,7 +4,7 @@ description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101/Release_Notes
 ---
 
-**Feb 2021 – released Sitecore Experience Platform 10.1.0**
+**Feb 2021 – released Sitecore Experience Platform 10.1.0 rev. 005207**
 
 This a feature release. Sitecore recommends that you upgrade to this release if it includes features that meet the specific needs of your organization. This release contains significant new feature functionality, and we encourage you to evaluate it.
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/Release_Notes.md
@@ -4,7 +4,7 @@ description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update1/Release_Notes
 ---
 
-**June 2021 – released Sitecore Experience Platform 10.1.1**
+**June 2021 – released Sitecore Experience Platform 10.1.1 rev. 005862**
 
 This is a product update. Sitecore recommends that you upgrade to this release if it includes fixes that meet the specific needs of your organization. If this release does not include new functionality or specific fixes that your organization requires, you may benefit from waiting to upgrade until Sitecore releases an update that is relevant for your organization. This is especially true in production environments.
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/Release_Notes.md
@@ -4,7 +4,7 @@ description: ""
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update2/Release_Notes
 ---
 
-**October 2021 – released Sitecore Experience Platform 10.1.2**
+**October 2021 – released Sitecore Experience Platform 10.1.2 rev. 006578**
 
 This is a product update. Sitecore recommends that you upgrade to this release if it includes fixes that meet the specific needs of your organization. If this release does not include new functionality or specific fixes that your organization requires, you may benefit from waiting to upgrade until Sitecore releases an update that is relevant for your organization. This is especially true in production environments.
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/Release_Notes.md
@@ -4,7 +4,7 @@ description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/101/Sitecore_Experience_Platform_101_Update3/Release_Notes
 ---
 
-**September 2023 – released Sitecore Experience Platform 10.1.3**
+**September 2023 – released Sitecore Experience Platform 10.1.3 rev. 009558**
 
 This is a product update. Sitecore recommends that you upgrade to this release if it includes fixes that meet the specific needs of your organization. If this release does not include new functionality or specific fixes that your organization requires, you may benefit from waiting to upgrade until Sitecore releases an update that is relevant for your organization. This is especially true in production environments.
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/Release_Notes.md
@@ -4,7 +4,7 @@ description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102/Release_Notes
 ---
 
-**November 2021 – released Sitecore Experience Platform 10.2.0**
+**November 2021 – released Sitecore Experience Platform 10.2.0 rev. 006766**
 
 This a feature release. Sitecore recommends that you upgrade to this release if it includes features that meet the specific needs of your organization. This release contains significant new feature functionality, and we encourage you to evaluate it.
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/Release_Notes.md
@@ -4,7 +4,7 @@ description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/102/Sitecore_Experience_Platform_102_Update1/Release_Notes
 ---
 
-**September 2023 – released Sitecore Experience Platform 10.2.1**
+**September 2023 – released Sitecore Experience Platform 10.2.1 rev. 009559**
 
 This is a product update. Sitecore recommends that you upgrade to this release if it includes fixes that meet the specific needs of your organization. If this release does not include new functionality or specific fixes that your organization requires, you may benefit from waiting to upgrade until Sitecore releases an update that is relevant for your organization. This is especially true in production environments.
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/Release_Notes.md
@@ -4,7 +4,7 @@ description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103/Release_Notes
 ---
 
-**December 2022 – released Sitecore Experience Platform 10.3.0**
+**December 2022 – released Sitecore Experience Platform 10.3.0 rev. 008463**
 
 This a feature release. Sitecore recommends that you upgrade to this release if it includes features that meet the specific needs of your organization. This release contains significant new feature functionality, and we encourage you to evaluate it.
 

--- a/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/Release_Notes.md
+++ b/apps/devportal/data/markdown/pages/downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/Release_Notes.md
@@ -4,7 +4,7 @@ description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/103/Sitecore_Experience_Platform_103_Update1/Release_Notes
 ---
 
-**August 2023 – released Sitecore Experience Platform 10.3.1**
+**August 2023 – released Sitecore Experience Platform 10.3.1 rev. 009452**
 
 This is a product update. Sitecore recommends that you upgrade to this release if it includes fixes that meet the specific needs of your organization. If this release does not include new functionality or specific fixes that your organization requires, you may benefit from waiting to upgrade until Sitecore releases an update that is relevant for your organization. This is especially true in production environments.
 


### PR DESCRIPTION
## Description / Motivation
- Added the build number to the release notes of each SXP release, starting with SXP 10.1 - the release where the platform pre-releases approach was introduced.
- Driven by customer support ticket and ADO work item #610920, to improve the clarity of the baseline release against which cumulative hotfixes are compared. 

## How Has This Been Tested?
- Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
