### PR TITLE
XC manifest - remove retired versions

### DIFF
--- a/data/markdown/pages/downloads/Sitecore_Commerce/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Commerce/index.md
@@ -34,32 +34,3 @@ Sitecore OrderCloud, our headless, API-first commerce platform that is part of S
 [Sitecore Experience Commerce 9.0 Update-2](/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Update2)\
 [Sitecore Experience Commerce 9.0 Update-1](/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Update1)\
 [Sitecore Experience Commerce 9.0 Initial Release](/downloads/Sitecore_Commerce/90/Sitecore_Experience_Commerce_90_Initial_Release)
-
-### Sitecore Commerce 8.2.1
-[Sitecore Commerce 8.2.1 Update-3](/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update3)\
-[Sitecore Commerce 8.2.1 Update-2](/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update2)\
-[Sitecore Commerce 8.2.1 Update-1](/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821_Update1)\
-[Sitecore Commerce 8.2.1 Initial Release](/downloads/Sitecore_Commerce/821/Sitecore_Commerce_821)
-
-### Sitecore Commerce 8.2
-[Sitecore Commerce 8.2 powered by Microsoft Dynamics](/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_powered_by_Microsoft_Dynamics)\
-[Sitecore Commerce 8.2 powered by Commerce Server](/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_powered_by_Commerce_Server)\
-[Sitecore Commerce 8.2 Connect](/downloads/Sitecore_Commerce/82/Sitecore_Commerce_82_Connect)\
-[Commerce Server 11.4](/downloads/Sitecore_Commerce/82/Commerce_Server_114)
-
-### Sitecore Commerce 8.1
-[Sitecore Commerce 8.1 powered by Microsoft Dynamics](/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_powered_by_Microsoft_Dynamics_Initial_Release)\
-[Sitecore Commerce 8.1 powered by Commerce Server](/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_powered_by_CS)\
-[Sitecore Commerce 8.1 Connect](/downloads/Sitecore_Commerce/81/Sitecore_Commerce_81_Connect)\
-[Commerce Server 11.3](/downloads/Sitecore_Commerce/81/Sitecore_Commerce_Server_113)
-
-### Sitecore Commerce 8.0
-[Sitecore Commerce 8.0 powered by Microsoft Dynamics Update-1](/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Microsoft_Dynamics_Update1)\
-[Sitecore Commerce 8.0 powered by Commerce Server Update-1](/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Commerce_Server_Update1)\
-[Commerce Server 11.2 Update-1](/downloads/Sitecore_Commerce/80/Commerce_Server_112_Update1)\
-[Sitecore Commerce 8.0 powered by Microsoft Dynamics Initial Release](/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Microsoft_Dynamics_Initial_Release)\
-[Sitecore Commerce 8.0 powered by Commerce Server Initial Release](/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_powered_by_Commerce_Server_Initial_Release)\
-[Commerce Server 11.2 Initial Release](/downloads/Sitecore_Commerce/80/Commerce_Server_112_Initial_Release)\
-[Sitecore Commerce 8.0 Connect](/downloads/Sitecore_Commerce/80/Sitecore_Commerce_80_Connect)
-
-For Sitecore Commerce 7.5 and below, please visit the [Sitecore Developer Network (SDN)](https://archive.doc.sitecore.com/xp/en/sdnarchive/).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Removed links to retired Sitecore Commerce versions, those that have reached end of Sustaining Support.
These releases are no longer installable out-of-box. Servers hosting documentation and release notes have been shut down.
The release download pages and continue to exist. It is only the links to them from the Commerce landing page that have been suppressed. 
These releases continue to be accessible via GitHub, for example if needed in support of a ServiceNow ticket. And, the download artifacts continue to be hosted in Azure Blob Storage.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
localhost
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
