### PR TITLE
Identity Server 8.0.28 release tidy

### DIFF
--- a/data/markdown/pages/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016/Release_Notes.md
@@ -1,10 +1,10 @@
 ---
 title: 'Release Notes'
 ---
-Publication history:<br/>
-**2025-04-15:** completed compatibility testing of Sitecore Identity Server 8.0 with Sitecore XP 9.1 through 10.4.<br/>
-**2025-04-03:** patched the on-premises *Deployment Configuration Files* package. Please see new Known Issue below.<br/>
-**2025-03-24:** released Sitecore Identity Server 8.0.16, certified compatible with Sitecore XP and Sitecore XC 10.2, 10.3, and 10.4.
+Publication history:\
+**2025-04-15:** Completed compatibility testing of Sitecore Identity Server 8.0 with Sitecore XP 9.1 through 10.4.\
+**2025-04-03:** Patched the on-premises *Deployment Configuration Files* package. Please see new Known Issue below.\
+**2025-03-24:** Released Sitecore Identity Server 8.0.16, compatible with Sitecore XP and Sitecore XC 10.2, 10.3, and 10.4.
 
 Return to the [Sitecore Identity Server 8.0.16](/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016) release page.
 

--- a/data/markdown/pages/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016/index.md
@@ -2,12 +2,7 @@
 title: 'Sitecore Identity Server 8.0.16'
 description: 'Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform and Sitecore Experience Commerce.'
 ---
-  <Alert variant='warning' mb={4}>
-    <AlertIcon />
-    **2025-04-03:** Patched the on-premises ***Deployment Configuration Files*** package. Please see the Known Issue on the [Release Notes](/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016/Release_Notes) page.
-  </Alert>
-
-Sitecore Identity Server 8.0 is compatible with Sitecore XP 9.1 through 10.4.
+Sitecore Identity Server 8.0.16 is compatible with Sitecore XP 9.1 through 10.4.
 
 See [all available Identity Server versions](/downloads/Sitecore_Identity)
 

--- a/data/markdown/pages/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028/Release_Notes.md
@@ -1,21 +1,17 @@
 ---
 title: 'Release Notes'
 ---
+**2025-10-06:** Released the Sitecore Identity Server 8.0.28 patch level release.
+
+These release notes apply specifically to this version 8.0.28 patch level release.\
+See also the [Identity Server 8.0.16](/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016) initial version release notes, as applicable.
 
 Return to the [Sitecore Identity Server 8.0.28](/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028) release page.
 
-## Improvements
+## Resolved issues
 
 | Description | Ref. |
 | --- | --- |
-| 500 server error returns when wrong provider is used in Identity Server | 627507, 627509 |
-| OpenID - Open URL Redirection via Redirect_Uri | PDXP-11692 |
-| Fix the create log file failure in Sitecore Identity Server 8. | PDXP-6561, PDXP-13019 |
-
-
-## Breaking Changes
-
-| Description | Ref. |
-| --- | --- |
-| For Identity Server on-premises and containerized deployments, Microsoft .NET 8 enforces higher security in the `Microsoft.Data.SqlClient`, enabling encryption by default for network traffic with SQL Server. For more information see the applicable install or uprade guide. For Azure App Service deployments, encryption was already enabled previous Identity Server versions. | 613902 |
-| Identity Server 8.0 must run in x64 mode. The previous Identity Server 7 version targeted x86, but x86 caused errors in certain Identity Server 8.0 scenarios, so x64 mode only is supported. | 626755 |
+| Security enhancement. | PDXP-11692 |
+| A 500 server error is returned when wrong provider is used. | 627507, 627509 |
+| Identity Server 8.0 does not create log files. | PDXP-6561, PDXP-13019 |

--- a/data/markdown/pages/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028/index.md
@@ -3,7 +3,7 @@ title: 'Sitecore Identity Server 8.0.28'
 description: 'Sitecore Identity Server is the platform single sign-on mechanism for Sitecore Experience Platform and Sitecore Experience Commerce.'
 ---
 
