### PR TITLE
Restore release notes

### DIFF
--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1000/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1000/Release_Notes.md
@@ -1,0 +1,27 @@
+---
+title: 'Release Notes'
+description: ''
+origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1000/Release_Notes
+---
+
+**August 2020 – released Sitecore Publishing Module 10.0.0**
+
+## Highlights
+
+Beginning with Sitecore XP 9.2.0, the Sitecore Publishing Module is released independently of the Sitecore Publishing Service. Future versions of the Sitecore Publishing Service will be compatible with any version of the Sitecore Publishing Module unless otherwise specified.
+
+## New features/improvements
+
+| Description                                                                                     | Customer ticket ID (or other) | TFS no. |
+| ----------------------------------------------------------------------------------------------- | ----------------------------- | ------- |
+| The default value of the `remoteEventCacheClearingThreshold` setting has been increased.​​​​​​​ |                               | 269136  |
+
+## Resolved issues
+
+The following issues have been fixed:
+
+| Description                                                                                                                                                           | Customer ticket ID (or other) | TFS no. |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------- |
+| ​​​​​​​The HTML cache is not cleared when a new version of an item becomes available​.                                                                                |                               | 271744  |
+| ​​The `OperationCompleteTimestamp` is set to null during a publishing job and this causes a nullable exception on the Sitecore side and empty data in the dashboard​. |                               | 381220  |
+| ​Languages are not listed in alphabetical order in the publishing dialogs.​​​​​​​                                                                                     |                               | 407677  |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/Release_Notes.md
@@ -1,0 +1,13 @@
+---
+title: 'Release Notes'
+description: ''
+origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/Release_Notes
+---
+
+**March 2021 – released Sitecore Publishing Service Module 10.1.0**
+
+## New features/improvements
+
+| Description                                                                                         | Customer ticket ID (or other) | TFS no. |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- | ------- |
+| The Sitecore Publishing Service and the Sitecore Publishing Service Module now ​support containers. |                               | 417118  |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/Release_Notes.md
@@ -1,0 +1,17 @@
+---
+title: 'Release Notes'
+description: ''
+origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/Release_Notes
+---
+
+**Oct 2021 – released Sitecore Publishing Module 10.2.0**
+
+## Highlights
+
+Since Sitecore XP 9.2.0, the Sitecore Publishing Module is released independently of the Sitecore Publishing Service. Future versions of the Sitecore Publishing Service will be compatible with any version of the Sitecore Publishing Module unless otherwise specified.
+
+## Deprecated/Removed
+
+| Description                                                                                                 | ADO no. |
+| ----------------------------------------------------------------------------------------------------------- | ------- |
+| ​The `Sitecore.Publishing.Service.ContentAvailability.lucene.config.disabled` file has been removed.​​​​​​​ | 407376  |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/Release_Notes.md
@@ -1,0 +1,27 @@
+---
+title: 'Release Notes'
+description: ''
+origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/Release_Notes
+---
+
+**December 2022 – released Sitecore Publishing Module 10.3.0**
+
+- [New features/improvements](#new-featuresimprovements)
+- [Resolved issues](#resolved-issues)
+
+## New features/improvements
+
+| Description                                                                              | ADO no. |
+| ---------------------------------------------------------------------------------------- | ------- |
+| The Publishing Dashboard now shows more than 10 results in `Recent` and `Queued` jobs.​​ | 457361  |
+
+## Resolved issues
+
+The following issues have been fixed:
+
+| Description                                                                                                | ADO no. |
+| ---------------------------------------------------------------------------------------------------------- | ------- |
+| There is no prompt to save any item changes when publishing an item that has changed.​​                    | 276418  |
+| The Publishing Service Module has been updated to use System.Reactive 4.x.​​                               | 376949  |
+| The field-value mapping in the Publishing Dashboard has discrepancies.​​                                   | 498541  |
+| ​​​A user with a role `sitecore\Publishing Service Administrator` cannot publish in the Experience Editor. | 527443  |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040/Release_Notes.md
@@ -1,0 +1,13 @@
+﻿---
+title: 'Release Notes'
+---
+
+**April 2024 - released Publishing Service Module 10.4.0**
+
+## Resolved issues
+
+The following issues have been fixed:
+
+| Description                                                                               | ADO no. |
+| ----------------------------------------------------------------------------------------- | ------- |
+| The _Recent Jobs_ tab fails to display entries when multiple publishing jobs are running. | 570337  |


### PR DESCRIPTION
## Description / Motivation
Restore release notes for publishing service 10.x

## How Has This Been Tested?
Local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
