### PR TITLE
Update navigation structure and links to match doc site

### DIFF
--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -27,19 +27,24 @@ export const mainNavigation: NavItem[] = [
             logo: Product.XMCloud,
           },
           {
-            title: 'Content Hub',
-            url: 'https://doc.sitecore.com/ch',
-            logo: Product.ContentHub,
-          },
-          {
-            title: 'Search',
-            url: 'https://doc.sitecore.com/search',
-            logo: Product.Search,
+            title: 'Experience Platform',
+            url: 'https://doc.sitecore.com/xp',
+            logo: Product.ExperiencePlatform,
           },
           {
             title: 'Content Hub ONE',
             url: 'https://doc.sitecore.com/ch-one',
             logo: Product.ContentHubOne,
+          },
+          {
+            title: 'CDP',
+            url: 'https://doc.sitecore.com/cdp',
+            logo: Product.CDP,
+          },
+          {
+            title: 'Send',
+            url: 'https://doc.sitecore.com/send',
+            logo: Product.Send,
           },
         ],
       },
@@ -47,9 +52,20 @@ export const mainNavigation: NavItem[] = [
         title: ' ',
         children: [
           {
-            title: 'CDP',
-            url: 'https://doc.sitecore.com/cdp',
-            logo: Product.CDP,
+            title: 'Content Hub',
+            url: 'https://doc.sitecore.com/ch',
+            logo: Product.ContentHub,
+          },
+
+          {
+            title: 'Experience Manager',
+            url: 'https://doc.sitecore.com/xp',
+            logo: Product.ExperienceManager,
+          },
+          {
+            title: 'Search',
+            url: 'https://doc.sitecore.com/search',
+            logo: Product.Search,
           },
           {
             title: 'Personalize',
@@ -61,10 +77,25 @@ export const mainNavigation: NavItem[] = [
             url: 'https://doc.sitecore.com/send',
             logo: Product.Send,
           },
+        ],
+      },
+      {
+        title: 'Capabilities',
+        children: [
+          {
+            title: 'Cloud Portal',
+            url: 'https://doc.sitecore.com/portal',
+            logo: Product.Sitecore,
+          },
           {
             title: 'Connect',
             url: 'https://doc.sitecore.com/connect',
             logo: Product.Connect,
+          },
+          {
+            title: 'Marketplace',
+            url: 'https://doc.sitecore.com/marketplace',
+            logo: Product.Sitecore,
           },
         ],
       },
@@ -81,27 +112,17 @@ export const mainNavigation: NavItem[] = [
             url: 'https://doc.sitecore.com/discover',
             logo: Product.Discover,
           },
-        ],
-      },
-
-      {
-        title: 'Platform DXP',
-        children: [
-          {
-            title: 'Experience Manager',
-            url: 'https://doc.sitecore.com/xp',
-            logo: Product.ExperienceManager,
-          },
-          {
-            title: 'Experience Platform',
-            url: 'https://doc.sitecore.com/xp',
-            logo: Product.ExperiencePlatform,
-          },
           {
             title: 'Experience Commerce',
             url: 'https://doc.sitecore.com/xp',
             logo: Product.ExperienceCommerce,
           },
+        ],
+      },
+
+      {
+        title: 'Services',
+        children: [
           {
             title: 'Managed Cloud',
             url: 'https://doc.sitecore.com/xp',

--- a/src/components/navigation/NavBar.tsx
+++ b/src/components/navigation/NavBar.tsx
@@ -163,8 +163,8 @@ const DesktopNav = () => {
                     </PopoverTrigger>
                     <PopoverContent width={'100%'} rounded={'md'} shadow={'base'}>
                       <PopoverArrow />
-                      <Box width="100%" maxWidth={'5xl'}>
-                        <SimpleGrid columns={{ base: 1, md: 3, lg: 4 }} pos="relative" gap={{ base: 2, sm: 2 }} px={5} py={6} p={{ sm: 8 }}>
+                      <Box width="100%" maxWidth={'6xl'}>
+                        <SimpleGrid columns={{ base: 1, md: 3, lg: 5 }} pos="relative" gap={{ base: 2, sm: 2 }} px={2} py={4} p={{ sm: 8 }}>
                           {navItem.children?.map((child) => <DesktopSubNav key={child.title} {...child} />)}
                         </SimpleGrid>
                       </Box>


### PR DESCRIPTION
## Description / Motivation
This PR syncs the navigation structure under the documentation node with the docs site.

## How Has This Been Tested?
Local and Vercel

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
