### PR TITLE
SPS9.0 - Update guide link and reference, fix release note

### DIFF
--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904/Release_Notes.md
@@ -1,0 +1,27 @@
+---
+title: 'Release Notes'
+description: ''
+---
+Publication history:<br/>
+**2026-XX-XX:** Released Sitecore Publishing Service 9.0.4<br/>
+
+Return to the [Sitecore Publishing Service 9.0.4](/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904) release page.
+
+## New features/improvements
+| Description | Ref. |
+| --- | --- |
+| Updated .NET 8 to .NET 10. | PDXP-26363 |
+| Added ltsc2025 Container Support | PDXP-28674 |
+
+## Breaking changes
+| Description | Ref. |
+| --- | --- |
+| API versioning package migrated from Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer to Asp.Versioning.Mvc.ApiExplorer | PDXP-23634 |
+
+## Resolved Issue
+| Description | Ref. |
+| --- | --- |
+| Updated Microsoft.Extensions.Configuration.xml to v4.7.1 | PDXP-23634 |
+| Updated Microsoft.Data.SqlClient from v5.2.2 to v6.1.4 | PDXP-23634 |
+| Migrated to Serilog.Sinks.File, Serilog.Sinks.Console; Added rollingInterval in config | PDXP-13019 |
+| Updated System.Security.AccessControl to v6.0.1 | PDXP-23634 |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904/Release_Notes.md
@@ -3,7 +3,7 @@ title: 'Release Notes'
 description: ''
 ---
 Publication history:<br/>
