### PR TITLE
Fix typo in Custom Contents Resolvers

### DIFF
--- a/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/information-architecture/publishing-to-edge.md
+++ b/data/markdown/pages/learn/accelerate/xm-cloud/pre-development/information-architecture/publishing-to-edge.md
@@ -129,7 +129,7 @@ Incremental Publish is only available at site level, for this reason, it might b
 
 Contents Resolvers are used with the Sitecore Layout Service to provide more complex data beyond the serialization of a component data source. A Contents Resolver gets executed when the page (layout) is rendered (in the GraphQL response it is the “rendered” property). This occurs in different contexts: in Experience Editor, in the Experience Preview. In these instances, the context is known because XM Cloud parses the request.
 
-This is not possible in Experience Edge - Edge is able to execute “custom” code, so no Contents Resolvers can run on it. So it gets executed at publishing time when the runtime context (eg. from visitor’s browser interactions) is not known.
+This is not possible in Experience Edge - Edge is not able to execute “custom” code, so no Contents Resolvers can run on it. So it gets executed at publishing time when the runtime context (eg. from visitor’s browser interactions) is not known.
 
 Due to this, Custom Content Resolvers are not supported in XM Cloud - XM Cloud resolvers such as the Navigation Contents Resolver, that should be utilized but custom Content Resolvers should not be created. If you are migrating from XM/XP, review these resolves and plan where best to transfer.
 


### PR DESCRIPTION
## Description / Motivation

Custom Contents Resolvers incorrectly said that "Edge IS able to execute custom code".  I fixed this important distinction - so that it is clear that it is NOT able to execute custom code.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the Contributing guide.
- [x ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [ x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