-Sitecore Identity Server 8.0 is compatible with Sitecore XP 9.1 through 10.4.
+Sitecore Identity Server 8.0.28 is compatible with Sitecore XP 9.1 through 10.4.
 
 See [all available Identity Server versions](/downloads/Sitecore_Identity)
 
@@ -13,7 +13,7 @@ See [all available Identity Server versions](/downloads/Sitecore_Identity)
 | --- | --- |
 | [Sitecore Identity Server WDP](https://scdp.blob.core.windows.net/downloads/Sitecore%20Identity/8x/Sitecore_Identity_Server_8028/Sitecore.IdentityServer.8.0.28.scwdp.zip) | Sitecore Identity Server WDP installation package. |
 | [Identity Server Upgrade Script](https://scdp.blob.core.windows.net/downloads/Sitecore%20Identity/8x/Sitecore_Identity_Server_8028/Sitecore.IdentityServer.UpgradeScripts.8.0.zip) | Script for updating the Core/Security database. |
-| [Deployment Configuration Files](https://scdp.blob.core.windows.net/downloads/Sitecore%20Identity/8x/Sitecore_Identity_Server_8028/IdentityServer%20Deployment%20Configuration%208.0.zip) | [Release Notes](/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028/Release_Notes) page. |
+| [Deployment Configuration Files](https://scdp.blob.core.windows.net/downloads/Sitecore%20Identity/8x/Sitecore_Identity_Server_8028/IdentityServer%20Deployment%20Configuration%208.0.zip) | Configuration files used in installing Identity Server. |
 | [Installation and Upgrade Guide - On-premises](https://scdp.blob.core.windows.net/downloads/Sitecore%20Identity/8x/Sitecore_Identity_Server_8028/Sitecore_Identity_Server_Installation_and_Upgrade-OnPremises-8.0.pdf) | Guide describing how to install Identity Server and upgrade it from Sitecore Identity Server 2.0 and later, for on-premises deployments. |
 
 ## Azure App Service deployments
@@ -38,4 +38,4 @@ See [all available Identity Server versions](/downloads/Sitecore_Identity)
 
 | Resource | Description |
 | --- | --- |
-| [Release Notes](/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028/Release_Notes) | Improvements, breaking changes, and known issues. |
+| [Release Notes](/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028/Release_Notes) | List of issues resolved specifically in this version 8.0.28 patch level release. See also the [Identity Server 8.0.16](/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016) initial version release notes, as applicable. |

--- a/data/markdown/pages/downloads/index.md
+++ b/data/markdown/pages/downloads/index.md
@@ -36,10 +36,10 @@ hasInPageNav: false
   link1href="/downloads/Sitecore_Stream_for_Platform_DXP"
 />
 <Download 
-  title="Sitecore Identity Server 8.0.16"
+  title="Sitecore Identity Server 8.0.28"
   description="Single sign-on mechanism for SXP deployments, used with Sitecore's membership storage or extended for use with an external identity provider."
   link1text="Get latest"
-  link1href="/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8016"
+  link1href="/downloads/Sitecore_Identity/8x/Sitecore_Identity_Server_8028"
    link2text="See all versions"
   link2href="/downloads/Sitecore_Identity"
 />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Minor tidying of new Identity Server 8.0.28 download page and release notes:
1. Updated one additional link to this latest release, which was missed.
2. Reduced scope of release notes to cover only this .28 patch release. Instead, added comments in two places to refer also to the 0.16 initial release, release notes. Why: The 8.0.28 release notes included some but not all the release notes from the previous 8.0.16 "initial release". The release notes should either be totally cumulative or not cumulative at all. I followed the not cumulative structure of a previous SXA module patch level release.
3. Other minor updates and tidying to Identity Server download and release notes pages.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on localhost
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the Contributing guide.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [X] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
