### PR TITLE
Add option to create customized changelog feed

### DIFF
--- a/src/components/changelog/ChangelogFeeds.tsx
+++ b/src/components/changelog/ChangelogFeeds.tsx
@@ -1,0 +1,106 @@
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Heading,
+  HStack,
+  IconButton,
+  Input,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverFooter,
+  PopoverHeader,
+  PopoverTrigger,
+  Radio,
+  RadioGroup,
+  Stack,
+  useClipboard,
+} from '@chakra-ui/react';
+import { mdiCogOutline, mdiOpenInNew, mdiRss } from '@mdi/js';
+import Icon from '@mdi/react';
+import React from 'react';
+import { LinkButton } from '../links';
+
+type ChangelogFeedsProps = {
+  url: string;
+};
+
+export const ChangelogFeeds = ({ url }: ChangelogFeedsProps) => {
+  const [feedType, setFeedType] = React.useState('1');
+  const [titleFilter, setTitleFilter] = React.useState('');
+  const { onCopy, value, setValue, hasCopied } = useClipboard('');
+
+  const generateFeedUrl = React.useCallback(() => {
+    const feed = feedType === '1' ? 'rss' : 'atom';
+    const params = new URLSearchParams();
+
+    if (titleFilter) {
+      params.append('search', titleFilter);
+    }
+
+    setValue(`${url}/${feed}.xml${params.toString() ? `?${params.toString()}` : ''}`);
+  }, [url, feedType, titleFilter, setValue]);
+
+  React.useEffect(() => {
+    generateFeedUrl();
+  }, [feedType, titleFilter, generateFeedUrl]);
+
+  return (
+    <HStack>
+      <LinkButton text={'RSS'} href={`${url}/rss.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} />
+      <LinkButton text={'ATOM'} href={`${url}/atom.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} />
+
+      <Popover>
+        <PopoverTrigger>
+          <IconButton icon={<Icon path={mdiCogOutline} size={1} />} size="sm" aria-label={'Customize feed'} title="Customize feed" variant={'ghost'} />
+        </PopoverTrigger>
+        <PopoverContent>
+          <PopoverArrow />
+          <PopoverCloseButton />
+          <PopoverHeader border="0" pt={4}>
+            <Heading size={'sm'} fontWeight={'semibold'}>
+              Customize feed
+            </Heading>
+          </PopoverHeader>
+          <PopoverBody>
+            <Stack spacing={4} direction="column">
+              <Stack spacing={4} direction="row">
+                <FormControl>
+                  <FormLabel>Feed type</FormLabel>
+                  <RadioGroup onChange={setFeedType} value={feedType}>
+                    <Stack direction="row">
+                      <Radio size={'md'} value="1">
+                        RSS
+                      </Radio>
+                      <Radio size={'md'} value="2">
+                        Atom
+                      </Radio>
+                    </Stack>
+                  </RadioGroup>
+                </FormControl>
+              </Stack>
+              <FormControl>
+                <FormLabel>Title filter (optional)</FormLabel>
+                <Input
+                  size="sm"
+                  value={titleFilter}
+                  onChange={(e) => {
+                    setTitleFilter(e.target.value);
+                  }}
+                  placeholder="Title must contain"
+                />
+              </FormControl>
+            </Stack>
+          </PopoverBody>
+          <PopoverFooter border="0" display="flex" alignItems="center" justifyContent="space-between" pb={4}>
+            <Button onClick={onCopy}>{hasCopied ? 'Copied!' : 'Copy'}</Button>
+            <LinkButton text={'Preview'} href={value} target="_blank" variant={'ghost'} rightIcon={<Icon path={mdiOpenInNew} size={0.5} />} leftIcon={undefined} />
+          </PopoverFooter>
+        </PopoverContent>
+      </Popover>
+    </HStack>
+  );
+};

--- a/src/components/links/LinkButton.tsx
+++ b/src/components/links/LinkButton.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonProps, Link } from '@chakra-ui/react';
 import { mdiArrowRight } from '@mdi/js';
 import Icon from '@mdi/react';
 import NextLink from 'next/link';
