### PR TITLE
Update getEntriesByProduct to accept an array of product IDs

### DIFF
--- a/packages/changelog/src/changelog.ts
+++ b/packages/changelog/src/changelog.ts
@@ -95,7 +95,7 @@ export class Changelog {
   async getEntriesByProduct(productId: string): Promise<ChangelogEntryList<ChangelogEntry[]>> {
     const response = await fetchGraphQL<SearchByProductQuery, SearchByProductQueryVariables>(SearchByProductDocument, this.credentials, this.isPreview, {
       date: new Date(),
-      productId: productId,
+      productId: [productId],
     });
 
     return ParseRawData(response.data);


### PR DESCRIPTION
## Description / Motivation
This PR fixes an issue with the single product RSS feeds for the changelog

## How Has This Been Tested?
Local and Vercel

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
