### PR TITLE
SPS 8 & SPS Module Interworking Improvements

### DIFF
--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service/7x/Sitecore_Publishing_Service_7020/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service/7x/Sitecore_Publishing_Service_7020/index.md
@@ -12,21 +12,21 @@ Integrating this service into Sitecore Experience Platform also requires the Sit
 See [Sitecore Publishing Service – compatibility tables](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB0761308) for compatibility between versions of Sitecore Publishing Service, Sitecore Publishing Service Module, and Sitecore Experience Platform.
 
 See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).\
-See [all available Module versions here](/downloads/Sitecore_Publishing_Service_Module).
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).
 
-## Download options for Sitecore Container deployments
+## Download for On Premises deployments
+
+ | Resource | Description |
+ | --- | --- |
+ | [Sitecore Publishing Service](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service/7x/Sitecore%20Publishing%20Service%207020/Secure/Sitecore%20Publishing%20Service%207.0.20%20rev.%200020-net6.0.zip) | Publishing Service .NET host |
+
+## Downloads for Container deployments
 
  | Resource | Description |
  | --- | --- |
  | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.3.0.00663.311) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
  | [Sitecore Publishing Service Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service/7x/Sitecore%20Publishing%20Service%207020/Secure/Sitecore%20Publishing%20Service%20Container%20Deployment%20Guide-SC-XP-10.3.0-en.pdf) | This guide describes how to deploy the Sitecore Publishing Service and module in containers with Docker Compose and Kubernetes. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
-
-## Downloads
-
- | Resource | Description |
- | --- | --- |
- | [Sitecore Publishing Service](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service/7x/Sitecore%20Publishing%20Service%207020/Secure/Sitecore%20Publishing%20Service%207.0.20%20rev.%200020-net6.0.zip) | Publishing Service .NET host |
 
 ## Release Information
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service/8x/Sitecore_Publishing_Service_803/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service/8x/Sitecore_Publishing_Service_803/index.md
@@ -9,19 +9,21 @@ Integrating this service into Sitecore Experience Platform also requires the Sit
 See [Sitecore Publishing Service – compatibility tables](<https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB0761308>) for compatibility between versions of Sitecore Publishing Service, Sitecore Publishing Service Module, and Sitecore Experience Platform.
 
 See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).\
-See [all available Module versions here](/downloads/Sitecore_Publishing_Service_Module).
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).
 
-## Download options for Sitecore Container deployments
-| Resource | Description |
-| --- | --- |
-| [Container Deployment Package](<https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.4.0.00703.467>) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
-| [Sitecore Publishing Service Module Container Deployment Guide](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service/8x/Sitecore_Publishing_Service_803/Sitecore_Publishing_Service_Module_10.4_Container_Deployment_Guide.pdf>) | Instructions in deploying the Sitecore Publishing Service and Module in containers with Docker Compose and Kubernetes. |
-| [Image and Tags List](<https://github.com/Sitecore/docker-images/tree/master/tags>) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
-
-## Downloads
+## Download for On Premises deployments
 | Resource | Description |
 | --- | --- |
 | [Sitecore Publishing Service](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service/8x/Sitecore_Publishing_Service_803/Sitecore%20Publishing%20Service%208.0.3%20rev.%200003-net8.0.zip>) | The Sitecore Publishing Service .NET host. |
+
+## Downloads for Container deployments
+Please retrieve the version-specific artifacts from the applicable Sitecore Publishing Service Module release page.
+| Resource | Description |
+| --- | --- |
+| [SPS Module 10.4.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040) | Link to the Sitecore Publishing Service Module 10.4.0 release page. |
+| [SPS Module 10.3.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030) | Link to the Sitecore Publishing Service Module 10.3.0 release page. |
+| [SPS Module 10.2.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020) | Link to the Sitecore Publishing Service Module 10.2.0 release page. |
+| [SPS Module 10.1.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010) | Link to the Sitecore Publishing Service Module 10.1.0 release page. |
 
 ## Release Information
 | Resource | Description |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/Release_Notes.md
@@ -3,8 +3,9 @@ title: 'Release Notes'
 description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/Release_Notes
 ---
-
-**March 2021 – released Sitecore Publishing Service Module 10.1.0**
+Publication history:<br/>
+**2025-07-17:** DEPRECATED Container Deployment Packages supporting SPS versions 7 and earlier. They are based on .NET 6 that has reached end-of-support.<br/>
+**2021-03-30:** Released Sitecore Publishing Service Module 10.1.0.
 
 ## New features/improvements
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010/index.md
@@ -11,19 +11,20 @@ See [Sitecore Publishing Service – compatibility tables](https://support.sitec
 See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
 See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
-## Download options for Sitecore Container deployments
-
- | Resource | Description |
- | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.1.0.00585.80) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
- | [Sitecore Publishing Service Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201010/Secure/The_Sitecore_Publishing_Service_Container_Deployment_Guide-SC-XP-10.1.0.pdf) | This guide describes how to deploy the Sitecore Publishing Service and module in containers with Docker Compose and Kubernetes. |
- | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
-
-## Downloads
+## Downloads for On Premises deployments
 
  | Resource | Description |
  | --- | --- |
  | [Sitecore Publishing Service Module](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201010/Secure/Sitecore%20Publishing%20Module%2010.1.0%20rev.%2000585.zip) | Publishing Service Sitecore installation package for Sitecore Experience Platform |
+
+## Downloads for Container deployments
+
+ | Resource | Description |
+ | --- | --- |
+ | [Container Deployment Package for SPS 8](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.1.0.00632.475) | Package compatible with SPS 8.x. Contains the Docker Compose and Kubernetes specification files used to deploy to Sitecore XP in development and production container environments. |
+ | [Container Deployment Package to SPS 7](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.1.0.00585.318) | **[DEPRECATED]** Package compatible with SPS versions up to 7.x. Contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Sitecore Publishing Service Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201010/Secure/The_Sitecore_Publishing_Service_Container_Deployment_Guide-SC-XP-10.1.0.pdf) | This guide describes how to deploy the Sitecore Publishing Service and module in containers with Docker Compose and Kubernetes. |
+ | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
 
 ## Release Information
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/Release_Notes.md
@@ -3,8 +3,9 @@ title: 'Release Notes'
 description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/Release_Notes
 ---
