### PR TITLE
Updated incorrect url for MP docs

### DIFF
--- a/data/data-navigation.ts
+++ b/data/data-navigation.ts
@@ -94,7 +94,7 @@ export const mainNavigation: NavItem[] = [
           },
           {
             title: 'Marketplace',
-            url: 'https://doc.sitecore.com/marketplace',
+            url: 'https://doc.sitecore.com/mp',
             logo: Product.Sitecore,
           },
         ],


### PR DESCRIPTION
The URL used for the MP docs is incorrect. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
