### PR TITLE
Fix formatting in Breaking_Changes.md for Sitecore_DataBus

### DIFF
--- a/data/markdown/pages/downloads/Sitecore_Experience_Platform/105/Sitecore_Experience_Platform_105/Breaking_Changes.md
+++ b/data/markdown/pages/downloads/Sitecore_Experience_Platform/105/Sitecore_Experience_Platform_105/Breaking_Changes.md
@@ -544,7 +544,7 @@ The Sitecore_Transport receive index change includes updates inherited from the 
 | --- | --- | --- |
 | Database Schema / Messaging | Sitecore 10.5 introduces schema updates for the Sitecore.Messaging SQL transport database after the upgrade to Sitecore Framework .NET 10. Environments that use the Messaging SQL transport database must run the required Messaging database upgrade script so the database schema matches the schema expected by Sitecore 10.5. | PDXP-28916 |
 | Database Schema / Sitecore_Transport | The IDX_RECEIVE_dbo_Sitecore_Transport receive index has been updated. The [priority] column sort order changes from ASC to DESC, and the indexed column order changes from [priority], [visible], [expiration], [id] to [priority], [visible], [id], [expiration]. This aligns the receive index with the optimized ordering used by the updated Rebus.SqlServer SQL transport implementation. | PDXP-28916 |
-| Database Schema / Sitecore_DataBus | The Sitecore_DataBus table structure has been updated. The [Id] column data type changes from varchar(200) to varchar(400), and the table now requires a clustered primary key on [Id] ASC. Additional indexes may be created as a result of the new primary key constraint, using the generated naming convention PK__Sitecore__{constraintKey}. | PDXP-28916 |
+| Database Schema / Sitecore_DataBus | The Sitecore_DataBus table structure has been updated. The [Id] column data type changes from varchar(200) to varchar(400), and the table now requires a clustered primary key on [Id] ASC. Additional indexes may be created as a result of the new primary key constraint, using the generated naming convention PK__Sitecore__\{constraintKey\}. | PDXP-28916 |
 
 ### Containerized SQL Server Connectivity
 


### PR DESCRIPTION
Updated the description of the Sitecore_DataBus table structure to escape curly braces in the primary key constraint naming convention.

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