-
-**Oct 2021 – released Sitecore Publishing Module 10.2.0**
+Publication history:<br/>
+**2025-07-17:** DEPRECATED Container Deployment Packages supporting SPS versions 7 and earlier. They are based on .NET 6 that has reached end-of-support.<br/>
+**2021-10-30:** Released Sitecore Publishing Service Module 10.2.0.
 
 ## Highlights
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020/index.md
@@ -11,19 +11,20 @@ See [Sitecore Publishing Service – compatibility tables](https://support.sitec
 See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
 See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
-## Download options for Sitecore Container deployments
-
- | Resource | Description |
- | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.2.0.00631.242) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
- | [Sitecore Publishing Service Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201020/Secure/SC-Publishing-Service-Container-Deployment-Guide-for-SC-XP-10.2.0-en.pdf) | This guide describes how to deploy the Sitecore Publishing Service and module in containers with Docker Compose and Kubernetes. |
- | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
-
-## Downloads
+## Downloads for On Premises deployments
 
  | Resource | Description |
  | --- | --- |
  | [Sitecore Publishing Service Module](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201020/Secure/Sitecore%20Publishing%20Module%2010.2.0%20rev.%2000631.zip) | Publishing Service Sitecore installation package for Sitecore Experience Platform |
+
+## Downloads for Container deployments
+
+ | Resource | Description |
+ | --- | --- |
+ | [Container Deployment Package for SPS 8](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.2.0.00665.476) | Package compatible with SPS 8.x. Contains the Docker Compose and Kubernetes specification files used to deploy to Sitecore XP in development and production container environments. |
+ | [Container Deployment Package to SPS 7](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.2.0.00631.341) | **[DEPRECATED]** Package compatible with SPS versions up to 7.x. Contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Sitecore Publishing Service Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201020/Secure/SC-Publishing-Service-Container-Deployment-Guide-for-SC-XP-10.2.0-en.pdf) | This guide describes how to deploy the Sitecore Publishing Service and module in containers with Docker Compose and Kubernetes. |
+ | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
 
 ## Release Information
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/Release_Notes.md
@@ -3,8 +3,9 @@ title: 'Release Notes'
 description: ''
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/Release_Notes
 ---
