### PR TITLE
Replace version specific with latest in docs urls

### DIFF
--- a/apps/devportal/data/markdown/pages/commerce/experience-commerce.md
+++ b/apps/devportal/data/markdown/pages/commerce/experience-commerce.md
@@ -13,18 +13,18 @@ Sitecore Experience Commerce (XC) empowers marketers and merchandizers to fully 
 
 ## Documentation
 
-- [Sitecore Commerce Documentation](https://doc.sitecore.com/xp/en/developers/103/xc)
-- [Commerce Developer Reference](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-commerce/en/commerce-developer-reference.html)
-- [Commerce DevOps](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-commerce/en/commerce-devops.html)
-- [Integrate 3rd party services](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-commerce/en/commerce-integration.html)
-- [Commerce Connect](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-commerce/en/commerce-connect.html)
-- [SXA Storefront](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-commerce/en/sxa-storefront.html)
+- [Sitecore Commerce Documentation](https://doc.sitecore.com/xp/en/developers/latest/xc)
+- [Commerce Developer Reference](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-commerce/en/commerce-developer-reference.html)
+- [Commerce DevOps](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-commerce/en/commerce-devops.html)
+- [Integrate 3rd party services](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-commerce/en/commerce-integration.html)
+- [Commerce Connect](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-commerce/en/commerce-connect.html)
+- [SXA Storefront](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-commerce/en/sxa-storefront.html)
 - [User Documentation](https://doc.sitecore.com/users/101/sitecore-experience-commerce/en/introduction-to-sitecore-experience-commerce.html)
 
 ## Getting Started
 
 - [Installation Guides](/downloads/Sitecore_Commerce/101/Sitecore_Experience_Commerce_101)
-- [Getting Started](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-commerce/getting-started-with-development.html)
+- [Getting Started](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-commerce/getting-started-with-development.html)
 - [Sitecore Essentials (FREE)](https://learning.sitecore.com/pathway/sitecore-essentials) - Introduction to Sitecore Experience Commerce 9 and 10
 
 ## Learn more

--- a/apps/devportal/data/markdown/pages/content-management/experience-manager.md
+++ b/apps/devportal/data/markdown/pages/content-management/experience-manager.md
@@ -43,7 +43,7 @@ With Experience Manager, you can create, manage, and publish content to your web
 ## Documentation
 
 - [User Documentation](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/experience-manager.html)
-- [Developer Documentation](https://doc.sitecore.com/xp/en/developers/101/xm/index.html)
+- [Developer Documentation](https://doc.sitecore.com/xp/en/developers/latest/xm/index.html)
 
 ## Learn & Examples
 

--- a/apps/devportal/data/markdown/pages/devops/containers.md
+++ b/apps/devportal/data/markdown/pages/devops/containers.md
@@ -13,14 +13,14 @@ There are a number of reasons why the use of containers is attractive for Siteco
 
 ## Documentation
 
-- [Containers in Sitecore development](https://doc.sitecore.com/xp/en/developers/101/developer-tools/containers-in-sitecore-development.html)
+- [Containers in Sitecore development](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/containers-in-sitecore-development.html)
 - [Sitecore, Docker, and Continuous Integration](https://www.sitecore.com/knowledge-center/getting-started/sitecore-docker-and-continuous-integration)
 - [Running Sitecore on Azure Kubernetes Service (AKS)](https://www.sitecore.com/knowledge-center/getting-started/running-sitecore-on-azure-kubernetes-service)
 
 ## Getting Started
 
 - [Docker: A quick overview](https://www.sitecore.com/knowledge-center/getting-started/docker-a-quick-overview)
-- [Run your first Sitecore instance](https://doc.sitecore.com/xp/en/developers/101/developer-tools/run-your-first-sitecore-instance.html)
+- [Run your first Sitecore instance](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/run-your-first-sitecore-instance.html)
 
 ## Resources
 

--- a/apps/devportal/data/markdown/pages/devops/developer-collection.md
+++ b/apps/devportal/data/markdown/pages/devops/developer-collection.md
@@ -15,7 +15,7 @@ The Sitecore Developer Collection was created by developers, for developers, to 
 Sitecore CLI provides a command line interface to interact with your Sitecore instance. This command line provides technical team members with automation capabilities and the ability to do content serialization, indexing, publishing, and more.
 
 - [Download Sitecore CLI plugin](/downloads/Sitecore_CLI)
-- [Documentation](https://doc.sitecore.com/xp/en/developers/101/developer-tools/sitecore-command-line-interface.html)
+- [Documentation](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/sitecore-command-line-interface.html)
 
 ## Sitecore for Visual Studio
 
@@ -23,7 +23,7 @@ Sitecore for Visual Studio provides a graphical tool to interact with your Sitec
 
 - [About SVS](https://www.teamdevelopmentforsitecore.com/Sitecore-for-Visual-Studio)
 - [Download SVS](https://www.teamdevelopmentforsitecore.com/Download/SVS)
-- [Documentation](https://doc.sitecore.com/xp/en/developers/101/developer-tools/sitecore-for-visual-studio.html)
+- [Documentation](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/sitecore-for-visual-studio.html)
 
 ## Team Development for Sitecore (TDS)
 

--- a/apps/devportal/data/markdown/pages/devops/managed-cloud.md
+++ b/apps/devportal/data/markdown/pages/devops/managed-cloud.md
@@ -13,7 +13,7 @@ Sitecore Managed Cloud is an offering that allows users to rely on Sitecore to m
 
 ## Documentation
 
-- [Managed Cloud with Containers](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/introduction-to-managed-cloud.html)
+- [Managed Cloud with Containers](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/introduction-to-managed-cloud.html)
 - [Managed Cloud with PaaS](https://doc.sitecore.com/xp/en/developers/100/managed-cloud/sitecore-cloud-services-overview.html)
 
 ## Getting Started

--- a/apps/devportal/data/markdown/pages/devops/sitecore-install-framework.md
+++ b/apps/devportal/data/markdown/pages/devops/sitecore-install-framework.md
@@ -21,4 +21,4 @@ The Sitecore Install Framework (SIF) enables users to deploy and configure a Sit
 
 - [Download SIF](/downloads/Sitecore_Installation_Framework)
 - [PowerShell Gallery](https://sitecore.myget.org/gallery/sc-powershell)
-- [PowerShell Gallery FAQ](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-manager/sitecore-powershell-public-nuget-feed-faq.html)
+- [PowerShell Gallery FAQ](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-manager/sitecore-powershell-public-nuget-feed-faq.html)

--- a/apps/devportal/data/markdown/pages/learn/getting-started/managed-cloud-with-containers/index.md
+++ b/apps/devportal/data/markdown/pages/learn/getting-started/managed-cloud-with-containers/index.md
@@ -18,17 +18,17 @@ There is an assumption that this is for an existing Sitecore solution (however m
   - [Learn more about Docker Pricing](https://www.docker.com/pricing)
 - Walkthrough uses Sitecore 10.2
 - Users should have a working MCC environment:
-  - [Access Details](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/getting-started-with-managed-cloud.html)
-  - [Architecture](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/the-managed-cloud-architecture.html)
+  - [Access Details](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/getting-started-with-managed-cloud.html)
+  - [Architecture](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/the-managed-cloud-architecture.html)
 - Users should have correct permissions to the MCC Azure DevOps project:
   - Users should see the "Repository" tab in Azure DevOps, if not, your account may need to have a valid Visual Studio Subscription.
   - Details about Permissions:
-    - [Managed Security Overview](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/managed-cloud-security-overview.html)
-    - [Managed Security Roles](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/the-managed-cloud-security-roles.html)
+    - [Managed Security Overview](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/managed-cloud-security-overview.html)
+    - [Managed Security Roles](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/the-managed-cloud-security-roles.html)
   - MCC project should contain an Infrastructure Repository:
-    - [Infrastructure Documentation](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/deploying-in-managed-cloud.html#infrastructure_body)
+    - [Infrastructure Documentation](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/deploying-in-managed-cloud.html#infrastructure_body)
   - MCC project should contain an Application Repository:
-    - [Application Documentation](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/deploying-in-managed-cloud.html#application_body)
+    - [Application Documentation](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/deploying-in-managed-cloud.html#application_body)
   - If you don't have the correct permissions, you should reach out to Sitecore Support and put in a "Get Access - User service request" to request access.
 - The move to MCC may require a large shift in your existing CI/CD strategy, especially with older versions of Sitecore and if your repository doesn't already use containers.
 - Basic understanding of the following:
@@ -41,9 +41,9 @@ There is an assumption that this is for an existing Sitecore solution (however m
 
 In order to get started with Managed Cloud with Containers (MCC), your existing solution needs to be extended to support containers. Sitecore has multiple resources that can assist with getting your solution configured with Docker.
 
-Before you get started with Docker, you'll need to ensure that Docker Desktop is installed and all pre-requisites to run docker locally are in place: [Pre-requisite list](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/deploying-in-managed-cloud.html).
+Before you get started with Docker, you'll need to ensure that Docker Desktop is installed and all pre-requisites to run docker locally are in place: [Pre-requisite list](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/deploying-in-managed-cloud.html).
 
-You should also ensure you can run a standard instance of Sitecore with Docker on your local environment, before attempting to customize your existing solution locally [Run Your First Docker Instance](https://doc.sitecore.com/xp/en/developers/102/developer-tools/run-your-first-sitecore-instance.html).
+You should also ensure you can run a standard instance of Sitecore with Docker on your local environment, before attempting to customize your existing solution locally [Run Your First Docker Instance](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/run-your-first-sitecore-instance.html).
 
 ### Solution Modifications
 
@@ -53,24 +53,24 @@ It is recommended to use a multi-repository architecture for Managed Cloud, wher
 
 Most of the details listed below are also included in this document:
 
-[Running Your First Sitecore Instance in Docker](https://doc.sitecore.com/xp/en/developers/102/developer-tools/run-your-first-sitecore-instance.html)
+[Running Your First Sitecore Instance in Docker](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/run-your-first-sitecore-instance.html)
 
 - You will start with creating solution images that extend the base images, based on a topology that works well for local development (likely XM or XP0). You can get the basic details for the Out of the Box (OOTB) definitions from the Container Deployment repository on Github.
   - [XP0 Container Deployment Example](https://github.com/Sitecore/container-deployment/tree/master/compose/sxp/10.2/ltsc2019/xp0)
   - You should place the `docker-compose.yml` in the root of your solution.
 - You will need a folder in your solution that contains the definition on creating the images you need for your implementation (contained in a Dockerfile), which should be a series of commands to take in base images, and layer on top of the image, your solution. In most common Sitecore implementations this folder is located at `./docker/build/[role]/Dockerfile`. You should create a file for each of your images, even if you don't intend to have customizations, so that future customizations are easier to make.
-  - [Building Custom Sitecore Images](https://doc.sitecore.com/xp/en/developers/102/developer-tools/building-custom-sitecore-images.html)
-  - [Build Sitecore Solution Guide](https://doc.sitecore.com/xp/en/developers/102/developer-tools/build-sitecore-solutions.html)
+  - [Building Custom Sitecore Images](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/building-custom-sitecore-images.html)
+  - [Build Sitecore Solution Guide](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/build-sitecore-solutions.html)
   - [Common Docker Examples](https://github.com/Sitecore/docker-examples)
 - You will need an environment file `.env` in the root of your solution which will contain basic environment variables to be used throughout your docker compose file, which looks like `${ENVIRONMENT_VARIABLE}`. You can start by reusing the file located to the corresponding version and topology in the following repository:
   - [Container Deployment Repository](https://github.com/Sitecore/container-deployment)
   - It's important to keep your Containers immutable as much as possible, which is why environment variables are important. [Learn more about Best Practices](https://cloud.google.com/architecture/best-practices-for-operating-containers#ensure_that_your_containers_are_stateless_and_immutable).
 - You'll need to define an override file for the OOTB docker-compose definition `docker-compose.override.yml`. This is where you'll define your custom images and pass in any build arguments to create those custom images. It is important to not make changes directly to the main `docker-compose.yml` file, since it contains OOTB topology information. Instead you should use the override file to make customizations, that way, future upgrades to the version of Sitecore will be easier.
   - [Example of an Existing Override File](https://github.com/Sitecore/docker-examples/blob/develop/custom-images/docker-compose.override.yml)
-  - [Recommendations on Docker Compose Configuration](https://doc.sitecore.com/xp/en/developers/101/developer-tools/build-sitecore-solutions.html#configure-in-docker-compose_body)
+  - [Recommendations on Docker Compose Configuration](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/build-sitecore-solutions.html#configure-in-docker-compose_body)
 - You'll likely need two different Powershell scripts to handle developer onboarding, including `init.ps1` used for certificate creation, and `clean.ps1`, which is used for cleaning volume data (such as logs or cores).
-  - [Preparing to Run Docker](https://doc.sitecore.com/xp/en/developers/102/developer-tools/run-your-first-sitecore-instance.html#preparation_body)
-  - [Persistent Storage Cleanup](https://doc.sitecore.com/xp/en/developers/102/developer-tools/run-your-first-sitecore-instance.html#persistent-storage-cleanup_body)
+  - [Preparing to Run Docker](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/run-your-first-sitecore-instance.html#preparation_body)
+  - [Persistent Storage Cleanup](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/run-your-first-sitecore-instance.html#persistent-storage-cleanup_body)
 - You'll need a data folder, where volume data is stored when your containers are running. The standard path you'll see in most repositories is `./docker/data/[role]`, these folders aren't needed for every role.
 - Lastly, you'll need a configuration folder for `Traefik` configuration. Traefik is used as a reverse proxy to facilitate SSL Certificates and friendly host names while running docker locally. This folder is typically located in `./docker/traefik` and contains SSL and other Traefik configuration.
 
@@ -82,15 +82,15 @@ There are often advanced scenarios needed in your images. Custom modules or even
 
 It's possible that you'll run into scenarios where you need to patch the configuration or add files to your images based on a specific scenario. Refer to the links below for handling some of these potential scenarios.
 
-- [Applying Configuration Transforms](https://doc.sitecore.com/xp/en/developers/102/developer-tools/applying-configuration-transforms.html)
+- [Applying Configuration Transforms](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/applying-configuration-transforms.html)
 
 #### Modules
 
 Modules should never directly get installed in your existing containers running in production, because not only would you need to install these modules on each environment, but on your next release, your modules would likely disappear. Instead, any files or item changes (Sitecore or 3rd party modules not committed to Source Control) need to be layered onto the images that are being created. By doing this, you ensure everyone or every environment that pulls those images, will have everything that matches everyone elses images.
 
 - Sitecore Modules
-  - [Add Sitecore Modules](https://doc.sitecore.com/xp/en/developers/102/developer-tools/add-sitecore-modules.html)
-  - [Sitecore Module References](https://doc.sitecore.com/xp/en/developers/102/developer-tools/sitecore-module-reference.html)
+  - [Add Sitecore Modules](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/add-sitecore-modules.html)
+  - [Sitecore Module References](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/sitecore-module-reference.html)
 - [3rd Party Modules Video](https://www.youtube.com/watch?v=R5kdGqXeMcc)
 
 ## Create CI Pipeline for Managed Cloud Deployments
@@ -119,21 +119,21 @@ The Continuous Delivery (CD) pipeline is hosted in the `Application` repository 
 
 The `Application` and `Infrastructure` repositories in the Managed Cloud with Containers (MCC) Azure DevOps environment are both configured to trigger deployments when a change is made to the `main` branch either directly or via a pull request (however you can also trigger the deployment manually). The best practice would be to create a new feature branch for your latest deployment and in that branch, you'll need to update the configuration to include references to your new custom images in the ACR. This is where you'll need to know the latest build number and branch (or tag version of the latest image in your ACR).
 
-- [Define Custom Images](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/configure-managed-cloud.html#add-a-custom-image_body)
+- [Define Custom Images](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/configure-managed-cloud.html#add-a-custom-image_body)
 
 ![Example Docker Images File](https://mss-p-006-delivery.stylelabs.cloud/api/public/content/9f0aca68e6ad43a79e913b51c0214a30?v=01d65206)
 
 Keep in mind that if you have any more complex scenarios, including customizations to Solr or MSSQL, you'll likely need to init these changes to the respective environment to include them. Example if you were using SXA, you'll need to include the latest CM version, but also include instructions or configuration to init these changes in Solr (SearchStax). There are several guides on how to add modules and make these changes.
 
-- [Walkthrough: Adding the SXA Module](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/walkthrough--adding-the-sxa-module.html)
+- [Walkthrough: Adding the SXA Module](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/walkthrough--adding-the-sxa-module.html)
 
 It is important to callout, that in Sitecore 10.2, Sitecore introduced Items as Resources (IAR) for modules, which means that you may not always need to Init MSSQL for a specific module. You should refer to the module references to understand when updates to MSSQL or Solr are required. If you have made changes to the Solr or MSSQL images locally, this likely means you'll need to make the same changes to push these to your MCC environment. Keeping in mind that Solr and MSSQL are not run within containers in a MCC environment.
 
-- [Sitecore Module References](https://doc.sitecore.com/xp/en/developers/102/developer-tools/sitecore-module-reference.html)
+- [Sitecore Module References](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/sitecore-module-reference.html)
 - [Sitecore Items as Resources](https://community.sitecore.com/community?id=community_blog&sys_id=52751abc1bd44110b8954371b24bcb31)
 
 ## New Infrastructure
 
 If you need to configure changes to your infrastructure, you'll need to work with Terraform and the Infrastructure repository, and likely include additional changes to your existing solution images (ie. Adding Horizon for example). Sitecore has provided multiple scenarios and how you would achieve those scenarios listed here:
 
-- [Infrastructure Scenarios](https://doc.sitecore.com/xp/en/developers/102/managed-cloud/configure-managed-cloud.html)
+- [Infrastructure Scenarios](https://doc.sitecore.com/xp/en/developers/latest/managed-cloud/configure-managed-cloud.html)

--- a/apps/devportal/data/markdown/pages/marketing-automation/experience-platform.md
+++ b/apps/devportal/data/markdown/pages/marketing-automation/experience-platform.md
@@ -11,22 +11,22 @@ Using Sitecore XP Marketing Automation features you will be able to send automat
 
 ## Documentation
 
-- [Marketing Automation Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/marketing-automation.html)
+- [Marketing Automation Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/marketing-automation.html)
 - [Email Experience Manager (EXM) Developer Documentation](https://doc.sitecore.com/xp/en/developers/exm/101/email-experience-manager/index-en.html)
 - [Marketing Operations Documentation](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/marketing-operations.html)
-- [Segmentation And Conditions Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/segmentation-engine.html)
-- [Processing Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/processing.html)
-- [Cortex Processing Engine Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/sitecore-cortex-processing-engine.html)
-- [Reporting Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/reporting.html)
+- [Segmentation And Conditions Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/segmentation-engine.html)
+- [Processing Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/processing.html)
+- [Cortex Processing Engine Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/sitecore-cortex-processing-engine.html)
+- [Reporting Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/reporting.html)
 
 ## Discover
 
-- [Getting started with marketing automation for developers](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
+- [Getting started with marketing automation for developers](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
 - [Getting started with EXM for developers](https://doc.sitecore.com/xp/en/developers/exm/101/email-experience-manager/getting-started-with-exm-for-developers.html)
 
 ## Learn
 
-- [Getting started with marketing automation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
+- [Getting started with marketing automation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
 - [Marketing Automation Engine YouTube playlist](https://www.youtube.com/watch?v=-44xRa0ju2k&list=PL1jJVFm_lGnyicywCcwcWa8RtsoiJEbC9)
 - [Create a Marketing Automation Campaign](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/create-a-marketing-automation-campaign.html)
 - [Digital Marketing Glossary](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/digital-marketing-glossary.html)

--- a/apps/devportal/data/markdown/partials/docs/cms/headless.md
+++ b/apps/devportal/data/markdown/partials/docs/cms/headless.md
@@ -1,9 +1,9 @@
 ### Headless
 
-- [Headless Services](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-headless-services.html)
+- [Headless Services](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/sitecore-headless-services.html)
 - [Experience Edge for XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/sitecore-experience-edge-for-xm.html)
-- [Experience Edge for XM](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-experience-edge-for-xm.html)
+- [Experience Edge for XM](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/sitecore-experience-edge-for-xm.html)
 - [Experience Edge for Content Hub](https://doc.sitecore.com/ch/en/users/content-hub/deliver-content--deliver-content-with-experience-edge.html)
-- [ASP.NET Rendering SDK](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-asp-net-rendering-sdk.html)
-- [JavaScript SDK (JSS)](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-javascript-rendering-sdks--jss-.html)
-- [Convert existing MVC apps to Jamstack](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/converting-existing-sitecore-mvc-applications-to-the-jamstack-architecture-with-headless-rendering.html)
+- [ASP.NET Rendering SDK](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/sitecore-asp-net-rendering-sdk.html)
+- [JavaScript SDK (JSS)](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/sitecore-javascript-rendering-sdks--jss-.html)
+- [Convert existing MVC apps to Jamstack](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/converting-existing-sitecore-mvc-applications-to-the-jamstack-architecture-with-headless-rendering.html)

--- a/apps/devportal/data/markdown/partials/docs/cms/sitecore-experience-manager.md
+++ b/apps/devportal/data/markdown/partials/docs/cms/sitecore-experience-manager.md
@@ -1,6 +1,6 @@
 ### Sitecore Experience Manager (XM)
 
 - [Developer Documentation](https://doc.sitecore.com/xp/en/developers)
-- [Developer Tools](https://doc.sitecore.com/xp/en/developers/103/developer-tools/index-en.html)
-- [Containers](https://doc.sitecore.com/xp/en/developers/103/developer-tools/containers-in-sitecore-development.html)
+- [Developer Tools](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/index-en.html)
+- [Containers](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/containers-in-sitecore-development.html)
 - [Sitecore Knowledge Center](https://www.sitecore.com/knowledge-center/getting-started)

--- a/apps/devportal/data/markdown/partials/docs/commerce/sitecore-experience-commerce.md
+++ b/apps/devportal/data/markdown/partials/docs/commerce/sitecore-experience-commerce.md
@@ -1,3 +1,3 @@
 ### Sitecore Experience Commerce (XC)
 
-- [Developer docs](https://doc.sitecore.com/xp/en/developers/103/xc)
+- [Developer docs](https://doc.sitecore.com/xp/en/developers/latest/xc)

--- a/apps/devportal/data/markdown/partials/docs/customer-data-management/sitecore-experience-platform.md
+++ b/apps/devportal/data/markdown/partials/docs/customer-data-management/sitecore-experience-platform.md
@@ -1,6 +1,6 @@
 ### Sitecore Experience Platform (XP)
 
-- [Getting Started with xConnect](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-xconnect.html)
-- [Sitecore xConnect and xDB Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/xconnect-and-the-xdb.html)
-- [Web Tracking Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/web-tracking.html)
-- [Universal Tracker](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/universal-tracker.html)
+- [Getting Started with xConnect](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-xconnect.html)
+- [Sitecore xConnect and xDB Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/xconnect-and-the-xdb.html)
+- [Web Tracking Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/web-tracking.html)
+- [Universal Tracker](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/universal-tracker.html)

--- a/apps/devportal/data/markdown/partials/docs/marketing-automation/sitecore-experience-platform.md
+++ b/apps/devportal/data/markdown/partials/docs/marketing-automation/sitecore-experience-platform.md
@@ -1,4 +1,4 @@
 ### Sitecore Experience Platform (XP)
 
-- [Marketing Automation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/marketing-automation.html)
-- [Email Experience Manager](https://doc.sitecore.com/xp/en/developers/exm/101/email-experience-manager/index-en.html)
+- [Marketing Automation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/marketing-automation.html)
+- [Email Experience Manager](https://doc.sitecore.com/xp/en/developers/exm/latest/email-experience-manager/index-en.html)

--- a/apps/devportal/data/markdown/partials/docs/personalization/sitecore-experience-platform.md
+++ b/apps/devportal/data/markdown/partials/docs/personalization/sitecore-experience-platform.md
@@ -1,6 +1,6 @@
 ### Sitecore Experience Platform (XP)
 
 - [XP Developer Documentation](https://doc.sitecore.com/xp/en/developers/xp/index.html)
-- [Segmentation and Conditions](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/segmentation-and-conditions.html)
-- [Developer Tools](https://doc.sitecore.com/xp/en/developers/101/developer-tools/index-en.html)
-- [Containers](https://doc.sitecore.com/xp/en/developers/101/developer-tools/containers-in-sitecore-development.html)
+- [Segmentation and Conditions](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/segmentation-and-conditions.html)
+- [Developer Tools](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/index-en.html)
+- [Containers](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/containers-in-sitecore-development.html)

--- a/apps/devportal/data/markdown/partials/learn/getting-started/platform-dxp-development-frameworks.md
+++ b/apps/devportal/data/markdown/partials/learn/getting-started/platform-dxp-development-frameworks.md
@@ -1,10 +1,10 @@
 ### Getting Started with Sitecore Platform DXP development frameworks
 
-- [Getting Started with JSS](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/getting-started-with-jss-for-next-js-development.html)
-- [Getting Started with JSS with Next.js](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/walkthrough--setting-up-a-development-environment-with-the-sitecore-containers-template-for-next-js.html)
-- [Getting Started with Sitecore Headless .NET Core SDK](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/walkthrough--using-the-getting-started-template.html)
+- [Getting Started with JSS](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/getting-started-with-jss-for-next-js-development.html)
+- [Getting Started with JSS with Next.js](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/walkthrough--setting-up-a-development-environment-with-the-sitecore-containers-template-for-next-js.html)
+- [Getting Started with Sitecore Headless .NET Core SDK](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/walkthrough--using-the-getting-started-template.html)
 - [Getting Started with SXA](https://www.youtube.com/watch?v=nMTUitaBMek&list=PL1jJVFm_lGnwKmalgi6sukqDhoYA73JDn&index=1)
-- [Getting Started with Containers](https://doc.sitecore.com/xp/en/developers/101/developer-tools/containers-in-sitecore-development.html)
+- [Getting Started with Containers](https://doc.sitecore.com/xp/en/developers/latest/developer-tools/containers-in-sitecore-development.html)
 - [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials)
   - Introduction to Sitecore Experience Accelerator
   - Sitecore JSS Fundamentals

--- a/apps/devportal/data/markdown/partials/learn/getting-started/platform-dxp.md
+++ b/apps/devportal/data/markdown/partials/learn/getting-started/platform-dxp.md
@@ -1,7 +1,7 @@
 ### Getting Started with the Sitecore Platform DXP
 
-- [Getting Started with Sitecore Experience Manager/Platform (XM/XP)](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/walkthrough--using-the-getting-started-template.html)
-- [Getting Started with Sitecore Experience Commerce (XC)](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-commerce/getting-started-with-development.html)
+- [Getting Started with Sitecore Experience Manager/Platform (XM/XP)](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/walkthrough--using-the-getting-started-template.html)
+- [Getting Started with Sitecore Experience Commerce (XC)](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-commerce/getting-started-with-development.html)
 - [Getting Started with Managed Cloud with Containers](/learn/getting-started/managed-cloud-with-containers)
 - [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials):
   - Getting Started with Managed Cloud

--- a/apps/devportal/data/markdown/partials/learn/getting-started/product-features.md
+++ b/apps/devportal/data/markdown/partials/learn/getting-started/product-features.md
@@ -1,11 +1,11 @@
 ### Getting Started with Sitecore Platform DXP product features
 
-- [Getting Started with xConnect](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-xconnect.html)
+- [Getting Started with xConnect](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-xconnect.html)
 - [Getting Started with Sitecore Forms](https://www.sitecore.com/knowledge-center/blog/359/sitecore-forms-create-your-first-form-4570)
-- [Getting started with marketing automation for developers](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
-- [Getting started with EXM for developers](https://doc.sitecore.com/xp/en/developers/exm/101/email-experience-manager/getting-started-with-exm-for-developers.html)
-- [Getting started with custom condition and segmentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/create-a-custom-condition-and-segmentation-query.html)
-- [Getting started with federated experience manager](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/using-fxm.html)
+- [Getting started with marketing automation for developers](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
+- [Getting started with EXM for developers](https://doc.sitecore.com/xp/en/developers/exm/latest/email-experience-manager/getting-started-with-exm-for-developers.html)
+- [Getting started with custom condition and segmentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/create-a-custom-condition-and-segmentation-query.html)
+- [Getting started with federated experience manager](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/using-fxm.html)
 - [Sitecore Essentials - Free on-demand learning](https://learning.sitecore.com/pathway/sitecore-essentials)
   - Design and Edit in the Sitecore Experience Editor
   - Prepare for Web Experience Management

--- a/apps/devportal/data/markdown/partials/solution/content-management/headless-dot-net.md
+++ b/apps/devportal/data/markdown/partials/solution/content-management/headless-dot-net.md
@@ -11,13 +11,13 @@ Sitecore Headless Development is based on a rendering host front end and a Sitec
 
 ## Documentation
 
-- [Sitecore Headless Development](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/headless-development-with-the-asp-net-rendering-sdk.html)
+- [Sitecore Headless Development](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/headless-development-with-the-asp-net-rendering-sdk.html)
 - [API Documentation](https://doc.sitecore.com/en/resources/sitecore-asp-dot-net-rendering-sdk/101/api/index.html)
 
 ## Learn
 
-- [Walkthrough: Using the Getting Started template](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/walkthrough--using-the-getting-started-template.html)
-- [Development Walkthroughs](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/development-walkthroughs.html)
+- [Walkthrough: Using the Getting Started template](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/walkthrough--using-the-getting-started-template.html)
+- [Development Walkthroughs](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/development-walkthroughs.html)
 
 ## Downloads
 

--- a/apps/devportal/data/markdown/partials/solution/content-management/jss.md
+++ b/apps/devportal/data/markdown/partials/solution/content-management/jss.md
@@ -11,20 +11,20 @@ Sitecore JSS offers front-end developer of whole new way of working and interact
 
 ## Documentation
 
-- [JSS Documentation](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/sitecore-javascript-rendering-sdks--jss-.html)
+- [JSS Documentation](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/sitecore-javascript-rendering-sdks--jss-.html)
 - [JSS Release Notes](https://github.com/Sitecore/jss/blob/master/CHANGELOG.md)
 
 ## Learn
 
-- [Getting Started](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/getting-started-with-jss-for-next-js-development.html)
+- [Getting Started](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/getting-started-with-jss-for-next-js-development.html)
 - [Sitecore Essentials (FREE eLearning)](https://learning.sitecore.com/pathway/sitecore-essentials) - Sitecore JSS Fundamentals
 - [Sitecore Headless Services for JSS Workshop](https://learning.sitecore.com/instructor-led-training/sitecore-jss-workshop)
 - [JSS with Blazer YouTube playlist](https://www.youtube.com/watch?v=EkJJmqQGkVI&list=PL1jJVFm_lGnzMlj7g-hJEFNEPDs5yhzf0)
 - [Integrating a Client Framework with JSS YouTube playlist](https://www.youtube.com/watch?v=vQxLQH0iYps&list=PL1jJVFm_lGnxDrexrlt0Wy_va_vQvQvjN)
 - [Headless and JSS YouTube playlist](https://www.youtube.com/watch?v=ugPy7BjH0H0&list=PL1jJVFm_lGnwZup4L4BjITS2sKr4rpMfI)
-- [Headless Services Architecture](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/services-and-apis.html)
-- [JSS Architecture](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/architecture-overview.html)
-- [Walkthrough: Using the Sitecore Container Template for JSS Next.js Projects](https://doc.sitecore.com/xp/en/developers/hd/200/sitecore-headless-development/walkthrough--setting-up-a-development-environment-with-the-sitecore-containers-template-for-next-js.html)
+- [Headless Services Architecture](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/services-and-apis.html)
+- [JSS Architecture](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/architecture-overview.html)
+- [Walkthrough: Using the Sitecore Container Template for JSS Next.js Projects](https://doc.sitecore.com/xp/en/developers/hd/latest/sitecore-headless-development/walkthrough--setting-up-a-development-environment-with-the-sitecore-containers-template-for-next-js.html)
 
 ## Examples
 

--- a/apps/devportal/data/markdown/partials/solution/content-management/sxa.md
+++ b/apps/devportal/data/markdown/partials/solution/content-management/sxa.md
@@ -17,8 +17,8 @@ In order to get started with SXA you will need a clean installation of Sitecore 
 
 ## Documentation
 
-- [Introducing Sitecore Experience Accelerator](https://doc.sitecore.com/en/users/sxa/101/sitecore-experience-accelerator/introducing-sitecore-experience-accelerator.html)
-- [Developer Documentation](https://doc.sitecore.com/xp/en/developers/sxa/101/sitecore-experience-accelerator/index-en.html)
+- [Introducing Sitecore Experience Accelerator](https://doc.sitecore.com/en/users/sxa/latest/sitecore-experience-accelerator/introducing-sitecore-experience-accelerator.html)
+- [Developer Documentation](https://doc.sitecore.com/xp/en/developers/sxa/latest/sitecore-experience-accelerator/index-en.html)
 - [JS Components documentation](https://doc.sitecore.com/xp/en/developers/sxa/components-theme-jsdoc/en/index.html)
 - [Search Components documentation](https://doc.sitecore.com/xp/en/developers/sxa/jsdoc-search-components/en/index.html)
 

--- a/apps/devportal/data/markdown/partials/solution/content-management/web-cms.md
+++ b/apps/devportal/data/markdown/partials/solution/content-management/web-cms.md
@@ -11,12 +11,12 @@ With Experience Manager, you can create, manage, and publish content to your web
 
 ## Getting Started
 
-- [WebCMS Documentation](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/experience-manager.html)
+- [WebCMS Documentation](https://doc.sitecore.com/en/users/latest/sitecore-experience-platform/experience-manager.html)
 
 ## Documentation
 
-- [User Documentation](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/experience-manager.html)
-- [Developer Documentation](https://doc.sitecore.com/xp/en/developers/101/xm/index.html)
+- [User Documentation](https://doc.sitecore.com/en/users/latest/sitecore-experience-platform/experience-manager.html)
+- [Developer Documentation](https://doc.sitecore.com/xp/en/developers/latest/xm/index.html)
 
 ## Learn & Examples
 

--- a/apps/devportal/data/markdown/partials/solution/customer-data-management/reference-data-service.md
+++ b/apps/devportal/data/markdown/partials/solution/customer-data-management/reference-data-service.md
@@ -10,11 +10,11 @@ The Reference Data Service can be used by features such as interaction aggregati
 
 ### Documentation
 
-- [Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/reference-data-service.html)
+- [Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/reference-data-service.html)
 
 ### Learn
 
-- [Reference Data Service Role](https://doc.sitecore.com/xp/en/developers/101/platform-administration-and-architecture/reference-data-service.html)
+- [Reference Data Service Role](https://doc.sitecore.com/xp/en/developers/latest/platform-administration-and-architecture/reference-data-service.html)
 
 ### Download
 

--- a/apps/devportal/data/markdown/partials/solution/customer-data-management/web-tracking.md
+++ b/apps/devportal/data/markdown/partials/solution/customer-data-management/web-tracking.md
@@ -10,8 +10,8 @@ The integrated Sitecore Web Tracker enables you to track and identify contacts a
 
 ### Documentation
 
-- [Web Tracking Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/web-tracking.html)
-- [Data flow and process](https://doc.sitecore.com/xp/en/developers/101/platform-administration-and-architecture/tracking-and-personalization.html)
+- [Web Tracking Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/web-tracking.html)
+- [Data flow and process](https://doc.sitecore.com/xp/en/developers/latest/platform-administration-and-architecture/tracking-and-personalization.html)
 
 ### Download
 

--- a/apps/devportal/data/markdown/partials/solution/customer-data-management/xconnect.md
+++ b/apps/devportal/data/markdown/partials/solution/customer-data-management/xconnect.md
@@ -12,11 +12,11 @@ xConnect is the service layer that sits in between the xDB and any trusted clien
 
 ## Documentation
 
-- [Sitecore xConnect and xDB Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/xconnect-and-the-xdb.html)
+- [Sitecore xConnect and xDB Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/xconnect-and-the-xdb.html)
 
 ## Learn
 
-- [Getting Started with xConnect](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-xconnect.html)
+- [Getting Started with xConnect](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-xconnect.html)
 
 ## Download
 

--- a/apps/devportal/data/markdown/partials/solution/customer-data-management/xdb.md
+++ b/apps/devportal/data/markdown/partials/solution/customer-data-management/xdb.md
@@ -12,11 +12,11 @@ xConnect is the service layer that sits in between the xDB and any trusted clien
 
 ### Documentation
 
-- [Sitecore xConnect and xDB Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/xconnect-and-the-xdb.html)
+- [Sitecore xConnect and xDB Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/xconnect-and-the-xdb.html)
 
 ### Learn
 
-- [Getting Started with xConnect](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-xconnect.html)
+- [Getting Started with xConnect](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-xconnect.html)
 
 ### Download
 

--- a/apps/devportal/data/markdown/partials/solution/marketing-automation/sitecore-xp-marketing-automation.md
+++ b/apps/devportal/data/markdown/partials/solution/marketing-automation/sitecore-xp-marketing-automation.md
@@ -11,25 +11,25 @@ Using Sitecore XP Marketing Automation features you will be able to send automat
 
 ## Documentation
 
-- [Marketing Automation Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/marketing-automation.html)
-- [Email Experience Manager (EXM) Developer Documentation](https://doc.sitecore.com/xp/en/developers/exm/101/email-experience-manager/index-en.html)
-- [Marketing Operations Documentation](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/marketing-operations.html)
-- [Segmentation And Conditions Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/segmentation-engine.html)
-- [Processing Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/processing.html)
-- [Cortex Processing Engine Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/sitecore-cortex-processing-engine.html)
-- [Reporting Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/reporting.html)
+- [Marketing Automation Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/marketing-automation.html)
+- [Email Experience Manager (EXM) Developer Documentation](https://doc.sitecore.com/xp/en/developers/exm/latest/email-experience-manager/index-en.html)
+- [Marketing Operations Documentation](https://doc.sitecore.com/en/users/latest/sitecore-experience-platform/marketing-operations.html)
+- [Segmentation And Conditions Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/segmentation-engine.html)
+- [Processing Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/processing.html)
+- [Cortex Processing Engine Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/sitecore-cortex-processing-engine.html)
+- [Reporting Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/reporting.html)
 
 ## Discover
 
-- [Getting started with marketing automation for developers](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
-- [Getting started with EXM for developers](https://doc.sitecore.com/xp/en/developers/exm/101/email-experience-manager/getting-started-with-exm-for-developers.html)
+- [Getting started with marketing automation for developers](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
+- [Getting started with EXM for developers](https://doc.sitecore.com/xp/en/developers/exm/latest/email-experience-manager/getting-started-with-exm-for-developers.html)
 
 ## Learn
 
-- [Getting started with marketing automation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
+- [Getting started with marketing automation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/getting-started-with-marketing-automation-for-developers.html)
 - [Marketing Automation Engine YouTube playlist](https://www.youtube.com/watch?v=-44xRa0ju2k&list=PL1jJVFm_lGnyicywCcwcWa8RtsoiJEbC9)
-- [Create a Marketing Automation Campaign](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/create-a-marketing-automation-campaign.html)
-- [Digital Marketing Glossary](https://doc.sitecore.com/en/users/101/sitecore-experience-platform/digital-marketing-glossary.html)
+- [Create a Marketing Automation Campaign](https://doc.sitecore.com/en/users/latest/sitecore-experience-platform/create-a-marketing-automation-campaign.html)
+- [Digital Marketing Glossary](https://doc.sitecore.com/en/users/latest/sitecore-experience-platform/digital-marketing-glossary.html)
 
 ## Resources
 

--- a/apps/devportal/data/markdown/partials/solution/personalization-testing/federated-experience-manager.md
+++ b/apps/devportal/data/markdown/partials/solution/personalization-testing/federated-experience-manager.md
@@ -9,8 +9,8 @@ The Federated Experience Manager (FXM) is an application that allows you to add 
 
 ### Documentation
 
-- [FXM Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/federated-experience-manager.html)
+- [FXM Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/federated-experience-manager.html)
 
 ### Learn
 
-- [Getting Started](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/using-fxm.html)
+- [Getting Started](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/using-fxm.html)

--- a/apps/devportal/data/markdown/partials/solution/personalization-testing/segmentation-and-conditions.md
+++ b/apps/devportal/data/markdown/partials/solution/personalization-testing/segmentation-and-conditions.md
@@ -7,7 +7,7 @@ product: ['xp']
 
 Docs
 
-- [Segmentation And Conditions Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/segmentation-engine.html)
+- [Segmentation And Conditions Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/segmentation-engine.html)
 
 Discover
 
@@ -15,7 +15,7 @@ Discover
 
 Learn
 
-- [Getting Started - Create custom condition and segmentation query](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/create-a-custom-condition-and-segmentation-query.html)
+- [Getting Started - Create custom condition and segmentation query](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/create-a-custom-condition-and-segmentation-query.html)
 - [Learn Segmentation And Conditions]()
 
 Playground

--- a/apps/devportal/data/markdown/partials/solution/personalization-testing/universal-tracker.md
+++ b/apps/devportal/data/markdown/partials/solution/personalization-testing/universal-tracker.md
@@ -9,7 +9,7 @@ The Sitecore Universal Tracker (UT) lets you collect data from different sources
 
 ### Documentation
 
-- [Universal Tracker Documentation](https://doc.sitecore.com/xp/en/developers/101/sitecore-experience-platform/universal-tracker.html)
+- [Universal Tracker Documentation](https://doc.sitecore.com/xp/en/developers/latest/sitecore-experience-platform/universal-tracker.html)
 
 ### Resources
 


### PR DESCRIPTION
## Description / Motivation
This PR updates all links to the documentation site and replaces any version specific URLs with the 'latest' version

## How Has This Been Tested?
Local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