-import { JSX } from 'react';
+import { HTMLAttributeAnchorTarget, JSX } from 'react';
 
 type LinkButtonProps = ButtonProps & {
   href: string;
@@ -12,13 +12,14 @@ type LinkButtonProps = ButtonProps & {
   variant?: string;
   colorScheme?: string;
   color?: string;
+  target?: HTMLAttributeAnchorTarget | undefined;
 };
 
-export const LinkButton = ({ href, text, showIcon, variant, colorScheme, color = 'chakra-body-text', icon, ...rest }: LinkButtonProps) => {
+export const LinkButton = ({ href, text, showIcon, variant, colorScheme, color = 'chakra-body-text', icon, target, ...rest }: LinkButtonProps) => {
   const ButtonIcon = icon != null ? icon : <Icon path={mdiArrowRight} size={0.8} />;
 
   return (
-    <Link as={NextLink} href={href} color={color}>
+    <Link as={NextLink} href={href} color={color} target={target}>
       <Button variant={variant} colorScheme={colorScheme} rightIcon={showIcon != false ? ButtonIcon : undefined} size={rest.size ? rest.size : 'md'} {...rest} whiteSpace={'normal'}>
         {text}
       </Button>

--- a/src/pages/changelog/[product]/index.tsx
+++ b/src/pages/changelog/[product]/index.tsx
@@ -5,14 +5,12 @@ import { Changelog } from '@lib/changelog';
 import { Product } from '@lib/changelog/types';
 import { getChangelogProductPaths } from '@lib/staticPaths';
 import { getSlug, slugify } from '@lib/utils';
-import { mdiRss } from '@mdi/js';
-import Icon from '@mdi/react';
 import Layout from '@src/layouts/Layout';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { ChangelogFeeds } from '@/src/components/changelog/ChangelogFeeds';
 import { TrackPageView } from '@/src/components/integrations/engage/TrackPageView';
-import { LinkButton } from '@/src/components/links';
 import { CenteredContent, Hero, VerticalGroup } from '@/src/components/ui/sections';
 import { getChangelogCredentials } from '@/src/lib/changelog/common/credentials';
 
@@ -86,8 +84,9 @@ const ChangelogProduct = ({ currentProduct }: ChangelogProps) => {
                 <ChangelogList initialProduct={currentProduct} />
               </GridItem>
               <GridItem colSpan={{ base: 2 }} hideBelow={'md'}>
-                <LinkButton text={'RSS'} href={`${getSlug(currentProduct.name)}/rss.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} />
-                <LinkButton text={'ATOM'} href={`${getSlug(currentProduct.name)}/atom.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} />
+                <ChangelogFeeds url={getSlug(currentProduct.name)} />
+                {/* <LinkButton text={'RSS'} href={`${getSlug(currentProduct.name)}/rss.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} />
+                <LinkButton text={'ATOM'} href={`${getSlug(currentProduct.name)}/atom.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} /> */}
                 <ChangelogByMonth product={currentProduct} />
               </GridItem>
             </Grid>

--- a/src/pages/changelog/index.tsx
+++ b/src/pages/changelog/index.tsx
@@ -1,13 +1,10 @@
 import { TrackPageView } from '@/src/components/integrations/engage/TrackPageView';
-import { LinkButton } from '@/src/components/links';
 import { Option } from '@/src/components/ui/dropdown';
 import { CenteredContent, Hero, VerticalGroup } from '@/src/components/ui/sections';
 import { getChangelogCredentials } from '@/src/lib/changelog/common/credentials';
 import { Alert, AlertIcon, Grid, GridItem, HStack, Image, Text, Tooltip, useColorModeValue } from '@chakra-ui/react';
 import ChangelogByMonth from '@components/changelog/ChangelogByMonth';
 import ChangelogList from '@components/changelog/ChangelogList';
-import { mdiRss } from '@mdi/js';
-import Icon from '@mdi/react';
 import Layout from '@src/layouts/Layout';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -15,6 +12,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { SWRConfig } from 'swr';
 
+import { ChangelogFeeds } from '@/src/components/changelog/ChangelogFeeds';
 import { Changelog } from '../../lib/changelog/changelog';
 
 type ChangelogHomeProps = {
@@ -66,8 +64,9 @@ export default function ChangelogHome({ fallback }: ChangelogHomeProps) {
                 </GridItem>
 
                 <GridItem colSpan={{ base: 2 }} hideBelow={'md'}>
-                  <LinkButton text={'RSS'} href={`${router.pathname}/rss.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} />
-                  <LinkButton text={'ATOM'} href={`${router.pathname}/atom.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} />
+                  <ChangelogFeeds url={router.pathname} />
+                  {/* <LinkButton text={'RSS'} href={`${router.pathname}/rss.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} />
+                  <LinkButton text={'ATOM'} href={`${router.pathname}/atom.xml`} variant={'ghost'} leftIcon={<Icon path={mdiRss} size={1} />} rightIcon={undefined} /> */}
                   <ChangelogByMonth product={undefined} selectedProducts={selectedProduct} />
                 </GridItem>
               </Grid>


### PR DESCRIPTION
## Description / Motivation
This PR adds the option to create customized changelog feed

## How Has This Been Tested?
Local and Vercel

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
