### PR TITLE
Created promo elements for DevEx Survey 2026

### DIFF
--- a/data/promos/survey.ts
+++ b/data/promos/survey.ts
@@ -1,15 +1,14 @@
 import type { PromoCardProps } from "@/src/components/cards/PromoCard";
 
 const data: PromoCardProps = {
-  title:
-    "Your voice matters - join the Sitecore Developer Experience Survey 2025",
+  title: "Shape the future of Sitecore's Developer Experience",
   description:
-    "This is your opportunity to share feedback on Sitecore tools, SDKs, and products.",
+    "Take the 2026 Developer Experience Survey — open all September. Win a Symposium ticket or one of two certification vouchers.",
   img: {
     src: "https://mss-p-006-delivery.sitecorecontenthub.cloud/api/public/content/e3e23f39681742a2ad41c9a2917c4c6e?v=1ff6d55b",
   },
   link: {
-    href: "https://forms.office.com/e/xt2d7u9j3V",
+    href: "https://forms.cloud.microsoft/e/R4di2KH0FX",
     text: "Take the survey",
   },
 };

--- a/src/components/cards/SurveyPromoCard.tsx
+++ b/src/components/cards/SurveyPromoCard.tsx
@@ -14,10 +14,9 @@ export const SurveyPromoCard = ({
 }: PromoCardProps) => (
   <div className="flex justify-center">
     <Card
-      padding="none"
       style="outline"
       elevation="xs"
-      className={cn("overflow-hidden max-w-3xl", className)}
+      className={cn("overflow-hidden max-w-3xl p-0!", className)}
     >
       <div className="flex flex-col md:flex-row">
         <div className="relative w-full md:w-[310px] h-40 md:h-auto">

--- a/src/components/cards/SurveyPromoCard.tsx
+++ b/src/components/cards/SurveyPromoCard.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/src/lib/util";
+import type { PromoCardProps } from "@src/components/cards/PromoCard";
+import { LinkButton } from "@src/components/links";
+import { Card, CardContent } from "@src/components/ui/card";
+import Image from "next/image";
+
+// Homepage-only rendering of the survey promo data, kept separate from the shared PromoCard component.
+export const SurveyPromoCard = ({
+  title,
+  description,
+  img,
+  link,
+  className,
+}: PromoCardProps) => (
+  <div className="flex justify-center">
+    <Card
+      padding="none"
+      style="outline"
+      elevation="xs"
+      className={cn("overflow-hidden max-w-3xl", className)}
+    >
+      <div className="flex flex-col md:flex-row">
+        <div className="relative w-full md:w-[310px] h-40 md:h-auto">
+          <Image
+            src={img.src}
+            alt={img.alt || ""}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, 310px"
+          />
+        </div>
+        <CardContent className="flex flex-col justify-center items-start gap-2 p-5 md:p-6">
+          <div>
+            <h4 className="text-lg font-heading mb-1">{title}</h4>
+            <p className="text-muted-foreground text-sm">{description}</p>
+          </div>
+          {link && (
+            <LinkButton href={link.href} text={link.text} target="_blank" />
+          )}
+        </CardContent>
+      </div>
+    </Card>
+  </div>
+);

--- a/src/components/cards/index.ts
+++ b/src/components/cards/index.ts
@@ -1,6 +1,6 @@
 export { Article } from "./Article";
-export type { CTACardProps } from "./CTACard";
 export { CTACard } from "./CTACard";
+export type { CTACardProps } from "./CTACard";
 export { Download } from "./Download";
 export { Group } from "./Group";
 export { LinkItem } from "./LinkItem";
@@ -9,5 +9,7 @@ export type { PromoCardProps } from "./PromoCard";
 export { Promo, PromoCard } from "./PromoCard";
 export { PromoList } from "./PromoList";
 export { Repository } from "./Repository";
-export type { VideoPromoProps } from "./videoPromo";
+export { SurveyPromoCard } from "./SurveyPromoCard";
 export { VideoPromo } from "./videoPromo";
+export type { VideoPromoProps } from "./videoPromo";
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,8 @@
 import platformData from "@data/data-capabilities";
 import communityListData from "@data/data-community-list";
 import getHelpCta from "@data/promos/get-help";
-import { Article, CTACard } from "@src/components/cards";
+import surveyPromo from "@data/promos/survey";
+import { Article, CTACard, SurveyPromoCard } from "@src/components/cards";
 import ChangelogEntries from "@src/components/changelog/ChangelogEntries";
 import {
   SitecoreCommunityBlog,
@@ -57,6 +58,12 @@ const HomePage: NextPage<HomePageProps> = ({ pageInfo, recipes }) => {
         openGraphImage={pageInfo.openGraphImage}
       >
         <Hero title={pageInfo.title} description={pageInfo.description} className='border-b-0' />
+
+        <VerticalGroup className="bg-subtle-bg">
+          <CenteredContent className="py-6! md:pt-8! md:pb-0!">
+            <SurveyPromoCard {...surveyPromo} />
+          </CenteredContent>
+        </VerticalGroup>
 
         <VerticalGroup>
           <CenteredContent>


### PR DESCRIPTION
## Summary

Adds a temporary homepage banner advertising the Sitecore Developer Experience Survey 2026, running through September.

## Changes

- **`data/promos/survey.ts`**: Updated survey promo content — new headline ("Shape the future of Sitecore's Developer Experience"), new subline copy, and the new Microsoft Forms link.
- **`src/components/cards/SurveyPromoCard.tsx`** (new): A homepage-only promo card, visually similar to the existing `PromoCard` but with tighter padding, an edge-to-edge image, a subtle border/shadow, and a button-style CTA. Kept as a separate component so the shared `PromoCard` (used across article/tutorial/accelerate pages) is untouched.
- **`src/components/cards/index.ts`**: Export `SurveyPromoCard` alongside the other card components.
- **`src/pages/index.tsx`**: Renders the survey banner below the hero section, with responsive spacing tuned to match the other homepage panels.

## Why a new component instead of reusing `PromoCard`?

The homepage banner needed different visual treatment (bleeding image, no heavy shadow, button CTA) than `PromoCard`'s default look, which is relied on elsewhere across the site (getting-started articles, accelerate pages, etc.). Rather than risk changing that shared component's appearance everywhere, the new styling lives in its own homepage-specific component.

## Testing

- Verified locally in the browser at both desktop and mobile breakpoints, light/dark themes.
- Confirmed no other pages using `PromoCard`/`PromoList` are affected (zero diff on `PromoCard.tsx`).

## To remove after the survey closes

Once the survey period ends, remove the `SurveyPromoCard` block from `src/pages/index.tsx` (and optionally delete `SurveyPromoCard.tsx` / `data/promos/survey.ts` if not reused for a future survey).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change.
- [ ] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