-
-**December 2022 – released Sitecore Publishing Module 10.3.0**
+Publication history:<br/>
+**2025-07-17:** DEPRECATED Container Deployment Packages supporting SPS versions 7 and earlier. They are based on .NET 6 that has reached end-of-support.<br/>
+**2022-12-15:** Released Sitecore Publishing Service Module 10.3.0.
 
 - [New features/improvements](#new-featuresimprovements)
 - [Resolved issues](#resolved-issues)

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030/index.md
@@ -11,19 +11,20 @@ See [Sitecore Publishing Service – compatibility tables](https://support.sitec
 See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
 See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service). 
 
-## Download options for Sitecore Container deployments
-
- | Resource | Description |
- | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.3.0.00663.311) | The Sitecore Container Deployment Package contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
- | [Sitecore Publishing Service Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201030/Secure/Sitecore%20Publishing%20Service%20Container%20Deployment%20Guide-SC-XP-10.3.0.pdf) | This guide describes how to deploy the Sitecore Publishing Service and module in containers with Docker Compose and Kubernetes. |
- | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
-
-## Downloads
+## Downloads for On Premises deployments
 
  | Resource | Description |
  | --- | --- |
  | [Sitecore Publishing Service Module](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201030/Secure/Sitecore%20Publishing%20Module%2010.3.0%20rev.%2000663.zip) | Publishing Service Sitecore installation package for Sitecore Experience Platform |
+
+## Downloads for Container deployments
+
+ | Resource | Description |
+ | --- | --- |
+ | [Container Deployment Package for SPS 8](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.3.0.00685.472) | Package compatible with SPS 8.x. Contains the Docker Compose and Kubernetes specification files used to deploy to Sitecore XP in development and production container environments. |
+ | [Container Deployment Package to SPS 7](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.3.0.00663.312) | **[DEPRECATED]** Package compatible with SPS versions up to 7.x. Contains the Docker Compose and Kubernetes specification files used to deploy Sitecore in development and production container environments. |
+ | [Sitecore Publishing Service Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201030/Secure/Sitecore_Publishing_Service_Module_10.3_Container_Deployment_Guide.pdf) | This guide describes how to deploy the Sitecore Publishing Service and module in containers with Docker Compose and Kubernetes. |
+ | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
 
 ## Release Information
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040/Release_Notes.md
@@ -1,8 +1,9 @@
 ﻿---
 title: 'Release Notes'
 ---
-
-**April 2024 - released Publishing Service Module 10.4.0**
+Publication history:<br/>
+**2025-07-17:** DEPRECATED Container Deployment Packages supporting SPS versions 7 and earlier. They are based on .NET 6 that has reached end-of-support.<br/>
+**2024-04-26:** Released Publishing Service Module 10.4.0.
 
 ## Resolved issues
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040/index.md
@@ -10,18 +10,19 @@ See [Sitecore Publishing Service – compatibility tables](https://support.sitec
 See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
 See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
 
-## Download for On Premises deployments
+## Downloads for On Premises deployments
 
  | Resource | Description |
  | --- | --- |
  | [Sitecore Publishing Service Module](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201040/Sitecore%20Publishing%20Module%2010.4.0%20rev.%2000689.zip) | Package containing the Publishing Service installation for Sitecore Experience Platform |
  | [Installation Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201040/Sitecore_Publishing_Service_Module_Installation_and_Configuration_Guide-10.4_en.pdf) | Installation and configuration procedures for Sitecore Publishing Service Module. |
 
-## Download options for Sitecore Container deployments
+## Downloads for Container deployments
 
  | Resource | Description |
  | --- | --- |
- | [Container Deployment Package](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.4.0.00689.405) | Package containing the Docker Compose and Kubernetes specification files used to deploy to Sitecore XP in development and production container environments. |
+ | [Container Deployment Package for SPS 8](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.4.0.00703.467) | Package compatible with SPS 8.x. Contains the Docker Compose and Kubernetes specification files used to deploy to Sitecore XP in development and production container environments. |
+ | [Container Deployment Package to SPS 7](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.4.0.00689.407) | **[DEPRECATED]** Package compatible with SPS versions up to 7.x. Contains the Docker Compose and Kubernetes specification files used to deploy to Sitecore XP in development and production container environments. |
  | [Sitecore Publishing Service Module Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201040/Sitecore_Publishing_Service_Module_10.4_Container_Deployment_Guide.pdf) | Instructions in deploying the Sitecore Publishing Service and Module in containers with Docker Compose and Kubernetes. |
  | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
- Improved the ability to find the downloads needed across both the SPS and SPS Module pages.
- On each SPS Module page, created two rows linking to the corresponding Container Deployment Package; one row for SPS versions up to SPS 7, and another row for SPS 8. This is needed because the CDPs are not backwards compatible to older SPS versions based on a different .NET version.
- Marked CDPs pertaining to SPS 7 / .NET 6 as DEPRECATED, to match the release notes on the CDP release pages in GitHub.
- Released an updated version of the SPS Module 10.3.0 Container Deployment Guide. This new version matches the recent edits made to the corresponding 10.4.0 guide. It helps Sitecore XP 10.3 customers deploy SPS 8 and know to configure the additional needed certification parameters. 
- Standardized and tidied pages.
- Updated the version history on SPS Module release notes pages.

Ref: CS0603476 - user downloaded SPS 8 for deployment on Sitecore XP 10.3, but the SPS 8 download page only included Container artifacts pertaining to Sitecore XP 10.4, 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
localhost
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