-**2026-XX-XX:** Released Sitecore Publishing Service 9.0.4<br/>
+**2026-09-02:** Released Sitecore Publishing Service 9.0.4<br/>
 
 Return to the [Sitecore Publishing Service 9.0.4](/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904) release page.
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904/index.md
@@ -1,0 +1,34 @@
+---
+title: "Sitecore Publishing Service 9.0.4"
+description: ""
+---
+
+The Sitecore Publishing Service is an opt-in service providing an alternative to the default Sitecore publishing mechanism focusing on increased performance by doing operations in bulk. It uses a different approach than the default publishing mechanism and is not a like for like replacement. There are differences to UI, integration points, deployment and in some cases publishing behavior.
+
+Integrating this service into Sitecore Experience Platform also requires the Sitecore Publishing Services Module.\
+See [Sitecore Publishing Service – compatibility tables](<https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB0761308>) for compatibility between versions of Sitecore Publishing Service, Sitecore Publishing Service Module, and Sitecore Experience Platform.
+
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).\
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).
+
+## Download for On Premises deployments
+| Resource | Description |
+| --- | --- |
+| [Sitecore Publishing Service](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service/9x/Sitecore_Publishing_Service_904/Sitecore%20Publishing%20Service%209.0.4%20rev.%200004-net10.0.zip>) | The Sitecore Publishing Service .NET host. |
+
+## Downloads for Container deployments
+Please retrieve the version-specific artifacts from the applicable Sitecore Publishing Service Module release page.
+| Resource | Description |
+| --- | --- |
+| [SPS Module 10.5.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050) | Link to the Sitecore Publishing Service Module 10.5.0 release page. |
+| [SPS Module 10.4.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040) | Link to the Sitecore Publishing Service Module 10.4.0 release page. |
+| [SPS Module 10.3.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030) | Link to the Sitecore Publishing Service Module 10.3.0 release page. |
+| [SPS Module 10.2.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020) | Link to the Sitecore Publishing Service Module 10.2.0 release page. |
+| [SPS Module 10.1.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1010) | Link to the Sitecore Publishing Service Module 10.1.0 release page. |
+
+## Release Information
+| Resource | Description |
+| --- | --- |
+| [Release Notes](/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904/Release_Notes) | A list of features, improvements, and fixes that have been implemented in this release. |
+| [Known Issues](<https://kb.sitecore.net/articles/431510>) | Choose this link to access the Sitecore Knowledge Base. |
+| [Installation and Configuration Guide](<https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service/9x/Sitecore_Publishing_Service_904/Sitecore_Publishing_Service_Installation_and_Configuration_Guide_9.0.pdf>) | The installation and configuration procedure for the Sitecore Publishing Service. |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service/index.md
@@ -3,6 +3,9 @@ title: "Sitecore Publishing Service"
 description: "The Publishing Service is an opt-in mechanism for high-performance publishing in large scale Sitecore setups."
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service.aspx
 ---
+### Sitecore Publishing Service 9.x
+[Sitecore Publishing Service 9.0.4](/downloads/Sitecore_Publishing_Service/9x/Sitecore_Publishing_Service_904)
+
 ### Sitecore Publishing Service 8.x
 [Sitecore Publishing Service 8.0.3](/downloads/Sitecore_Publishing_Service/8x/Sitecore_Publishing_Service_803)
 

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050/Release_Notes.md
@@ -2,7 +2,7 @@
 title: 'Release Notes'
 ---
 Publication history:<br/>
-**2026-XX-XX:** Released Publishing Service Module 10.5.0
+**2026-09-02:** Released Publishing Service Module 10.5.0
 
 ## New features/improvements
 | Description | Ref. |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050/Release_Notes.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050/Release_Notes.md
@@ -1,0 +1,23 @@
+﻿---
+title: 'Release Notes'
+---
+Publication history:<br/>
+**2026-XX-XX:** Released Publishing Service Module 10.5.0
+
+## New features/improvements
+| Description | Ref. |
+| --- | --- |
+| Updated .NET 8 to .NET 10. | PDXP-28671 |
+| Added ltsc2025 Container Support | PDXP-11550 |
+
+## Breaking changes
+| Description | Ref. |
+| --- | --- |
+| Updated circuitBreaker and recovery path run against new Polly APIs (Polly v8.6.5) | PDXP-26068 |
+
+## Resolved issues
+| Description | Ref. |
+| --- | --- |
+| Updated Refit Library to v10.1.6 | PDXP-26907 |
+| Updated System.ConfigurationManager to v6.0.1 | PDXP-25409 |
+| Updated TargetFramework to net481 | PDXP-23206 |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050/index.md
@@ -1,0 +1,33 @@
+---
+title: "Sitecore Publishing Service Module 10.5.0"
+description: ""
+---
+
+The Sitecore Publishing Service Module provides integration with the opt-in Publishing Service, supporting high-performance publishing in large scale Sitecore setups.
+
+See [Sitecore Publishing Service – compatibility tables](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB0761308) for compatibility between versions of Sitecore Publishing Service Module, Sitecore Publishing Service, and Sitecore Experience Platform.
+ 
+See [all available Sitecore Publishing Service Module versions here](/downloads/Sitecore_Publishing_Service_Module).\
+See [all available Sitecore Publishing Service versions here](/downloads/Sitecore_Publishing_Service).
+
+## Downloads for On Premises deployments
+
+ | Resource | Description |
+ | --- | --- |
+ | [Sitecore Publishing Service Module](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201050/Sitecore%20Publishing%20Module%2010.5.0%20rev.%2000726.zip) | Package containing the Publishing Service installation for Sitecore Experience Platform |
+ | [Installation Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201050/Sitecore_Publishing_Service_Module_Installation_and_Configuration_Guide-10.5_en.pdf) | Installation and configuration procedures for Sitecore Publishing Service Module. |
+
+## Downloads for Container deployments
+
+ | Resource | Description |
+ | --- | --- |
+ | [Container Deployment Package for SPS 9](https://github.com/Sitecore/container-deployment/releases/tag/publishing%2F10.5.0.00726.550) | Package compatible with SPS 9.x. Contains the Docker Compose and Kubernetes specification files used to deploy to Sitecore XP in development and production container environments. |
+ | [Sitecore Publishing Service Module Container Deployment Guide](https://scdp.blob.core.windows.net/downloads/Sitecore%20Publishing%20Service%20Module/10x/Sitecore%20Publishing%20Service%20Module%201050/Sitecore_Publishing_Service_Module_10.5_Container_Deployment_Guide.pdf) | Instructions in deploying the Sitecore Publishing Service and Module in containers with Docker Compose and Kubernetes. |
+ | [Image and Tags List](https://github.com/Sitecore/docker-images/tree/master/tags) | Link to the official tags list (.md and .json format) of all published Sitecore images available on Sitecore Container Registry (SCR). |
+
+## Release Information
+
+ | Resource | Description |
+ | --- | --- |
+ | [Release Notes](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050/Release_Notes) | A list of features, improvements, and fixes that have been implemented in this release. |
+ | [Known Issues](https://kb.sitecore.net/articles/431510) | Link to the known issue article on the Sitecore Knowledge Base. |

--- a/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/index.md
+++ b/data/markdown/pages/downloads/Sitecore_Publishing_Service_Module/index.md
@@ -4,6 +4,7 @@ description: "The Publishing Service Module provides integration with the opt-in
 origin: https://dev.sitecore.net/Downloads/Sitecore_Publishing_Service_Module.aspx
 ---
 ### Sitecore Publishing Service Module 10.x
+[Sitecore Publishing Service Module 10.5.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1050)\
 [Sitecore Publishing Service Module 10.4.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1040)\
 [Sitecore Publishing Service Module 10.3.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1030)\
 [Sitecore Publishing Service Module 10.2.0](/downloads/Sitecore_Publishing_Service_Module/10x/Sitecore_Publishing_Service_Module_1020)\


### PR DESCRIPTION
## Description / Motivation

- Updated the link in SPS Module 10.5 download age to the latest Module 10.5 Container Deployment Guide, so that it aligns with the guide version just published with SPS9.0.4
- Tidied descriptions of this guide
- Fixed an incorrect date in SPS 9.0 release notes

## How Has This Been Tested?

localhost

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/data` directory or other markdown files)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the Contributing guide.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change.
- [x] My change is a documentation change and there are NO other updates required.
- [ ] My change has new or updated images which are stored in the `/public/images` folder that need to be migrated to Sitecore DAM
